### PR TITLE
Security clean up, bug fixes for coderbotV2 and other major fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,48 @@
+# Server
+HOST=127.0.0.1
+PORT=8000
+DEBUG=false
+
+# CORS — comma-separated origins; default to localhost frontends
+ALLOWED_ORIGINS=http://localhost:8000,http://127.0.0.1:8000
+
+# HTTP client TLS verification (set to false ONLY for known self-signed internal services)
+HTTP_VERIFY_SSL=true
+
+# Local services — override with your homelab IPs locally
+OLLAMA_URL=http://127.0.0.1:11434
+CODEBOX_URL=http://127.0.0.1:8585
+OPENHANDS_URL=http://127.0.0.1:8586
+SEARXNG_URL=http://127.0.0.1:8888
+N8N_URL=http://127.0.0.1:5678
+N8N_WEBHOOK_PATH=/webhook/execute-code
+N8N_RESEARCH_PATH=/webhook/deep-research
+
+# Storage
+DATABASE_PATH=/opt/hyprchat/data/hyprchat.db
+UPLOAD_DIR=/opt/hyprchat/data/uploads
+TOOLS_DIR=/opt/hyprchat/data/tools
+KB_DIR=/opt/hyprchat/data/knowledge_bases
+SANDBOX_DIR=/opt/hyprchat/data/sandbox
+SETTINGS_PATH=/opt/hyprchat/data/settings.json
+MAX_UPLOAD_SIZE_MB=50
+
+# Execution
+EXECUTION_TIMEOUT=60
+SEARCH_RESULTS_COUNT=15
+MAX_FETCH_CHARS=8000
+
+# Models
+DEFAULT_MODEL=qwen3.5:27b
+WORKSPACE_MODEL=qwen3.5:4b
+PLANNING_MODEL=qwen3.5:27b
+CODER_MODEL=qwen2.5-coder:14b
+CRITIC_ENABLED=true
+
+# Agents
+OPENHANDS_ENABLED=true
+OPENHANDS_MAX_ROUNDS=20
+OPENHANDS_NUM_CTX=16384
+DEFAULT_NUM_CTX=16384
+MAX_AGENT_ROUNDS=12
+MAX_AGENT_ROUNDS_CODER=30

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ __pycache__/
 # Internal infra inventory — homelab IPs and service map
 CLAUDE.md
 claude.md
+AGENTS.MD
+AGENTS.md
+agents.md
 
 # Environment / secrets
 .idea/misc.xml
@@ -42,3 +45,26 @@ Thumbs.db
 *.swp
 *.swo
 *~
+
+# OpenAI / Ollama / API keys
+openai_api_key*
+anthropic_api_key*
+*_API_KEY*
+*_TOKEN*
+
+# -------------------------
+# AI agent local files
+# -------------------------
+.codex/
+.claude/
+.agents/
+.cursor/
+.windsurf/
+.ai/
+.agent/
+agent-output/
+agent-logs/
+codex-output/
+codex-logs/
+claude-output/
+claude-logs/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ claude.md
 .idea/misc.xml
 .env
 .env.*
+!.env.example
 *.pem
 *.key
 

--- a/.idea/hyprchat.iml
+++ b/.idea/hyprchat.iml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="Python 3.10 (pythonProject)" jdkType="Python SDK" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+      <excludeFolder url="file://$MODULE_DIR$/backend/.venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.14 (hyprchat)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Alpha v17.0.1 — May 8, 2026
+## Alpha v17.0.1 — May 26, 2026
 
 ### Coder Bot v2 — workflow gate hardening
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,21 +31,24 @@ Ten edge cases in the v2 gate, profile detection, and persona prompt that togeth
 - **Why it matters** — the SDK defaults `reasoning_effort=high` + `extended_thinking_budget=200000`. On a 30B model with `num_ctx=16384` that's 30+ s per tool round; with chat ↔ builder VRAM thrashing, a 3-file scaffold ran 5 min wall-clock. Medium/Low cuts that with no quality regression on CRUD/UI tasks.
 - **Plumbing** — `OPENHANDS_REASONING_EFFORT` in `config.py` → settings handlers in `main.py` → `oh_payload` in `tools.py` → `RunRequest.reasoning_effort` in `openhands_worker.py` → `_LLM(reasoning_effort=…)` with a `TypeError` fallback for older SDKs (logs a warning, no-op).
 
-### Quick Search — multi-round agent
+### Quick Search — best-of synthesis
 
-Replaced the single-shot rewrite-and-search pipeline with `backend/search_agent.py`. Same call site, smarter inside.
+Pulled the highest-ROI patterns from Perplexica (24k★), Khoj (18k★), and Open WebUI (70k★) into `backend/search_agent.py` + `backend/quick_search.py`.
 
-- **Triage stage** — one Ollama call (`format=json`, `think=false`) returns `{needs_search, queries[1-3], category, reason}`. Replaces the old skip-classify / rewrite / pronoun-validate chain. Falls back to searching the raw user message on JSON-parse failure.
-- **Multi-query fanout** — compound questions get parallel SearXNG calls, results merged.
-- **Relevance check + optional refine** — if top-3 result tokens overlap < 30% with the user's message, refine the query and search once more (max 2 rounds).
-- **Domain bias** retained — news queries demote SO/GitHub, code queries demote news/recipe, etc.
-- **Anti-leak prompt** — triage examples now use disjoint domains (sourdough/Rust/Brazil/greeting/attached) with explicit "don't copy these entities" instruction; small models like dolphin-phi:2.7b were regurgitating the old UK-politics example verbatim.
-- **VRAM fix** — triage call hard-caps `num_ctx=4096`. Without it, qwen3.5:4b's 256K default allocated ~19GB of KV cache and evicted the chat model. Saved 12.5GB.
-- **Workspace model wired end-to-end** — the UI's "Workspace Analysis Model" dropdown now PATCHes `workspace_model` to `/api/settings`, persisted to `settings.json`, loaded into `config.WORKSPACE_MODEL` on boot. Was localStorage-only; backend never saw the user's choice. Triage priority: `QUICK_SEARCH_TRIAGE_MODEL` → workspace → chat model → default.
-- **Carousel reuses agent results** — agent emits `search_results` SSE event tagged `source: "quick_search"`; frontend renders that into the QUICK SEARCH RESULTS carousel directly. Removed the parallel `/api/quick-search` POST in the chat send path. One SearXNG round-trip per turn instead of two; carousel and chat answer can no longer disagree.
-- **Removed** — `_rewrite_query`, `_try_rewrite_call`, `_topic_phrase` legacy chain. `_should_skip` / `_content_tokens` / `_needs_context` / `_classify_query` / domain-bias / page-fetch / OG enrichment helpers stay (reused by the agent).
-- **Tests** — `backend/tests/test_search_agent.py`, 24 unit tests covering triage validation, relevance scoring, single/refine paths, max-rounds cap, skip-gate.
-- **Deploy monitor** — `backend/search_agent.py` added to `WATCHED` in `deploy_monitor.py`.
+- **`standalone_query` in triage** (Perplexica) — triage now returns a context-independent rephrasing of the latest message alongside `queries[]`. Used as the canonical query for ranking, embedding, and the carousel — kills pronoun/anaphora bugs at the source.
+- **Embedding rerank + dedup** (Perplexica) — batched `nomic-embed-text` call scores snippets vs `standalone_query`; drops sim < 0.45, dedups pairs > 0.85. Catches synonym/paraphrase mismatches and the SearXNG-mirror dup case. Falls back to heuristic order on any embed failure.
+- **Trafilatura page extraction** — replaces the regex strip with `trafilatura.extract()` on top-N pages. JS-heavy and paywall-prelude pages now produce usable content. Falls back inline (same fetched HTML, no double round-trip) if trafilatura is unavailable.
+- **Per-conversation subquery dedup** (Khoj) — drops queries already searched earlier in the same conversation; preserves at least one query if all are dupes.
+- **Follow-up relevance fix** — `relevance_score` now folds prior-turn tokens into the user-token set when the message is a follow-up. Refine actually fires for "any updates?" instead of returning 1.0 every time.
+- **News freshness** — when triage's category is `news` and the user message has a recency cue (`today`/`latest`/`current year`), SearXNG gets `time_range=month`. Cache key becomes `(query, time_range)`.
+- **Triage category used for ranking** — was being computed and discarded; now drives `_apply_domain_bias` directly. Regex `_classify_query` becomes the triage-failure fallback only.
+- **SSRF guard** (Open WebUI) — `_url_safe()` resolves hostnames before fetch; rejects private/loopback/link-local IPs. Defends against malicious search results redirecting to internal services.
+- **Bounded LRU cache** — `_CACHE` capped at 512 entries with LRU eviction. Prevents long-running-process leak.
+- **Concurrency semaphore** — `_FETCH_SEMA(6)` around page-fetch + OG-image-fetch. Smooths bursts on the SearXNG LXC and ProtonVPN exit.
+- **Search-failure note** — when quick search throws, a system note ("web search was unavailable, don't guess") is appended to the user turn so the model doesn't hallucinate current events.
+- **Pre-existing `_search_searxng` bug** — any SearXNG result with a thumbnail was being marked `type="image"` and filtered out by the chat ranker. News results almost always carry an `og:image`; this was silently dropping ~60% of news results before they reached embedding rerank. Narrowed to URL-extension-only.
+- **Removed** — `_fetch_page` import in `quick_search.py` (replaced by `_fetch_clean_page`); stale `_rewrite_query` references in docstrings.
+- **New dep** — `trafilatura>=1.10.0` in `requirements.txt`.
 
 
 ## Alpha v17 — May 7, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,48 @@
+## Alpha v17.0.1 — May 8, 2026
+
+### Coder Bot v2 — workflow gate hardening
+
+A run-by-run debugging session against real user projects exposed ten edge cases in the v2 workflow gate, profile detection, and persona prompt. Each one would, on its own, derail a single conversation; together they explained why the same prompt ("fix the QFont error in this uploaded project") could swing between a clean 16-round bug fix and a 24-round rebuild loop that clobbered the user's edits. All ten are fixed and verified against the same prompt re-run.
+
+#### Reviewer/Fixer/gate fixes
+
+- **Phantom `run_fixer` guard** — `backend/tools.py` exec_tool gate now refuses `run_fixer` unless the latest meaningful run is a reviewer with `status="issues"` or `"error"`. Previously the gate's allow-list let `run_fixer` through after a builder, so a model that hallucinated a `reviewer_run_id` immediately after `generate_code` would burn a cycle-cap slot for zero work. Block message includes the actual most-recent run role/status and a `run_review` next-step hint with the on-disk project_dir.
+- **"Nothing to fix" no longer counts as a succeeded cycle** — `backend/agents/fixer.py:249` switched the no-envelope skip path from `status="succeeded"` to `status="skipped"`. The 3-cycle cap counts only real fix attempts now.
+- **`pytest` exit code 5 ("no tests collected") treated as benign** — `backend/agents/reviewer.py:43,47` appended `|| echo '(no tests)'` to the `pyproject.toml` and `requirements.txt` test commands, matching the plain-Python fallback at line 76. Greenfield scaffolds with no tests yet stop triggering an infinite review/fix loop where the Fixer writes `pytest.ini` over and over.
+- **Cycle cap allows graceful delivery** — when the 3-cycle fixer cap fires, `tools.py` PENDING_FIX gate now releases `download_project`, `download_file`, `read_file`, `list_files` so the model can ship what was built or inspect the tree. Cap message also explicitly suggests `download_project` as a "ship as-is" path instead of telling the model "respond with text only" (which qwen3-coder ignored).
+- **Anti-rebuild guard for `generate_code`** — `tools.py` blocks a second `generate_code` against the same project in the same conversation turn (since the latest user message). Detected via `runs.started_at >= latest_user_message.created_at`. Pushes the model toward `read_file` + `write_file` for iterative refinement instead of running the OpenHands feature-builder twice for ~150s of clobbering. Block message includes file-path hints so the model knows exactly what to do next.
+- **Profile auto-detection for write_file-edited uploaded projects** — `tools.py` coding_projects fallback now sets `_builder_profile = "feature"` when there's an active project but no prior builder run. Previously the fallback left it as `"scaffold"`, so a user who uploaded a project and then edited it via `write_file` would get their code clobbered the first time they triggered `generate_code`.
+
+#### `_parse_ts_loose()` helper
+
+- New helper in `tools.py` parses both Python `datetime.utcnow().isoformat()` (T-separator, microseconds) and SQLite `CURRENT_TIMESTAMP` (space separator, no microseconds, occasional trailing `Z`). The runs table and the messages table use different formats; without a unified parser, "is this run from the current turn?" comparisons would silently fail.
+
+#### ACTIVE PROJECT block — Bug 9 / 10
+
+- **Path-explicit project block** — `backend/agents/chat.py` injection now emits `**ON-DISK PATH (use this for ALL tool calls): /root/projects/{project_id}**` as a top-level field, with the human-readable name relabeled `display name (NOT a directory — do NOT use this as a path)`. Previously the model would `mkdir -p /root/projects/{display-name}` because it couldn't tell the difference between the human label and the slug.
+- **v2 active-project guidance — write_file is now the default**, not generate_code. Pasted 1–5 lines of code, 1–3 file tweaks, refactors of an existing function: all explicitly listed as `read_file` → `write_file`. `generate_code` only for genuinely 3+ NEW files or major refactors. Includes "NEVER pass a task description like 'create a complete X' for a project that already exists" — that wording was directly responsible for the scaffold rebuild that nearly clobbered a working font fix.
+- **Runtime-bug branch added** — split the bug-report path in two: build/compile/lint errors → `run_review` (existing behavior), but **runtime bugs that compile fine** (crashes when clicked, preview not updating, invalid font strings) → read the relevant 1–3 files and `write_file` directly, because the reviewer can't see them. Persona prompt updated to match.
+
+#### Persona prompt + re-seed plumbing
+
+- **Coder Bot v2 system prompt** — added the runtime-bug branch and a top-level **ANTI-REBUILD RULE** section: "Once `generate_code` has succeeded for a project this turn, do NOT call it again. … The server enforces this with a hard gate; ignoring it just costs you a round."
+- **`seed_coder_bot_v2()` now updates in-place** — `backend/agents/personas.py` stopped deleting and recreating the persona on re-seed. The `mc_id` is preserved if an existing row matches by name, so existing conversations keep their persona link across re-seeds. New `update_model_config` call replaces the `delete + create_model_config` pattern.
+
+#### Settings persistence — Bug 6
+
+- **Empty-string settings now respected on startup** — `backend/main.py:183` switched from `if _settings.get("planning_model"):` (truthy check, skips empty strings) to `if "planning_model" in _settings:` with `or ""` assignment. Previously a user setting Planning Model to "(use chat model)" → empty string → saved correctly via `PATCH /api/settings`, but on the next restart `config.PLANNING_MODEL` reverted to the env default (`qwen3.5:27b` in `config.py`). Now the user's choice survives restarts. Same fix applied to `coder_model`. Visible in startup logs: `[Config] Loaded Planning Model from settings: (use chat model)`.
+
+#### Upload size limit
+
+- **Default upload limit raised 50 MB → 250 MB** — `backend/config.py` `MAX_UPLOAD_SIZE_MB` (still env-overridable). 50 MB rejected most real projects once `.venv` was included; 250 MB fits a typical PyQt5 + dependencies venv with headroom and still buffers safely in a single uvicorn worker.
+- **Hardcoded 50 MB checks routed through the constant** — `backend/main.py:1641` (PDF route) was hardcoded; now uses `config.MAX_UPLOAD_SIZE_MB`. Frontend single-file attach guard at `frontend/dist/index.html:2589` bumped to match.
+
+### OpenHands — Reasoning Effort setting
+
+- **New "Reasoning Effort" dropdown in the OpenHands settings tile.** Three options: **Low** (fastest, minimal think tokens), **Medium** (balanced — new default for local Ollama), **High** (most thorough, what the SDK defaults to and what was making local builds take 5+ minutes per file). Helper text recommends Low when generate_code is taking minutes per file.
+- **End-to-end plumbing**: `OPENHANDS_REASONING_EFFORT` config in `backend/config.py` (env-overridable, default `medium`), load/save/expose via `backend/main.py` settings handlers, forwarded in `oh_payload` from `backend/tools.py`, received as `RunRequest.reasoning_effort` in `backend/openhands_worker.py`, passed to `_LLM(reasoning_effort=...)` with a graceful `TypeError` fallback for older SDK versions that don't accept the kwarg (logs a warning, uses SDK default — setting becomes a no-op for that case rather than crashing).
+- **Why this matters**: the OpenHands SDK defaults `reasoning_effort=high` and `extended_thinking_budget=200000`, which on a 30B Ollama model with `num_ctx=16384` (~46 GB VRAM) makes a single tool-decision round take 30+ seconds. Combined with model-swap thrashing (chat agent ↔ builder agent fighting for VRAM), a 3-file scaffold could take 5 minutes wall-clock. Dropping to `medium` or `low` cuts that significantly with no observable quality regression on standard CRUD/UI tasks.
+
 ## Alpha v17 — May 7, 2026
 
 ### Coder Bot v2 — Multi-Agent Rebuild
@@ -186,7 +231,6 @@ Each gate state's tool result tells the model exactly what to call next, with th
 - Fixed Reviewer / Fixer scope-validation edge case where issues with no `suggested_fix_scope` field caused the Fixer to error out instead of skipping the issue cleanly.
 - Fixed Bash render error where `$VAR` and command-substitution `$(cmd)` inside a `bash` code fence prematurely terminated rendering.
 - Fixed `num_ctx` from user settings being silently ignored by OpenHands runs after the first model load — now evict-and-reload guarantees the runtime context matches the requested value.
-
 
 
 ## Alpha v16.2 — April 22, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,23 @@ Ten edge cases in the v2 gate, profile detection, and persona prompt that togeth
 - **Why it matters** — the SDK defaults `reasoning_effort=high` + `extended_thinking_budget=200000`. On a 30B model with `num_ctx=16384` that's 30+ s per tool round; with chat ↔ builder VRAM thrashing, a 3-file scaffold ran 5 min wall-clock. Medium/Low cuts that with no quality regression on CRUD/UI tasks.
 - **Plumbing** — `OPENHANDS_REASONING_EFFORT` in `config.py` → settings handlers in `main.py` → `oh_payload` in `tools.py` → `RunRequest.reasoning_effort` in `openhands_worker.py` → `_LLM(reasoning_effort=…)` with a `TypeError` fallback for older SDKs (logs a warning, no-op).
 
+### Quick Search — multi-round agent
+
+Replaced the single-shot rewrite-and-search pipeline with `backend/search_agent.py`. Same call site, smarter inside.
+
+- **Triage stage** — one Ollama call (`format=json`, `think=false`) returns `{needs_search, queries[1-3], category, reason}`. Replaces the old skip-classify / rewrite / pronoun-validate chain. Falls back to searching the raw user message on JSON-parse failure.
+- **Multi-query fanout** — compound questions get parallel SearXNG calls, results merged.
+- **Relevance check + optional refine** — if top-3 result tokens overlap < 30% with the user's message, refine the query and search once more (max 2 rounds).
+- **Domain bias** retained — news queries demote SO/GitHub, code queries demote news/recipe, etc.
+- **Anti-leak prompt** — triage examples now use disjoint domains (sourdough/Rust/Brazil/greeting/attached) with explicit "don't copy these entities" instruction; small models like dolphin-phi:2.7b were regurgitating the old UK-politics example verbatim.
+- **VRAM fix** — triage call hard-caps `num_ctx=4096`. Without it, qwen3.5:4b's 256K default allocated ~19GB of KV cache and evicted the chat model. Saved 12.5GB.
+- **Workspace model wired end-to-end** — the UI's "Workspace Analysis Model" dropdown now PATCHes `workspace_model` to `/api/settings`, persisted to `settings.json`, loaded into `config.WORKSPACE_MODEL` on boot. Was localStorage-only; backend never saw the user's choice. Triage priority: `QUICK_SEARCH_TRIAGE_MODEL` → workspace → chat model → default.
+- **Carousel reuses agent results** — agent emits `search_results` SSE event tagged `source: "quick_search"`; frontend renders that into the QUICK SEARCH RESULTS carousel directly. Removed the parallel `/api/quick-search` POST in the chat send path. One SearXNG round-trip per turn instead of two; carousel and chat answer can no longer disagree.
+- **Removed** — `_rewrite_query`, `_try_rewrite_call`, `_topic_phrase` legacy chain. `_should_skip` / `_content_tokens` / `_needs_context` / `_classify_query` / domain-bias / page-fetch / OG enrichment helpers stay (reused by the agent).
+- **Tests** — `backend/tests/test_search_agent.py`, 24 unit tests covering triage validation, relevance scoring, single/refine paths, max-rounds cap, skip-gate.
+- **Deploy monitor** — `backend/search_agent.py` added to `WATCHED` in `deploy_monitor.py`.
+
+
 ## Alpha v17 — May 7, 2026
 
 ### Coder Bot v2 — Multi-Agent Rebuild

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,46 +2,34 @@
 
 ### Coder Bot v2 — workflow gate hardening
 
-A run-by-run debugging session against real user projects exposed ten edge cases in the v2 workflow gate, profile detection, and persona prompt. Each one would, on its own, derail a single conversation; together they explained why the same prompt ("fix the QFont error in this uploaded project") could swing between a clean 16-round bug fix and a 24-round rebuild loop that clobbered the user's edits. All ten are fixed and verified against the same prompt re-run.
+Ten edge cases in the v2 gate, profile detection, and persona prompt that together swung the same prompt between a clean 16-round bug fix and a 24-round rebuild loop. All fixed.
 
-#### Reviewer/Fixer/gate fixes
+#### Gate / Reviewer / Fixer
+- **Phantom `run_fixer` blocked** — `tools.py` gate refuses `run_fixer` unless the latest run is a reviewer with `status="issues"`/`"error"`. Stops cycle-cap burn from hallucinated `reviewer_run_id`s.
+- **"Nothing to fix" is `skipped`, not `succeeded`** — `agents/fixer.py:249`. The 3-cycle cap counts only real attempts now.
+- **`pytest` exit 5 ("no tests collected") treated as benign** — `agents/reviewer.py:43,47` append `|| echo '(no tests)'`. Greenfield scaffolds stop infinite-looping on a missing `pytest.ini`.
+- **Cycle cap delivers gracefully** — PENDING_FIX gate releases `download_project`, `download_file`, `read_file`, `list_files` once the cap fires, with the cap message suggesting `download_project` as the ship path.
+- **Anti-rebuild guard** — `tools.py` blocks a second `generate_code` against the same project in the same turn (detected via `runs.started_at >= latest_user_message.created_at`). Pushes the model toward `read_file` + `write_file` for refinement.
+- **Profile auto-detect for edited uploads** — `tools.py` fallback sets `_builder_profile = "feature"` when an active project has no prior builder run, so `write_file`-edited uploads aren't clobbered by a scaffold rebuild.
+- **`_parse_ts_loose()`** — new helper unifies SQLite `CURRENT_TIMESTAMP` (space, no µs) and Python `isoformat()` (T, with µs) for cross-table "is this run from the current turn?" comparisons.
 
-- **Phantom `run_fixer` guard** — `backend/tools.py` exec_tool gate now refuses `run_fixer` unless the latest meaningful run is a reviewer with `status="issues"` or `"error"`. Previously the gate's allow-list let `run_fixer` through after a builder, so a model that hallucinated a `reviewer_run_id` immediately after `generate_code` would burn a cycle-cap slot for zero work. Block message includes the actual most-recent run role/status and a `run_review` next-step hint with the on-disk project_dir.
-- **"Nothing to fix" no longer counts as a succeeded cycle** — `backend/agents/fixer.py:249` switched the no-envelope skip path from `status="succeeded"` to `status="skipped"`. The 3-cycle cap counts only real fix attempts now.
-- **`pytest` exit code 5 ("no tests collected") treated as benign** — `backend/agents/reviewer.py:43,47` appended `|| echo '(no tests)'` to the `pyproject.toml` and `requirements.txt` test commands, matching the plain-Python fallback at line 76. Greenfield scaffolds with no tests yet stop triggering an infinite review/fix loop where the Fixer writes `pytest.ini` over and over.
-- **Cycle cap allows graceful delivery** — when the 3-cycle fixer cap fires, `tools.py` PENDING_FIX gate now releases `download_project`, `download_file`, `read_file`, `list_files` so the model can ship what was built or inspect the tree. Cap message also explicitly suggests `download_project` as a "ship as-is" path instead of telling the model "respond with text only" (which qwen3-coder ignored).
-- **Anti-rebuild guard for `generate_code`** — `tools.py` blocks a second `generate_code` against the same project in the same conversation turn (since the latest user message). Detected via `runs.started_at >= latest_user_message.created_at`. Pushes the model toward `read_file` + `write_file` for iterative refinement instead of running the OpenHands feature-builder twice for ~150s of clobbering. Block message includes file-path hints so the model knows exactly what to do next.
-- **Profile auto-detection for write_file-edited uploaded projects** — `tools.py` coding_projects fallback now sets `_builder_profile = "feature"` when there's an active project but no prior builder run. Previously the fallback left it as `"scaffold"`, so a user who uploaded a project and then edited it via `write_file` would get their code clobbered the first time they triggered `generate_code`.
+#### ACTIVE PROJECT block
+- **Path-explicit injection** — `agents/chat.py` emits `**ON-DISK PATH (use this for ALL tool calls): /root/projects/{project_id}**` and relabels the human name `display name (NOT a directory)`. Stops `mkdir -p /root/projects/{display-name}` mistakes.
+- **`write_file` is the default** — small edits, refactors, 1–5 line pastes all route to `read_file` → `write_file`. `generate_code` reserved for genuinely new 3+ files or major refactors.
+- **Runtime-bug branch** — runtime crashes that compile fine (font errors, bad preview state) skip `run_review` and go straight to `read_file` → `write_file`, since the reviewer can't see them. Persona prompt updated to match.
 
-#### `_parse_ts_loose()` helper
+#### Persona + seeding
+- **Coder Bot v2 prompt** — runtime-bug branch added; new top-level **ANTI-REBUILD RULE** explaining the gate.
+- **`seed_coder_bot_v2()` updates in-place** — `agents/personas.py` no longer deletes-and-recreates on re-seed, preserving `mc_id` so existing conversations keep their persona link.
 
-- New helper in `tools.py` parses both Python `datetime.utcnow().isoformat()` (T-separator, microseconds) and SQLite `CURRENT_TIMESTAMP` (space separator, no microseconds, occasional trailing `Z`). The runs table and the messages table use different formats; without a unified parser, "is this run from the current turn?" comparisons would silently fail.
+#### Settings & uploads
+- **Empty-string settings respected on restart** — `main.py:183` switched to `"key" in _settings` membership checks. Planning Model = "(use chat model)" now survives restarts instead of reverting to the env default. Same fix for `coder_model`.
+- **Upload limit 50 MB → 250 MB** — `config.MAX_UPLOAD_SIZE_MB` (env-overridable). Fits a typical PyQt5 + venv. `main.py:1641` PDF route and `frontend/dist/index.html:2589` attach guard now route through the constant.
 
-#### ACTIVE PROJECT block — Bug 9 / 10
-
-- **Path-explicit project block** — `backend/agents/chat.py` injection now emits `**ON-DISK PATH (use this for ALL tool calls): /root/projects/{project_id}**` as a top-level field, with the human-readable name relabeled `display name (NOT a directory — do NOT use this as a path)`. Previously the model would `mkdir -p /root/projects/{display-name}` because it couldn't tell the difference between the human label and the slug.
-- **v2 active-project guidance — write_file is now the default**, not generate_code. Pasted 1–5 lines of code, 1–3 file tweaks, refactors of an existing function: all explicitly listed as `read_file` → `write_file`. `generate_code` only for genuinely 3+ NEW files or major refactors. Includes "NEVER pass a task description like 'create a complete X' for a project that already exists" — that wording was directly responsible for the scaffold rebuild that nearly clobbered a working font fix.
-- **Runtime-bug branch added** — split the bug-report path in two: build/compile/lint errors → `run_review` (existing behavior), but **runtime bugs that compile fine** (crashes when clicked, preview not updating, invalid font strings) → read the relevant 1–3 files and `write_file` directly, because the reviewer can't see them. Persona prompt updated to match.
-
-#### Persona prompt + re-seed plumbing
-
-- **Coder Bot v2 system prompt** — added the runtime-bug branch and a top-level **ANTI-REBUILD RULE** section: "Once `generate_code` has succeeded for a project this turn, do NOT call it again. … The server enforces this with a hard gate; ignoring it just costs you a round."
-- **`seed_coder_bot_v2()` now updates in-place** — `backend/agents/personas.py` stopped deleting and recreating the persona on re-seed. The `mc_id` is preserved if an existing row matches by name, so existing conversations keep their persona link across re-seeds. New `update_model_config` call replaces the `delete + create_model_config` pattern.
-
-#### Settings persistence — Bug 6
-
-- **Empty-string settings now respected on startup** — `backend/main.py:183` switched from `if _settings.get("planning_model"):` (truthy check, skips empty strings) to `if "planning_model" in _settings:` with `or ""` assignment. Previously a user setting Planning Model to "(use chat model)" → empty string → saved correctly via `PATCH /api/settings`, but on the next restart `config.PLANNING_MODEL` reverted to the env default (`qwen3.5:27b` in `config.py`). Now the user's choice survives restarts. Same fix applied to `coder_model`. Visible in startup logs: `[Config] Loaded Planning Model from settings: (use chat model)`.
-
-#### Upload size limit
-
-- **Default upload limit raised 50 MB → 250 MB** — `backend/config.py` `MAX_UPLOAD_SIZE_MB` (still env-overridable). 50 MB rejected most real projects once `.venv` was included; 250 MB fits a typical PyQt5 + dependencies venv with headroom and still buffers safely in a single uvicorn worker.
-- **Hardcoded 50 MB checks routed through the constant** — `backend/main.py:1641` (PDF route) was hardcoded; now uses `config.MAX_UPLOAD_SIZE_MB`. Frontend single-file attach guard at `frontend/dist/index.html:2589` bumped to match.
-
-### OpenHands — Reasoning Effort setting
-
-- **New "Reasoning Effort" dropdown in the OpenHands settings tile.** Three options: **Low** (fastest, minimal think tokens), **Medium** (balanced — new default for local Ollama), **High** (most thorough, what the SDK defaults to and what was making local builds take 5+ minutes per file). Helper text recommends Low when generate_code is taking minutes per file.
-- **End-to-end plumbing**: `OPENHANDS_REASONING_EFFORT` config in `backend/config.py` (env-overridable, default `medium`), load/save/expose via `backend/main.py` settings handlers, forwarded in `oh_payload` from `backend/tools.py`, received as `RunRequest.reasoning_effort` in `backend/openhands_worker.py`, passed to `_LLM(reasoning_effort=...)` with a graceful `TypeError` fallback for older SDK versions that don't accept the kwarg (logs a warning, uses SDK default — setting becomes a no-op for that case rather than crashing).
-- **Why this matters**: the OpenHands SDK defaults `reasoning_effort=high` and `extended_thinking_budget=200000`, which on a 30B Ollama model with `num_ctx=16384` (~46 GB VRAM) makes a single tool-decision round take 30+ seconds. Combined with model-swap thrashing (chat agent ↔ builder agent fighting for VRAM), a 3-file scaffold could take 5 minutes wall-clock. Dropping to `medium` or `low` cuts that significantly with no observable quality regression on standard CRUD/UI tasks.
+### OpenHands — Reasoning Effort
+- **New "Reasoning Effort" dropdown** in the OpenHands settings tile: **Low** / **Medium** (new default for local Ollama) / **High** (SDK default).
+- **Why it matters** — the SDK defaults `reasoning_effort=high` + `extended_thinking_budget=200000`. On a 30B model with `num_ctx=16384` that's 30+ s per tool round; with chat ↔ builder VRAM thrashing, a 3-file scaffold ran 5 min wall-clock. Medium/Low cuts that with no quality regression on CRUD/UI tasks.
+- **Plumbing** — `OPENHANDS_REASONING_EFFORT` in `config.py` → settings handlers in `main.py` → `oh_payload` in `tools.py` → `RunRequest.reasoning_effort` in `openhands_worker.py` → `_LLM(reasoning_effort=…)` with a `TypeError` fallback for older SDKs (logs a warning, no-op).
 
 ## Alpha v17 — May 7, 2026
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Built with FastAPI + a single-file React SPA. No build step, no cloud dependenci
 
 ---
 
+## ⚠️ Security Warning
+
+HyprChat can execute code, upload files, call local services, and drive coding agents. **Do not expose it directly to the public internet.** Run it behind Tailscale, a VPN, or a reverse proxy with authentication. The default configuration binds to `127.0.0.1` and assumes a trusted local network.
+
+---
+
 ## ✨ Core Features
 
 ### 💬 Chat

--- a/backend/agents/architect.py
+++ b/backend/agents/architect.py
@@ -24,6 +24,7 @@ import uuid
 
 import config
 import database as db
+import cancel_registry
 
 
 # Required top-level keys in the validated plan.
@@ -119,10 +120,17 @@ def _validate_plan(plan: dict) -> tuple[bool, str]:
 
 
 async def _call_planning_model(http, model: str, prompt: str,
-                                num_ctx: int = 16384) -> str:
-    """Single non-streaming call to Ollama, returns the message content."""
+                                num_ctx: int = 16384,
+                                run_id: str = "") -> str:
+    """Single non-streaming call to Ollama, returns the message content.
+
+    If `run_id` is registered with `cancel_registry`, the in-flight POST is
+    aborted when the user presses Stop and `RunCancelled` propagates up so
+    `run_architect` can mark the run cancelled instead of letting it dangle
+    on the 600s timeout.
+    """
     try:
-        r = await http.post(
+        coro = http.post(
             f"{config.OLLAMA_URL}/api/chat",
             json={
                 "model": model,
@@ -132,9 +140,12 @@ async def _call_planning_model(http, model: str, prompt: str,
             },
             timeout=600,
         )
+        r = await cancel_registry.await_cancellable(coro, run_id)
         if r.status_code == 200:
             return (r.json().get("message", {}).get("content") or "").strip()
         return ""
+    except cancel_registry.RunCancelled:
+        raise
     except Exception as e:
         print(f"[ARCHITECT] LLM call failed: {e}")
         return ""
@@ -159,8 +170,66 @@ async def run_architect(http, events, conv_id: str, *,
         print(f"[ARCHITECT] create_run failed (non-fatal): {e}")
         run_id = ""
 
-    # Step counter for the durable runs.events_log — frontend RunCard sorts
-    # and renders step events in order, so each event needs a stable step #.
+    # Per-agent override (config.ARCHITECT_MODEL) wins if set; otherwise fall
+    # through to the umbrella PLANNING_MODEL, then the chat model, then default.
+    model = (config.ARCHITECT_MODEL or config.PLANNING_MODEL or conv_model or config.DEFAULT_MODEL or "")
+    if not model:
+        envelope = {"status": "error",
+                    "summary": "No planning model configured for Architect",
+                    "manifest": [], "success_criteria": []}
+        if run_id:
+            try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
+            except Exception: pass
+        return envelope
+
+    # Register the cancel event keyed by run_id so the user's Stop button
+    # (POST /api/runs/{id}/cancel) can abort the in-flight Ollama call. The
+    # event is cleaned up after the inner run finishes (success, error, or
+    # cancel).
+    if run_id:
+        cancel_registry.register(run_id)
+    try:
+        return await _run_architect_inner(
+            http, events, conv_id, run_id=run_id, model=model,
+            task=task, language_hint=language_hint, kb_chunks=kb_chunks,
+        )
+    finally:
+        if run_id:
+            cancel_registry.cleanup(run_id)
+
+
+async def _emit_cancelled(events, conv_id: str, run_id: str, model: str) -> dict:
+    """Build + persist the cancelled-by-user envelope and emit a tool_end."""
+    envelope = {
+        "status": "cancelled",
+        "summary": "Architect cancelled by user (Stop pressed)",
+        "architect_model": model,
+        "manifest": [],
+        "success_criteria": [],
+    }
+    try:
+        await events.emit(conv_id, "tool_end", {
+            "tool": "plan_project", "icon": "compass",
+            "status": "⛔ Architect cancelled by user",
+            "run_id": run_id,
+        })
+    except Exception:
+        pass
+    if run_id:
+        try:
+            await db.update_run(run_id, status="cancelled",
+                                result_envelope=envelope, ended=True)
+        except Exception as e:
+            print(f"[ARCHITECT] cancelled update_run failed (non-fatal): {e}")
+    return envelope
+
+
+async def _run_architect_inner(http, events, conv_id: str, *, run_id: str,
+                                model: str, task: str, language_hint: str,
+                                kb_chunks: list | None) -> dict:
+    """Real body of run_architect — split out so the outer wrapper can do
+    the register/cleanup pair around it without mass-indenting everything."""
+
     _step_n = [0]
 
     async def _step(action: str, detail: str = ""):
@@ -179,18 +248,6 @@ async def run_architect(http, events, conv_id: str, *,
                 })
             except Exception:
                 pass
-
-    # Per-agent override (config.ARCHITECT_MODEL) wins if set; otherwise fall
-    # through to the umbrella PLANNING_MODEL, then the chat model, then default.
-    model = (config.ARCHITECT_MODEL or config.PLANNING_MODEL or conv_model or config.DEFAULT_MODEL or "")
-    if not model:
-        envelope = {"status": "error",
-                    "summary": "No planning model configured for Architect",
-                    "manifest": [], "success_criteria": []}
-        if run_id:
-            try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
-            except Exception: pass
-        return envelope
 
     # Build the kb_section. Each chunk is rendered as a labelled block, capped
     # so the prompt stays reasonable.
@@ -212,7 +269,10 @@ async def run_architect(http, events, conv_id: str, *,
     )
 
     await _step("planning", f"calling {model}")
-    text = await _call_planning_model(http, model, base_prompt)
+    try:
+        text = await _call_planning_model(http, model, base_prompt, run_id=run_id)
+    except cancel_registry.RunCancelled:
+        return await _emit_cancelled(events, conv_id, run_id, model)
     plan, parse_err = _try_parse_architect_json(text)
 
     if plan:
@@ -230,7 +290,10 @@ async def run_architect(http, events, conv_id: str, *,
             + "Output ONLY a valid JSON object that satisfies the schema above. "
             + "No prose, no fences. Try again now:"
         )
-        text = await _call_planning_model(http, model, retry_prompt)
+        try:
+            text = await _call_planning_model(http, model, retry_prompt, run_id=run_id)
+        except cancel_registry.RunCancelled:
+            return await _emit_cancelled(events, conv_id, run_id, model)
         plan, parse_err = _try_parse_architect_json(text)
         if plan:
             valid, validation_err = _validate_plan(plan)

--- a/backend/agents/architect.py
+++ b/backend/agents/architect.py
@@ -180,7 +180,9 @@ async def run_architect(http, events, conv_id: str, *,
             except Exception:
                 pass
 
-    model = (config.PLANNING_MODEL or conv_model or config.DEFAULT_MODEL or "")
+    # Per-agent override (config.ARCHITECT_MODEL) wins if set; otherwise fall
+    # through to the umbrella PLANNING_MODEL, then the chat model, then default.
+    model = (config.ARCHITECT_MODEL or config.PLANNING_MODEL or conv_model or config.DEFAULT_MODEL or "")
     if not model:
         envelope = {"status": "error",
                     "summary": "No planning model configured for Architect",

--- a/backend/agents/architect.py
+++ b/backend/agents/architect.py
@@ -143,7 +143,8 @@ async def _call_planning_model(http, model: str, prompt: str,
 async def run_architect(http, events, conv_id: str, *,
                         task: str, language_hint: str = "",
                         kb_chunks: list | None = None,
-                        parent_run_id: str = "") -> dict:
+                        parent_run_id: str = "",
+                        conv_model: str = "") -> dict:
     """Execute an Architect run. Returns the structured plan envelope.
 
     Side effects:
@@ -179,7 +180,7 @@ async def run_architect(http, events, conv_id: str, *,
             except Exception:
                 pass
 
-    model = (config.PLANNING_MODEL or config.DEFAULT_MODEL or "")
+    model = (config.PLANNING_MODEL or conv_model or config.DEFAULT_MODEL or "")
     if not model:
         envelope = {"status": "error",
                     "summary": "No planning model configured for Architect",

--- a/backend/agents/architect.py
+++ b/backend/agents/architect.py
@@ -143,8 +143,7 @@ async def _call_planning_model(http, model: str, prompt: str,
 async def run_architect(http, events, conv_id: str, *,
                         task: str, language_hint: str = "",
                         kb_chunks: list | None = None,
-                        parent_run_id: str = "",
-                        conv_model: str = "") -> dict:
+                        parent_run_id: str = "") -> dict:
     """Execute an Architect run. Returns the structured plan envelope.
 
     Side effects:
@@ -180,7 +179,7 @@ async def run_architect(http, events, conv_id: str, *,
             except Exception:
                 pass
 
-    model = (config.PLANNING_MODEL or conv_model or config.DEFAULT_MODEL or "")
+    model = (config.PLANNING_MODEL or config.DEFAULT_MODEL or "")
     if not model:
         envelope = {"status": "error",
                     "summary": "No planning model configured for Architect",

--- a/backend/agents/chat.py
+++ b/backend/agents/chat.py
@@ -634,6 +634,42 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
         else:
             messages.insert(0, {"role": "system", "content": _viz_hint.strip()})
 
+    # Research-only sessions (deep_research / conspiracy_research enabled without
+    # codeagent) need an explicit nudge — without it the model sees the tool but
+    # just answers from memory. Skipped when full codeagent is on; that prompt
+    # already covers tool use.
+    _research_tools_present = available_tool_names & {"deep_research", "conspiracy_research"}
+    if _research_tools_present and not _has_full_codeagent:
+        _names = " or ".join(sorted(_research_tools_present))
+        _research_sys = (
+            "\n\n## RESEARCH PROTOCOL (MANDATORY)\n"
+            f"The user has explicitly enabled **{_names}** for this turn. That means "
+            "they want a multi-source web-researched answer, not your own analysis. "
+            f"Your FIRST response MUST be a call to {_names}.\n"
+            "\n"
+            "**This applies even when context is attached.** Attached PDFs, pasted "
+            "text, or knowledge-base excerpts describe the USER (their data, their "
+            "situation) — they are NOT a substitute for external research. The user "
+            "wants you to compare, benchmark, or contextualize that attached data "
+            "against external sources you fetch with the tool.\n"
+            "\n"
+            "- Call the tool with a clear `topic` derived from the user's question. "
+            "Pull comparison terms, entity names, or benchmarks out of the attached "
+            "context to make the topic specific.\n"
+            "- Use `depth` to match the user's request (1=quick, 3=standard, 5=exhaustive).\n"
+            "- Wait for the tool result, then synthesize a final report that "
+            "cross-references the attached data against what the tool returned. "
+            "Cite sources from the tool result.\n"
+            "- Do NOT write a written answer before calling the tool. Do NOT say "
+            "\"based on the attached document...\" as your first move.\n"
+            "- Only skip the tool for greetings, clarification questions, or trivial "
+            "definitional questions where external research adds nothing.\n"
+        )
+        if messages and messages[0]["role"] == "system":
+            messages[0]["content"] += _research_sys
+        else:
+            messages.insert(0, {"role": "system", "content": _research_sys.strip()})
+
     # Inject tool-use system prompt when full codeagent tools are available
     if _has_full_codeagent:
         tool_sys = "\n\n## CODING AGENT PROTOCOL (MANDATORY)\n"

--- a/backend/agents/chat.py
+++ b/backend/agents/chat.py
@@ -452,10 +452,12 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
     if _active_project:
         _ap_files = _active_project.get("file_manifest") or []
         _ap_id = _active_project.get("id", "") or ""
+        _ap_path = f"/root/projects/{_ap_id}" if _ap_id else ""
         _ap_lines = [
             "## ACTIVE PROJECT (this conversation already has a built project)",
-            f"- name: {_active_project.get('name', '?')}",
+            f"- display name: {_active_project.get('name', '?')}  (NOT a directory — do NOT use this as a path)",
             f"- project_id: {_ap_id}",
+            f"- **ON-DISK PATH (use this for ALL tool calls): `{_ap_path}`**",
             f"- language: {_active_project.get('language', '?')}",
             f"- description: {(_active_project.get('description') or '')[:200]}",
         ]
@@ -468,6 +470,10 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
         if _is_v2_persona:
             _ap_lines.append(
                 "\n## How to handle this project\n"
+                f"**The project lives at `{_ap_path}` — already extracted on disk. "
+                f"NEVER mkdir a new directory. NEVER use the display name "
+                f"('{_active_project.get('name', '?')}') as a path. ALWAYS pass "
+                f"`{_ap_path}` to any tool that takes a project_dir or path.**\n\n"
                 "1. **For QUESTIONS** about the code (\"how does X work?\", \"walk me "
                 "through Y\", \"show me Z\", \"break down W line by line\", \"what does "
                 "this do?\"): your VERY FIRST tool call MUST be `ask_project(question='...')`. "
@@ -476,13 +482,28 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                 "relevant, and produces a grounded answer with file:line citations in "
                 "ONE round. Hand-rolling read_file across many files is the v1 "
                 "antipattern that wastes rounds.\n"
-                "2. **For CHANGE REQUESTS** (\"add X\", \"fix Y\", \"refactor Z\", "
-                "\"implement W\"): use `generate_code(task='...', project_id="
-                f"'{_ap_id}')` for substantial changes, or `write_file` + `run_review` "
-                "for tweaks to 1-2 files.\n"
+                "2. **For CHANGE REQUESTS — DEFAULT TO write_file, NOT generate_code.** "
+                "Only call generate_code when the user is genuinely asking you to add "
+                "3+ NEW files or do a major refactor. For ALL of these, use read_file + "
+                "write_file:\n"
+                "   - User pastes 1–5 lines of code (\"the fix is `x.foo()`\", \"replace "
+                "Y with Z\", \"use this API call\") → read_file the relevant file(s) → "
+                "write_file with the change.\n"
+                "   - 1–3 file tweaks, bug fixes, refactors of an existing function, "
+                "additions of small features.\n"
+                "   - Anything where you'd touch fewer than ~3 files.\n"
+                f"   When you DO need generate_code, pass `project_id='{_ap_id}'` so the "
+                f"Builder amends in place instead of scaffolding fresh. NEVER pass a "
+                f"task description that says \"create a complete X\" or \"build a Y\" "
+                f"for a project that already exists — that triggers a scaffold rebuild "
+                f"and clobbers the existing code.\n"
                 "3. **For BUG REPORTS** (\"the tests are failing\", \"it crashes when "
-                "...\"): call `run_review(project_dir='/root/projects/" + _ap_id + "')` "
-                "first — the Reviewer runs the build/tests and tells you what's broken.\n"
+                f"...\"): call `run_review(project_dir='{_ap_path}')` first — the "
+                f"Reviewer runs the build/tests and tells you what's broken. If the "
+                f"reviewer comes back clean but the user still reports a runtime bug "
+                f"(crashes, UI not updating, error that compiles fine): read the "
+                f"relevant 1–3 files and write_file the targeted fix. Do NOT call "
+                f"generate_code for runtime bugs.\n"
                 "4. **Do NOT auto-package or download** the project unless the user "
                 "explicitly asks for the tarball/zip. They already uploaded it."
             )
@@ -718,6 +739,12 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
 
         # Keepalive before Ollama call — prevents browser/proxy timeout during prompt eval
         yield f"data: {json.dumps({'type': 'keepalive'})}\n\n"
+
+        # Estimate prompt tokens so the frontend counter reflects context-in-flight,
+        # not just live generation. Real prompt_eval_count arrives only at done=True.
+        _est_prompt_pre = sum(len(m.get("content", "")) for m in messages) // 4
+        if _est_prompt_pre:
+            yield f"data: {json.dumps({'type': 'ctx_update', 'gen_tokens': 0, 'prompt_tokens': _est_prompt_pre, 'live': True})}\n\n"
 
         try:
             async with http.stream("POST", f"{config.OLLAMA_URL}/api/chat",

--- a/backend/agents/chat.py
+++ b/backend/agents/chat.py
@@ -603,6 +603,18 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                 })
             except Exception:
                 pass
+            # Tell the model search is unavailable so it doesn't confidently
+            # hallucinate current-event facts. Prepended to the latest user
+            # message so it stays scoped to this turn.
+            _fail_note = (
+                "\n\n[SYSTEM: Web search was unavailable for this turn. "
+                "If asked about current events, recent news, or specific "
+                "factual claims, say you can't verify them rather than guessing.]"
+            )
+            for _m in reversed(messages):
+                if _m["role"] == "user":
+                    _m["content"] = (_m.get("content") or "") + _fail_note
+                    break
 
     # Inject visualization hint for non-coder chats that have execute_code + download_file
     _has_full_codeagent = bool(available_tool_names & (CODEAGENT_TOOLS_SET - {"execute_code", "download_file"}))

--- a/backend/agents/chat.py
+++ b/backend/agents/chat.py
@@ -587,6 +587,7 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                 config.WORKSPACE_MODEL or config.DEFAULT_MODEL,
                 events, conv_id, messages,
                 default_model=config.DEFAULT_MODEL,
+                chat_model=req.model or "",
             )
             if qs.get("context"):
                 for m in reversed(messages):

--- a/backend/agents/fixer.py
+++ b/backend/agents/fixer.py
@@ -246,7 +246,10 @@ async def run_fixer(http, events, conv_id: str, *,
                     "issues_addressed": 0, "files_touched": [], "errors": [],
                     "project_dir": project_dir, "language": language}
         if run_id:
-            try: await db.update_run(run_id, status="succeeded", result_envelope=envelope, ended=True)
+            # Status="skipped" (not "succeeded") so this no-op doesn't count
+            # toward the 3-cycle cap in tools.py — a fixer call with nothing
+            # to fix shouldn't burn a quota slot.
+            try: await db.update_run(run_id, status="skipped", result_envelope=envelope, ended=True)
             except Exception: pass
         await events.emit(conv_id, "tool_end", {
             "tool": "run_fixer", "icon": "wrench",
@@ -255,7 +258,10 @@ async def run_fixer(http, events, conv_id: str, *,
         })
         return envelope
 
-    fixer_model = (config.CODER_MODEL or config.PLANNING_MODEL
+    # Per-agent override (config.FIXER_MODEL) wins if set; else umbrella
+    # CODER_MODEL → PLANNING_MODEL → default. Fixer is a code-editing agent so
+    # it intentionally does NOT fall back to the chat model.
+    fixer_model = (config.FIXER_MODEL or config.CODER_MODEL or config.PLANNING_MODEL
                    or config.DEFAULT_MODEL or "")
     if not fixer_model:
         envelope = {"status": "error",

--- a/backend/agents/fixer.py
+++ b/backend/agents/fixer.py
@@ -28,6 +28,7 @@ import uuid
 
 import config
 import database as db
+import cancel_registry
 
 
 _FIXER_PROMPT = """You are the Fixer — a focused code-editing agent. You MUST only edit the files listed in 'allowed_paths' to address the specific issue described below. Do not touch any other files. Do not add new files. Do not refactor unrelated code.
@@ -200,6 +201,11 @@ async def run_fixer(http, events, conv_id: str, *,
         print(f"[FIXER] create_run failed (non-fatal): {e}")
         run_id = ""
 
+    # Register cancel event so POST /api/runs/{id}/cancel can interrupt the
+    # in-flight per-issue Ollama calls. Cleaned up at every return below.
+    if run_id:
+        cancel_registry.register(run_id)
+
     async def _step(action: str, detail: str = ""):
         await events.emit(conv_id, "tool_progress", {
             "tool": "run_fixer", "icon": "wrench",
@@ -221,6 +227,7 @@ async def run_fixer(http, events, conv_id: str, *,
         if run_id:
             try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
             except Exception: pass
+            cancel_registry.cleanup(run_id)
         return envelope
 
     reviewer = await db.get_run(reviewer_run_id)
@@ -231,6 +238,7 @@ async def run_fixer(http, events, conv_id: str, *,
         if run_id:
             try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
             except Exception: pass
+            cancel_registry.cleanup(run_id)
         return envelope
 
     rev_env = reviewer.get("result_envelope") or {}
@@ -259,6 +267,7 @@ async def run_fixer(http, events, conv_id: str, *,
             # to fix shouldn't burn a quota slot.
             try: await db.update_run(run_id, status="skipped", result_envelope=envelope, ended=True)
             except Exception: pass
+            cancel_registry.cleanup(run_id)
         await events.emit(conv_id, "tool_end", {
             "tool": "run_fixer", "icon": "wrench",
             "status": "🛠 No issues to fix — skipped",
@@ -278,6 +287,7 @@ async def run_fixer(http, events, conv_id: str, *,
         if run_id:
             try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
             except Exception: pass
+            cancel_registry.cleanup(run_id)
         return envelope
 
     await _step("start", f"{len(issues)} issue(s) to address with {fixer_model}")
@@ -392,7 +402,7 @@ async def run_fixer(http, events, conv_id: str, *,
         await _step(f"calling {fixer_model}", f"issue {i}/{len(issues)}")
         text = ""
         try:
-            r = await http.post(
+            coro = http.post(
                 f"{config.OLLAMA_URL}/api/chat",
                 json={
                     "model": fixer_model,
@@ -403,11 +413,45 @@ async def run_fixer(http, events, conv_id: str, *,
                 },
                 timeout=600,
             )
+            r = await cancel_registry.await_cancellable(coro, run_id)
             if r.status_code == 200:
                 text = (r.json().get("message", {}).get("content") or "").strip()
             else:
                 errors.append(f"Issue {i}: model HTTP {r.status_code}")
                 continue
+        except cancel_registry.RunCancelled:
+            # User pressed Stop mid-loop. Bail out of the issue loop and emit
+            # a cancelled envelope so the frontend run card flips to cancelled.
+            cancelled_env = {
+                "status": "cancelled",
+                "summary": (f"Fixer cancelled by user during issue {i}/{len(issues)}; "
+                            f"{len(files_touched)} file(s) already written before cancel."),
+                "issues_addressed": i - 1,
+                "files_touched": sorted(files_touched),
+                "diffs": diffs[:20],
+                "errors": errors[:10],
+                "fixer_model": fixer_model,
+                "project_dir": project_dir,
+                "language": language,
+                "reviewer_run_id": reviewer_run_id,
+                "research_used": bool(research_context),
+            }
+            try:
+                await events.emit(conv_id, "tool_end", {
+                    "tool": "run_fixer", "icon": "wrench",
+                    "status": "⛔ Fixer cancelled by user",
+                    "run_id": run_id,
+                })
+            except Exception:
+                pass
+            if run_id:
+                try:
+                    await db.update_run(run_id, status="cancelled",
+                                        result_envelope=cancelled_env, ended=True)
+                except Exception:
+                    pass
+                cancel_registry.cleanup(run_id)
+            return cancelled_env
         except Exception as e:
             errors.append(f"Issue {i}: model call failed: {e}")
             continue
@@ -491,5 +535,6 @@ async def run_fixer(http, events, conv_id: str, *,
             )
         except Exception as e:
             print(f"[FIXER] update_run failed (non-fatal): {e}")
+        cancel_registry.cleanup(run_id)
 
     return envelope

--- a/backend/agents/fixer.py
+++ b/backend/agents/fixer.py
@@ -176,7 +176,8 @@ def _parse_fixer_output(text: str) -> dict:
 
 async def run_fixer(http, events, conv_id: str, *,
                     reviewer_run_id: str = "",
-                    parent_run_id: str = "") -> dict:
+                    parent_run_id: str = "",
+                    conv_model: str = "") -> dict:
     """Execute a Fixer run that addresses every issue in a prior Reviewer envelope.
 
     Returns a structured envelope. Creates a `runs` row with role='fixer' and
@@ -255,7 +256,7 @@ async def run_fixer(http, events, conv_id: str, *,
         })
         return envelope
 
-    fixer_model = (config.CODER_MODEL or config.PLANNING_MODEL
+    fixer_model = (config.CODER_MODEL or conv_model
                    or config.DEFAULT_MODEL or "")
     if not fixer_model:
         envelope = {"status": "error",

--- a/backend/agents/fixer.py
+++ b/backend/agents/fixer.py
@@ -37,7 +37,7 @@ _FIXER_PROMPT = """You are the Fixer — a focused code-editing agent. You MUST 
 - Language: {language}
 - Build command: {build_cmd}
 - Test command: {test_cmd}
-
+{research_section}
 ## The issue you are fixing
 {issue_block}
 
@@ -176,11 +176,19 @@ def _parse_fixer_output(text: str) -> dict:
 
 async def run_fixer(http, events, conv_id: str, *,
                     reviewer_run_id: str = "",
-                    parent_run_id: str = "") -> dict:
+                    parent_run_id: str = "",
+                    research_context: str = "") -> dict:
     """Execute a Fixer run that addresses every issue in a prior Reviewer envelope.
 
     Returns a structured envelope. Creates a `runs` row with role='fixer' and
     parent_run_id set to the reviewer run, so the run graph stays linked.
+
+    `research_context`, if provided, is the (possibly-truncated) text of a
+    recent deep_research call on this conversation. The orchestrator-side
+    dispatcher in tools.py grabs it from a per-conv cache and passes it in
+    so the Fixer's coder LLM has additional grounding for tricky errors.
+    The Fixer itself does NOT make any network calls — research happens
+    entirely on the orchestrator side; this is just an injected reference.
     """
 
     run_id = f"run-{uuid.uuid4().hex[:12]}"
@@ -278,6 +286,27 @@ async def run_fixer(http, events, conv_id: str, *,
     diffs: list[dict] = []
     errors: list[str] = []
 
+    # Build the research section once, then reuse across issues. When no
+    # research context is supplied, the section is empty and disappears
+    # from the prompt entirely. Cap at 3000 chars to keep the per-issue
+    # LLM prompt size sane — the report is a reference, not the source
+    # of truth (the issue + scoped files are still the primary signal).
+    if research_context:
+        _research_excerpt = research_context.strip()
+        if len(_research_excerpt) > 3000:
+            _research_excerpt = _research_excerpt[:3000] + "\n\n[... truncated ...]"
+        research_section = (
+            "\n## Reference (recent web research from this conversation)\n"
+            "Use this as supporting context for HOW to fix the issue when training-cutoff "
+            "knowledge may be wrong (recent library versions, API changes, deprecations, "
+            "obscure errors). The issue + scoped file contents below are still the "
+            "primary signal — the research is just additional grounding.\n\n"
+            f"{_research_excerpt}\n"
+        )
+        await _step("research-context-injected", f"{len(_research_excerpt)} chars")
+    else:
+        research_section = ""
+
     # Helper: normalize a path that may be relative (./tests/Foo.java) or
     # workspace-relative (com/pong/Foo.java) into absolute form rooted at
     # project_dir. Reviewer LLM output is inconsistent — sometimes it copies
@@ -352,6 +381,7 @@ async def run_fixer(http, events, conv_id: str, *,
             language=language or "(unknown)",
             build_cmd=build_cmd or "(none)",
             test_cmd=test_cmd or "(none)",
+            research_section=research_section,
             issue_block=issue_block,
             allowed_paths_list="\n".join(f"  - {p}" for p in capped_scope),
             files_section="\n\n".join(files_section_lines),
@@ -442,6 +472,7 @@ async def run_fixer(http, events, conv_id: str, *,
         "project_dir": project_dir,
         "language": language,
         "reviewer_run_id": reviewer_run_id,
+        "research_used": bool(research_context),
     }
 
     await events.emit(conv_id, "tool_end", {

--- a/backend/agents/fixer.py
+++ b/backend/agents/fixer.py
@@ -176,8 +176,7 @@ def _parse_fixer_output(text: str) -> dict:
 
 async def run_fixer(http, events, conv_id: str, *,
                     reviewer_run_id: str = "",
-                    parent_run_id: str = "",
-                    conv_model: str = "") -> dict:
+                    parent_run_id: str = "") -> dict:
     """Execute a Fixer run that addresses every issue in a prior Reviewer envelope.
 
     Returns a structured envelope. Creates a `runs` row with role='fixer' and
@@ -256,7 +255,7 @@ async def run_fixer(http, events, conv_id: str, *,
         })
         return envelope
 
-    fixer_model = (config.CODER_MODEL or conv_model
+    fixer_model = (config.CODER_MODEL or config.PLANNING_MODEL
                    or config.DEFAULT_MODEL or "")
     if not fixer_model:
         envelope = {"status": "error",

--- a/backend/agents/fixer.py
+++ b/backend/agents/fixer.py
@@ -19,6 +19,7 @@ other's job.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import os
@@ -31,7 +32,7 @@ import database as db
 import cancel_registry
 
 
-_FIXER_PROMPT = """You are the Fixer — a focused code-editing agent. You MUST only edit the files listed in 'allowed_paths' to address the specific issue described below. Do not touch any other files. Do not add new files. Do not refactor unrelated code.
+_FIXER_PROMPT = """You are the Fixer — a focused code-editing agent. You MUST only edit the files listed in 'allowed_paths' to address the issues described below. Do not touch any other files. Do not add new files. Do not refactor unrelated code.
 
 ## Project context
 - Project root: {project_dir}
@@ -39,7 +40,7 @@ _FIXER_PROMPT = """You are the Fixer — a focused code-editing agent. You MUST 
 - Build command: {build_cmd}
 - Test command: {test_cmd}
 {research_section}
-## The issue you are fixing
+## Issues to fix
 {issue_block}
 
 ## Files you may edit (allowed_paths)
@@ -60,7 +61,7 @@ After all your EDIT sections (zero or more), write ONE summary line:
 
 ### SUMMARY: <one short line describing what you changed and why>
 
-If you genuinely cannot fix the issue (ambiguous, need info not provided, etc.), output ONLY:
+If you genuinely cannot fix any issue (ambiguous, need info not provided, etc.), output ONLY:
 
 ### CANNOT_FIX: <one-line reason>
 
@@ -69,6 +70,7 @@ If you genuinely cannot fix the issue (ambiguous, need info not provided, etc.),
 2. The contents inside ``` fences MUST be the COMPLETE file (every line). Not a diff. Not a snippet.
 3. NO prose, explanation, or commentary outside the EDIT sections. The first line of your response should be either `### EDIT:`, `### SUMMARY:`, or `### CANNOT_FIX:`.
 4. If a file in allowed_paths needs no change, simply do not include an EDIT section for it.
+5. Address ALL listed issues in a single pass. If two issues touch the same file, emit ONE EDIT section for that file with both fixes applied.
 
 Output your sections now:"""
 
@@ -138,7 +140,7 @@ async def _write_file_sandbox(http, path: str, content: str) -> tuple[bool, str]
 # - content captured lazily, terminated by closing fence
 # - tolerates an optional language tag after the opening fence
 _EDIT_RE = re.compile(
-    r"###\s*EDIT\s*:\s*([^\n]+?)\s*\n```[A-Za-z0-9_+\-]*\s*\n(.*?)\n```",
+    r"###\s*EDIT\s*:\s*([^\n]+?)\s*\n```[A-Za-z0-9_.+#\-]*\s*\n(.*?)\n```",
     re.DOTALL,
 )
 _SUMMARY_RE = re.compile(r"###\s*SUMMARY\s*:?\s*(.+?)(?=\n\s*###|\Z)", re.DOTALL)
@@ -246,7 +248,6 @@ async def run_fixer(http, events, conv_id: str, *,
 
     project_dir = (rev_env.get("project_dir") or "").strip()
     if not project_dir:
-        # Last resort: derive from first issue's file path (e.g. /root/projects/<name>/...).
         first_file = (issues[0].get("file") if issues else "") or ""
         if first_file.startswith("/root/projects/"):
             parts = first_file.split("/")
@@ -257,14 +258,36 @@ async def run_fixer(http, events, conv_id: str, *,
     build_cmd = rev_env.get("build_cmd", "")
     test_cmd = rev_env.get("test_cmd", "")
 
+    # Validate project_dir exists on Codebox before proceeding (#14).
+    if project_dir:
+        try:
+            _chk = await http.post(
+                f"{config.CODEBOX_URL}/command",
+                json={"command": f"test -d {shlex.quote(project_dir)} && echo OK || echo NO",
+                      "timeout": 5},
+                timeout=10,
+            )
+            if _chk.status_code != 200 or "OK" not in (_chk.json().get("stdout") or ""):
+                print(f"[FIXER] project_dir={project_dir} does not exist on Codebox")
+                envelope = {
+                    "status": "error",
+                    "summary": f"project_dir '{project_dir}' not found on Codebox (workspace may have been cleaned)",
+                    "issues_addressed": 0, "files_touched": [], "errors": [],
+                    "project_dir": project_dir, "language": language,
+                }
+                if run_id:
+                    try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
+                    except Exception: pass
+                    cancel_registry.cleanup(run_id)
+                return envelope
+        except Exception as _e:
+            print(f"[FIXER] project_dir check failed (non-fatal, proceeding): {_e}")
+
     if not issues:
         envelope = {"status": "skipped", "summary": "No issues in reviewer envelope — nothing to fix",
                     "issues_addressed": 0, "files_touched": [], "errors": [],
                     "project_dir": project_dir, "language": language}
         if run_id:
-            # Status="skipped" (not "succeeded") so this no-op doesn't count
-            # toward the 3-cycle cap in tools.py — a fixer call with nothing
-            # to fix shouldn't burn a quota slot.
             try: await db.update_run(run_id, status="skipped", result_envelope=envelope, ended=True)
             except Exception: pass
             cancel_registry.cleanup(run_id)
@@ -275,9 +298,6 @@ async def run_fixer(http, events, conv_id: str, *,
         })
         return envelope
 
-    # Per-agent override (config.FIXER_MODEL) wins if set; else umbrella
-    # CODER_MODEL → PLANNING_MODEL → default. Fixer is a code-editing agent so
-    # it intentionally does NOT fall back to the chat model.
     fixer_model = (config.FIXER_MODEL or config.CODER_MODEL or config.PLANNING_MODEL
                    or config.DEFAULT_MODEL or "")
     if not fixer_model:
@@ -296,11 +316,6 @@ async def run_fixer(http, events, conv_id: str, *,
     diffs: list[dict] = []
     errors: list[str] = []
 
-    # Build the research section once, then reuse across issues. When no
-    # research context is supplied, the section is empty and disappears
-    # from the prompt entirely. Cap at 3000 chars to keep the per-issue
-    # LLM prompt size sane — the report is a reference, not the source
-    # of truth (the issue + scoped files are still the primary signal).
     if research_context:
         _research_excerpt = research_context.strip()
         if len(_research_excerpt) > 3000:
@@ -317,183 +332,217 @@ async def run_fixer(http, events, conv_id: str, *,
     else:
         research_section = ""
 
-    # Helper: normalize a path that may be relative (./tests/Foo.java) or
-    # workspace-relative (com/pong/Foo.java) into absolute form rooted at
-    # project_dir. Reviewer LLM output is inconsistent — sometimes it copies
-    # paths from javac error messages verbatim (relative because the build
-    # command uses `find .`), other times it prepends the project_dir.
     def _normalize_path(p: str) -> str:
         if not p:
             return ""
         p = p.strip()
         if p.startswith("/"):
             return p
-        # Strip a single leading "./"
         if p.startswith("./"):
             p = p[2:]
-        # Refuse paths that try to escape the project root
         if ".." in p.split("/"):
             return ""
         return f"{project_dir.rstrip('/')}/{p}"
 
-    # 2. Process issues sequentially. Future: parallelize when scopes are disjoint.
+    # 2. Collect all scope files across all issues, dedup, then batch into
+    # a single LLM call. This replaces the old per-issue sequential loop
+    # that made N separate Ollama calls (one per issue).
+    _LANG_TAG = {
+        "java": "java", "python": "python", "go": "go", "rust": "rust",
+        "javascript": "javascript", "typescript": "typescript",
+        "c": "c", "cpp": "cpp", "kotlin": "kotlin",
+    }
+    lang_tag = _LANG_TAG.get((language or "").lower(), "")
+
+    # Build per-issue scopes and a union scope for the prompt.
+    all_scope: list[str] = []  # ordered, deduped union of scope files
+    _scope_set: set[str] = set()
+    _norm_pdir = os.path.normpath(project_dir)
+    issue_blocks: list[str] = []
+    skipped = 0
     for i, issue in enumerate(issues, 1):
         raw_scope = issue.get("suggested_fix_scope") or []
-        # Always include the issue's primary file even if scope didn't list it.
         if issue.get("file") and issue["file"] not in raw_scope:
             raw_scope = [issue["file"]] + raw_scope
-        # Normalize all paths to absolute, then keep only files inside project_dir.
         scope: list[str] = []
         for p in raw_scope:
             ap = _normalize_path(p)
-            if ap and ap.startswith(project_dir.rstrip("/")) and ap not in scope:
-                scope.append(ap)
+            if not ap:
+                continue
+            try:
+                if os.path.commonpath([_norm_pdir, os.path.normpath(ap)]) != _norm_pdir:
+                    continue
+            except ValueError:
+                continue
+            scope.append(ap)
+            if ap not in _scope_set:
+                _scope_set.add(ap)
+                all_scope.append(ap)
         if not scope:
             errors.append(f"Issue {i}: no in-scope files to edit "
                           f"(raw={raw_scope}, project_dir={project_dir}); skipping "
                           f"(severity={issue.get('severity','?')})")
+            skipped += 1
             continue
 
         await _step(f"issue {i}/{len(issues)}",
                     f"[{issue.get('severity','?')}] {issue.get('summary','')[:80]}")
 
-        # 2a. Read each scope file (cap at 5 to bound prompt size).
-        capped_scope = scope[:5]
-        files_section_lines = []
-        for path in capped_scope:
-            content = await _read_file_sandbox(http, path)
-            if content:
-                # Trim very long files so the prompt stays under context budget.
-                snippet = content[:8000]
-                if len(content) > 8000:
-                    snippet += f"\n\n... [truncated; full file is {len(content)} chars]"
-                files_section_lines.append(f"### {path}\n```\n{snippet}\n```")
-            else:
-                files_section_lines.append(f"### {path}\n(file is empty or unreadable)")
-
-        issue_block = "\n".join([
-            f"Severity: {issue.get('severity','?')}",
-            f"File: {issue.get('file','?')}"
-                + (f":{','.join(str(x) for x in issue.get('lines') or [])}" if issue.get('lines') else ""),
-            f"Summary: {issue.get('summary','')}",
-        ])
-
-        # Map our language guess to the typical markdown fence tag the model uses.
-        _LANG_TAG = {
-            "java": "java", "python": "python", "go": "go", "rust": "rust",
-            "javascript": "javascript", "typescript": "typescript",
-            "c": "c", "cpp": "cpp", "kotlin": "kotlin",
-        }
-        lang_tag = _LANG_TAG.get((language or "").lower(), "")
-
-        prompt = _FIXER_PROMPT.format(
-            project_dir=project_dir,
-            language=language or "(unknown)",
-            build_cmd=build_cmd or "(none)",
-            test_cmd=test_cmd or "(none)",
-            research_section=research_section,
-            issue_block=issue_block,
-            allowed_paths_list="\n".join(f"  - {p}" for p in capped_scope),
-            files_section="\n\n".join(files_section_lines),
-            lang_tag=lang_tag,
+        issue_blocks.append(
+            f"### Issue {i}\n"
+            f"- Severity: {issue.get('severity','?')}\n"
+            f"- File: {issue.get('file','?')}"
+            + (f":{','.join(str(x) for x in issue.get('lines') or [])}" if issue.get('lines') else "")
+            + f"\n- Summary: {issue.get('summary','')}\n"
+            f"- Fix scope: {', '.join(scope[:5])}"
         )
 
-        # 2b. Call coder model.
-        await _step(f"calling {fixer_model}", f"issue {i}/{len(issues)}")
-        text = ""
+    if not issue_blocks:
+        envelope = {"status": "no_op",
+                    "summary": "All issues had no in-scope files — nothing to fix",
+                    "issues_addressed": 0, "files_touched": [], "errors": errors[:10],
+                    "project_dir": project_dir, "language": language}
+        if run_id:
+            try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
+            except Exception: pass
+            cancel_registry.cleanup(run_id)
+        await events.emit(conv_id, "tool_end", {
+            "tool": "run_fixer", "icon": "wrench",
+            "status": f"🛠 No in-scope files — {len(errors)} error(s)",
+            "run_id": run_id,
+        })
+        return envelope
+
+    # Cap total scope files to keep prompt size bounded.
+    capped_scope = all_scope[:15]
+    _allowed_set = set(capped_scope)
+    if len(all_scope) > 15:
+        errors.append(f"Scope truncated from {len(all_scope)} to 15 files — "
+                      f"{len(all_scope) - 15} file(s) not shown to fixer")
+
+    issue_block = "\n\n".join(issue_blocks)
+
+    # Compute per-file character budget so the prompt fits the context window.
+    _fixer_ctx = config.DEFAULT_NUM_CTX or 16384
+    _char_budget = _fixer_ctx * 3
+    _overhead = len(issue_block) + len(research_section) + 2000
+    _file_budget = max(_char_budget - _overhead, 8000)
+    _per_file_cap = min(max(_file_budget // max(len(capped_scope), 1), 1000), 8000)
+    print(f"[FIXER] budget: num_ctx={_fixer_ctx}, files={len(capped_scope)}, "
+          f"per_file_cap={_per_file_cap}, file_budget={_file_budget}")
+
+    # 2a. Read all scope files in parallel.
+    await _step("reading", f"{len(capped_scope)} scope file(s)")
+    _read_tasks = [_read_file_sandbox(http, path) for path in capped_scope]
+    _read_results = await asyncio.gather(*_read_tasks, return_exceptions=True)
+
+    files_section_lines = []
+    for path, content in zip(capped_scope, _read_results):
+        if isinstance(content, str) and content:
+            snippet = content[:_per_file_cap]
+            if len(content) > _per_file_cap:
+                snippet += f"\n\n... [truncated; full file is {len(content)} chars]"
+            files_section_lines.append(f"### {path}\n```\n{snippet}\n```")
+        else:
+            files_section_lines.append(f"### {path}\n(file is empty or unreadable)")
+
+    prompt = _FIXER_PROMPT.format(
+        project_dir=project_dir,
+        language=language or "(unknown)",
+        build_cmd=build_cmd or "(none)",
+        test_cmd=test_cmd or "(none)",
+        research_section=research_section,
+        issue_block=issue_block,
+        allowed_paths_list="\n".join(f"  - {p}" for p in capped_scope),
+        files_section="\n\n".join(files_section_lines),
+        lang_tag=lang_tag,
+    )
+
+    # 2b. Single LLM call for all issues.
+    await _step(f"calling {fixer_model}", f"{len(issue_blocks)} issue(s) batched")
+    text = ""
+    try:
+        coro = http.post(
+            f"{config.OLLAMA_URL}/api/chat",
+            json={
+                "model": fixer_model,
+                "messages": [{"role": "user", "content": prompt}],
+                "stream": False,
+                "options": {"temperature": 0.2,
+                            "num_ctx": config.DEFAULT_NUM_CTX},
+            },
+            timeout=600,
+        )
+        r = await cancel_registry.await_cancellable(coro, run_id)
+        if r.status_code == 200:
+            text = (r.json().get("message", {}).get("content") or "").strip()
+        else:
+            errors.append(f"Model HTTP {r.status_code}")
+    except cancel_registry.RunCancelled:
+        cancelled_env = {
+            "status": "cancelled",
+            "summary": (f"Fixer cancelled by user during LLM call; "
+                        f"{len(files_touched)} file(s) already written before cancel."),
+            "issues_addressed": 0,
+            "files_touched": sorted(files_touched),
+            "diffs": diffs[:20],
+            "errors": errors[:10],
+            "fixer_model": fixer_model,
+            "project_dir": project_dir,
+            "language": language,
+            "reviewer_run_id": reviewer_run_id,
+            "research_used": bool(research_context),
+        }
         try:
-            coro = http.post(
-                f"{config.OLLAMA_URL}/api/chat",
-                json={
-                    "model": fixer_model,
-                    "messages": [{"role": "user", "content": prompt}],
-                    "stream": False,
-                    "options": {"temperature": 0.2,
-                                "num_ctx": config.DEFAULT_NUM_CTX},
-                },
-                timeout=600,
-            )
-            r = await cancel_registry.await_cancellable(coro, run_id)
-            if r.status_code == 200:
-                text = (r.json().get("message", {}).get("content") or "").strip()
-            else:
-                errors.append(f"Issue {i}: model HTTP {r.status_code}")
-                continue
-        except cancel_registry.RunCancelled:
-            # User pressed Stop mid-loop. Bail out of the issue loop and emit
-            # a cancelled envelope so the frontend run card flips to cancelled.
-            cancelled_env = {
-                "status": "cancelled",
-                "summary": (f"Fixer cancelled by user during issue {i}/{len(issues)}; "
-                            f"{len(files_touched)} file(s) already written before cancel."),
-                "issues_addressed": i - 1,
-                "files_touched": sorted(files_touched),
-                "diffs": diffs[:20],
-                "errors": errors[:10],
-                "fixer_model": fixer_model,
-                "project_dir": project_dir,
-                "language": language,
-                "reviewer_run_id": reviewer_run_id,
-                "research_used": bool(research_context),
-            }
+            await events.emit(conv_id, "tool_end", {
+                "tool": "run_fixer", "icon": "wrench",
+                "status": "⛔ Fixer cancelled by user",
+                "run_id": run_id,
+            })
+        except Exception:
+            pass
+        if run_id:
             try:
-                await events.emit(conv_id, "tool_end", {
-                    "tool": "run_fixer", "icon": "wrench",
-                    "status": "⛔ Fixer cancelled by user",
-                    "run_id": run_id,
-                })
+                await db.update_run(run_id, status="cancelled",
+                                    result_envelope=cancelled_env, ended=True)
             except Exception:
                 pass
-            if run_id:
-                try:
-                    await db.update_run(run_id, status="cancelled",
-                                        result_envelope=cancelled_env, ended=True)
-                except Exception:
-                    pass
-                cancel_registry.cleanup(run_id)
-            return cancelled_env
-        except Exception as e:
-            errors.append(f"Issue {i}: model call failed: {e}")
-            continue
+            cancel_registry.cleanup(run_id)
+        return cancelled_env
+    except Exception as e:
+        errors.append(f"Model call failed: {e}")
 
+    # 2c. Parse and apply edits.
+    if text:
         parsed = _parse_fixer_output(text)
         edits = parsed.get("edits") or []
         edit_summary = (parsed.get("summary") or "")[:140]
 
         if parsed.get("cannot_fix"):
-            errors.append(f"Issue {i}: fixer declined — {edit_summary}")
-            continue
-        if not edits:
-            # No EDIT markers found in the output. Surface a sample of what the
-            # model produced so we can debug — first 200 chars.
+            errors.append(f"Fixer declined — {edit_summary}")
+        elif not edits:
             sample = text[:200].replace("\n", " \\n ")
             errors.append(
-                f"Issue {i}: model output had no `### EDIT:` sections "
+                f"Model output had no `### EDIT:` sections "
                 f"({len(text)} chars). Sample: {sample!r}"
             )
-            continue
-
-        # 2c. Apply edits — but only if the path is in scope.
-        applied_this_issue = 0
-        for edit in edits[:10]:  # safety cap
-            path = (edit.get("path") or "").strip()
-            content = edit.get("content")
-            if not path or content is None:
-                continue
-            if path not in capped_scope:
-                errors.append(f"Issue {i}: model tried out-of-scope edit on {path} — refused")
-                continue
-            await _step("writing", path[len(project_dir) + 1:] if path.startswith(project_dir + "/") else path)
-            ok, err_detail = await _write_file_sandbox(http, path, content)
-            if ok:
-                files_touched.add(path)
-                diffs.append({"path": path, "summary": edit_summary or "(no summary)"})
-                applied_this_issue += 1
-            else:
-                errors.append(f"Issue {i}: write failed for {path} — {err_detail}")
-
-        if applied_this_issue == 0:
-            errors.append(f"Issue {i}: model proposed edits but none could be written")
+        else:
+            for edit in edits[:20]:  # safety cap
+                path = (edit.get("path") or "").strip()
+                content = edit.get("content")
+                if not path or content is None:
+                    continue
+                if path not in _allowed_set:
+                    errors.append(f"Model tried out-of-scope edit on {path} — refused")
+                    continue
+                rel = path[len(project_dir) + 1:] if path.startswith(project_dir + "/") else path
+                await _step("writing", rel)
+                ok, err_detail = await _write_file_sandbox(http, path, content)
+                if ok:
+                    files_touched.add(path)
+                    diffs.append({"path": path, "summary": edit_summary or "(no summary)"})
+                else:
+                    errors.append(f"Write failed for {path} — {err_detail}")
 
     # 3. Build envelope.
     if files_touched and not errors:
@@ -508,7 +557,7 @@ async def run_fixer(http, events, conv_id: str, *,
         "summary": (f"Applied edits to {len(files_touched)} file(s) across "
                     f"{len(issues)} issue(s)") if files_touched
                    else "No edits applied — see errors",
-        "issues_addressed": len(issues),
+        "issues_addressed": len(issues) - skipped,
         "files_touched": sorted(files_touched),
         "diffs": diffs[:20],
         "errors": errors[:10],

--- a/backend/agents/personas.py
+++ b/backend/agents/personas.py
@@ -160,6 +160,20 @@ If `run_review` is in your tool list and any of the above is true, calling `read
 - Task is a complete app: game, API, CLI tool, web app, library, service.
 - You'd otherwise need >3 write_file calls to finish.
 
+## deep_research — WHEN TO USE IT
+Web research saves cycles and prevents dead ends. Use it surgically — NOT before every tool call. Call `deep_research` (depth=2 for quick, depth=3 for hard problems) ONLY in these three situations:
+
+1. **Pre-build for unfamiliar tech.** Before `plan_project`/`generate_code`, if the user's task names a specific library, framework, SDK, or recent API you haven't worked with extensively (e.g. "use the new X SDK", "integrate with Y v2 API", "build with Z runtime"). ONE research call per project — not before every file edit. The model's training-cutoff knowledge of fast-moving libraries goes stale; verifying current usage saves an entire failed build cycle.
+
+2. **Stuck on the SAME error twice.** If `run_review` returns an issue you already attempted to fix (same file, same error class, after a `run_fixer` cycle), do NOT call `run_fixer` again immediately. The model has demonstrably failed to fix it from training knowledge alone — repeating will burn another cycle for the same result. Call `deep_research` with the exact error message + library/version, THEN call `run_fixer` again. The Fixer will see the research result in your conversation and use it.
+
+3. **Final cycle before the cap.** If you're about to make your 3rd `run_fixer` call (i.e. 2 fixer runs already succeeded but issues remain), call `deep_research` FIRST. After the 3rd fixer attempt the cap blocks further fixes — better to spend one round on research before the last shot than to give up with a broken project.
+
+Rules:
+- `depth=2` for quick lookups, `depth=3` for harder problems. Do NOT use 4–5 in the build loop — too slow.
+- Research is NOT a substitute for `run_review`. Reviewer tells you WHAT is broken; research tells you HOW to fix a specific kind of error.
+- Do NOT research EVERY error. Only when (a) it's pre-build for unfamiliar tech, (b) the model failed to fix it once already, or (c) it's the last fixer cycle. If reviewer issues are obvious lint/typo/syntax errors, skip research and go straight to `run_fixer`.
+
 ## RULES
 1. First response = tool call. Always.
 2. NEVER show code in chat text. Use write_file or execute_code.

--- a/backend/agents/personas.py
+++ b/backend/agents/personas.py
@@ -122,9 +122,9 @@ async def seed_coder_bot_v2():
     """
     all_configs = await db.get_model_configs()
     existing = next((c for c in all_configs if (c.get("name") or "").strip() == "💻 Coder Bot v2"), None)
-    if existing:
-        await db.delete_model_config(existing["id"])
-    mc_id = f"mc-{uuid.uuid4().hex[:12]}"
+    # Preserve mc_id when re-seeding so existing conversations linked to this
+    # persona keep working. Only generate a fresh id for first-time seeds.
+    mc_id = existing["id"] if existing else f"mc-{uuid.uuid4().hex[:12]}"
     system_prompt = """You are HyprCoder v2 — a senior software engineer AI with full sandbox access. You build, test, debug, and deliver working software via a tightly-scoped agentic workflow.
 
 ## PRIME DIRECTIVE: ACT, DON'T TALK
@@ -182,12 +182,18 @@ When an ACTIVE PROJECT is present:
 1. **For questions about the project** ("how does X work?", "where is Y?", "what does Z do?"): call `ask_project(question='...')`. The ProjectQA agent greps the tree for relevant code, reads the matching files, and produces a grounded answer with file:line citations — in ONE tool call instead of 5+ rounds of read_file+search_files. If the question is actually a change request, ask_project will flag that and you should follow up with `generate_code` or `write_file` accordingly.
 2. **For modifications / new features:**
    - Small change (1–3 files): read_file → write_file → `run_review` to confirm nothing broke.
-   - Large refactor or many new files: call generate_code with the SAME project_id, then `run_review`.
-3. **For bug reports:** call `run_review` first — it runs the build/tests and tells you exactly what's broken with file:line references. If issues are returned, call `run_fixer(reviewer_run_id='...')` to apply targeted fixes, then `run_review` again to verify.
+   - Large refactor or many new files (genuinely 3+ NEW files): call generate_code with the SAME project_id, then `run_review`.
+3. **For bug reports — pick the right path:**
+   - **Build/compile/lint errors** ("X won't compile", "import error", "syntax error"): call `run_review` first. It runs the project's real build/test/lint and returns structured issues with file:line and fix-scope. If issues come back, call `run_fixer(reviewer_run_id='...')` then `run_review` again.
+   - **Runtime bugs that compile fine** ("crashes when I click", "preview doesn't update", "QFont: invalid description", "button does nothing", "wrong output"): the reviewer canNOT see these — `py_compile`/`pip install`/`pytest` all pass while the bug is still there. For these, READ the relevant 1–3 files, then WRITE_FILE the surgical fix, then run_review to confirm nothing else broke. **Do NOT call generate_code for runtime bugs** — re-running the OpenHands feature-builder for a 2-line fix is 60–90s of wasted work that almost always produces a worse result than a targeted edit. The anti-rebuild gate will block a 2nd generate_code in the same turn anyway.
+   - **User gives you a specific fix list** ("error X, also do Y, also add Z"): treat each item independently. Small additions and runtime fixes → write_file. Only escalate to generate_code if the list genuinely requires 3+ new files.
 4. **Install missing deps** with pip3/npm/cargo/etc. before running if a fresh requirements file appeared.
 5. **Deliver updates** with `download_file` for single files or `download_project` for the tree.
 
 Do NOT start a fresh project from scratch when an ACTIVE PROJECT block is present — work on THAT code.
+
+## ANTI-REBUILD RULE (READ THIS)
+Once `generate_code` has succeeded for a project this turn, do NOT call it again in the same turn. The OpenHands feature-builder is for substantial NEW functionality (3+ new files / major refactor), not iterative refinement. If the result has bugs, fix them with read_file → write_file → run_review. If the result is genuinely wrong end-to-end, stop and ask the user — don't silently rebuild. The server enforces this with a hard gate; ignoring it just costs you a round.
 
 This works for ANY language — Python, Java, Rust, Go, JS/TS, C/C++, Ruby, PHP, Kotlin, Swift, Scala, etc. The diagnose-via-run_review → fix → re-review loop is the same; only the build/test commands differ (Reviewer auto-detects them)."""
 
@@ -223,13 +229,23 @@ This works for ANY language — Python, Java, Rust, Go, JS/TS, C/C++, Ruby, PHP,
     except Exception:
         pass
 
-    await db.create_model_config(
-        mc_id, "💻 Coder Bot v2", overseer_model,
-        system_prompt,
-        ["codeagent", "deep_research", "research"],
-        coder_kb_ids,
-        parameters
-    )
+    if existing:
+        await db.update_model_config(
+            mc_id,
+            base_model=overseer_model,
+            system_prompt=system_prompt,
+            tool_ids=["codeagent", "deep_research", "research"],
+            kb_ids=coder_kb_ids,
+            parameters=parameters,
+        )
+    else:
+        await db.create_model_config(
+            mc_id, "💻 Coder Bot v2", overseer_model,
+            system_prompt,
+            ["codeagent", "deep_research", "research"],
+            coder_kb_ids,
+            parameters
+        )
 
     return {"id": mc_id, "name": "💻 Coder Bot v2",
             "existed": existing is not None, "kb_ids": coder_kb_ids}

--- a/backend/agents/project_indexer.py
+++ b/backend/agents/project_indexer.py
@@ -21,6 +21,7 @@ Stateless. Single-shot. Does NOT modify the project. Does NOT call any LLM
 
 from __future__ import annotations
 
+import asyncio
 import shlex
 import uuid
 
@@ -222,15 +223,29 @@ async def run_project_indexer(http, events, conv_id: str, *,
 
     await _step("found_files", f"{len(paths)} source file(s) (capped at {file_cap})")
 
-    # 3. Read each file. We could batch-read via tar-stream but for ~100 small
-    # files the per-file `cat` is fine and keeps the code simple.
+    # 3. Read files in parallel batches (10 concurrent to avoid flooding Codebox).
+    _READ_CONCURRENCY = 10
+    _sema = asyncio.Semaphore(_READ_CONCURRENCY)
     file_contents: dict[str, str] = {}
-    for i, rel in enumerate(paths):
-        if i % 10 == 0 and i > 0:
-            await _step("reading", f"{i}/{len(paths)}")
-        body = await _read_file(http, project_dir, rel)
-        if body and len(body.strip()) >= 20:
-            file_contents[rel] = body
+
+    async def _read_one(rel: str) -> tuple[str, str]:
+        async with _sema:
+            body = await _read_file(http, project_dir, rel)
+            return rel, body
+
+    for batch_start in range(0, len(paths), _READ_CONCURRENCY):
+        batch = paths[batch_start:batch_start + _READ_CONCURRENCY]
+        if batch_start > 0:
+            await _step("reading", f"{batch_start}/{len(paths)}")
+        results = await asyncio.gather(
+            *[_read_one(rel) for rel in batch],
+            return_exceptions=True,
+        )
+        for res in results:
+            if isinstance(res, tuple):
+                rel, body = res
+                if body and len(body.strip()) >= 20:
+                    file_contents[rel] = body
     await _step("read_done", f"{len(file_contents)} file(s) with substantive content")
 
     if not file_contents:

--- a/backend/agents/project_qa.py
+++ b/backend/agents/project_qa.py
@@ -19,12 +19,14 @@ row with role='qa' for the same durability story as builder/reviewer/fixer.
 
 from __future__ import annotations
 
+import asyncio
 import re
 import shlex
 import uuid
 
 import config
 import database as db
+import cancel_registry
 
 
 # Common English "stopwords" that aren't useful as grep targets. Keep small —
@@ -379,6 +381,9 @@ async def run_project_qa(http, events, conv_id: str, *,
         print(f"[QA] create_run failed (non-fatal): {e}")
         run_id = ""
 
+    if run_id:
+        cancel_registry.register(run_id)
+
     _step_n = [0]
 
     async def _step(action: str, detail: str = ""):
@@ -397,212 +402,232 @@ async def run_project_qa(http, events, conv_id: str, *,
             except Exception:
                 pass
 
-    if not question:
-        envelope = {"status": "error", "summary": "ask_project requires a question",
-                    "answer": "", "files_examined": [],
-                    "looks_like_change_request": False}
-        if run_id:
-            try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
-            except Exception: pass
-        return envelope
+    try:  # try/finally ensures cancel_registry.cleanup on every exit path
 
-    if not project_dir:
-        envelope = {"status": "error",
-                    "summary": "ask_project requires project_dir; pass it explicitly or run after a builder run",
-                    "answer": "", "files_examined": [],
-                    "looks_like_change_request": False}
-        if run_id:
-            try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
-            except Exception: pass
-        return envelope
+        if not question:
+            envelope = {"status": "error", "summary": "ask_project requires a question",
+                        "answer": "", "files_examined": [],
+                        "looks_like_change_request": False}
+            if run_id:
+                try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
+                except Exception: pass
+            return envelope
 
-    await _step("question", question[:140])
+        if not project_dir:
+            envelope = {"status": "error",
+                        "summary": "ask_project requires project_dir; pass it explicitly or run after a builder run",
+                        "answer": "", "files_examined": [],
+                        "looks_like_change_request": False}
+            if run_id:
+                try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
+                except Exception: pass
+            return envelope
 
-    # Phase 1: orient with a file listing.
-    await _step("list_files", project_dir)
-    file_list = await _list_files(http, project_dir)
-    if not file_list:
+        await _step("question", question[:140])
+
+        # Phase 1: orient with a file listing.
+        await _step("list_files", project_dir)
+        file_list = await _list_files(http, project_dir)
+        if not file_list:
+            envelope = {
+                "status": "error",
+                "summary": f"Could not list files at {project_dir} (does the project exist?)",
+                "answer": f"I couldn't read the project at `{project_dir}`. The directory may not exist or be empty.",
+                "files_examined": [],
+                "looks_like_change_request": False,
+            }
+            await events.emit(conv_id, "tool_end", {
+                "tool": "ask_project", "icon": "help-circle",
+                "status": f"⚠ Project not accessible at {project_dir}",
+                "run_id": run_id,
+            })
+            if run_id:
+                try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
+                except Exception: pass
+            return envelope
+
+        snippet_blocks: list[str] = []
+        files_examined: list[str] = []
+
+        # Phase 2a — filename targeting.
+        targets = _extract_filename_targets(question)
+        target_paths: list[str] = []
+        if targets:
+            await _step("filename_targets", ", ".join(targets[:5]))
+            target_paths = await _resolve_filename_targets(file_list, targets)
+            if target_paths:
+                await _step("matched_files", f"{len(target_paths)} file(s): " + ", ".join(p.rsplit('/', 1)[-1] for p in target_paths))
+                for path in target_paths:
+                    full = await _read_file_full(http, project_dir, path)
+                    if full:
+                        snippet_blocks.append(
+                            f"### `{path}` (full contents — user asked for this file)\n"
+                            f"```\n{full[:12000]}\n```"
+                            + (f"\n[truncated; full file is {len(full)} chars]" if len(full) > 12000 else "")
+                        )
+                        files_examined.append(path)
+            else:
+                await _step("no_match", f"no files in tree match: {targets[:3]}")
+
+        # Phase 2b — keyword grep.
+        keywords = _extract_keywords(question)
+        await _step("keywords", ", ".join(keywords) if keywords else "(none — using head-of-file fallback)")
+        hits = await _grep_for_keywords(http, project_dir, keywords) if keywords else []
+        await _step("grep", f"{len(hits)} hit(s) across the tree")
+
+        # Phase 3: pick top grep-files by hit-count, read short snippets.
+        file_to_hits: dict[str, list[dict]] = {}
+        for h in hits:
+            if h["file"] in target_paths:
+                continue
+            file_to_hits.setdefault(h["file"], []).append(h)
+        ranked_files = sorted(
+            file_to_hits.items(),
+            key=lambda kv: (-len(kv[1]), min(h["line"] for h in kv[1])),
+        )
+        if not ranked_files and not target_paths:
+            await _step("fallback", "no grep hits; reading entry-point candidates")
+            candidates = []
+            for path in file_list:
+                base = path.rsplit("/", 1)[-1].lower()
+                if base in ("main.rs", "main.py", "main.go", "main.java",
+                            "index.js", "index.ts", "index.html",
+                            "lib.rs", "mod.rs", "app.py", "server.py"):
+                    candidates.append(path)
+                elif base.startswith("readme."):
+                    candidates.append(path)
+                if len(candidates) >= 4:
+                    break
+            _fb_tasks = [
+                _read_snippet(http, project_dir, p, line=0, radius=20)
+                for p in candidates[:4]
+            ]
+            _fb_results = await asyncio.gather(*_fb_tasks, return_exceptions=True)
+            for path, snip in zip(candidates[:4], _fb_results):
+                if isinstance(snip, str) and snip:
+                    snippet_blocks.append(f"### `{path}` (head)\n```\n{snip[:1800]}\n```")
+                    files_examined.append(path)
+        else:
+            _ranked_paths = [(p, fh[0]["line"], len(fh)) for p, fh in ranked_files[:5]]
+            _gr_tasks = [
+                _read_snippet(http, project_dir, p, line=anchor, radius=15)
+                for p, anchor, _ in _ranked_paths
+            ]
+            _gr_results = await asyncio.gather(*_gr_tasks, return_exceptions=True)
+            for (path, anchor, n_hits), snip in zip(_ranked_paths, _gr_results):
+                if isinstance(snip, str) and snip:
+                    snippet_blocks.append(
+                        f"### `{path}` (around line {anchor}; "
+                        f"{n_hits} hit{'s' if n_hits != 1 else ''})\n```\n{snip[:1800]}\n```"
+                    )
+                    files_examined.append(path)
+        snippets_section = "\n\n".join(snippet_blocks) if snippet_blocks else "(no snippets retrieved)"
+        await _step("snippets", f"{len(files_examined)} file(s) inspected")
+
+        # Phase 4: ask LLM to compose grounded answer.
+        qa_model = (config.QA_MODEL or conv_model or config.DEFAULT_MODEL or config.PLANNING_MODEL or "").strip()
+        if not qa_model:
+            envelope = {"status": "error",
+                        "summary": "No model configured for ProjectQA",
+                        "answer": "", "files_examined": files_examined,
+                        "looks_like_change_request": _is_change_request(question)}
+            if run_id:
+                try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
+                except Exception: pass
+            return envelope
+
+        tree_text = "\n".join(file_list[:80])
+        if len(file_list) > 80:
+            tree_text += f"\n... ({len(file_list) - 80} more files)"
+
+        prompt = _QA_PROMPT.format(
+            project_dir=project_dir,
+            language=language or "(unknown)",
+            file_tree=tree_text,
+            question=question,
+            snippets_section=snippets_section,
+        )
+
+        await _step("compose", f"calling {qa_model}")
+        answer = ""
+        try:
+            coro = http.post(
+                f"{config.OLLAMA_URL}/api/chat",
+                json={
+                    "model": qa_model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "stream": False,
+                    "options": {"temperature": 0.3, "num_ctx": config.DEFAULT_NUM_CTX},
+                },
+                timeout=600,
+            )
+            r = await cancel_registry.await_cancellable(coro, run_id)
+            if r.status_code == 200:
+                answer = (r.json().get("message", {}).get("content") or "").strip()
+            else:
+                answer = f"(LLM call failed: HTTP {r.status_code})"
+        except cancel_registry.RunCancelled:
+            cancelled_env = {
+                "status": "cancelled",
+                "summary": "ProjectQA cancelled by user (Stop pressed) during LLM call.",
+                "answer": "",
+                "files_examined": files_examined,
+                "looks_like_change_request": False,
+                "qa_model": qa_model,
+                "project_dir": project_dir,
+                "language": language,
+            }
+            try:
+                await events.emit(conv_id, "tool_end", {
+                    "tool": "ask_project", "icon": "help-circle",
+                    "status": "⛔ ProjectQA cancelled by user",
+                    "run_id": run_id,
+                })
+            except Exception:
+                pass
+            if run_id:
+                try:
+                    await db.update_run(run_id, status="cancelled",
+                                        result_envelope=cancelled_env, ended=True)
+                except Exception:
+                    pass
+            return cancelled_env
+        except Exception as e:
+            answer = f"(LLM call failed: {type(e).__name__}: {e})"
+
+        looks_like_change = _is_change_request(question)
         envelope = {
-            "status": "error",
-            "summary": f"Could not list files at {project_dir} (does the project exist?)",
-            "answer": f"I couldn't read the project at `{project_dir}`. The directory may not exist or be empty.",
-            "files_examined": [],
-            "looks_like_change_request": False,
+            "status": "ok" if answer and not answer.startswith("(LLM call failed") else "error",
+            "summary": (f"Answered question by examining {len(files_examined)} file(s)"
+                        if answer else "Failed to compose answer"),
+            "answer": answer,
+            "files_examined": files_examined,
+            "keywords": keywords,
+            "grep_hits": len(hits),
+            "looks_like_change_request": looks_like_change,
+            "qa_model": qa_model,
+            "project_dir": project_dir,
+            "language": language,
         }
+
         await events.emit(conv_id, "tool_end", {
             "tool": "ask_project", "icon": "help-circle",
-            "status": f"⚠ Project not accessible at {project_dir}",
+            "status": (f"❓ Answered using {len(files_examined)} file(s)"
+                       + (" — looks like a change request" if looks_like_change else "")),
             "run_id": run_id,
         })
         if run_id:
-            try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
-            except Exception: pass
-        return envelope
-
-    snippet_blocks: list[str] = []
-    files_examined: list[str] = []
-
-    # Phase 2a — filename targeting. If the user mentioned specific files
-    # ("score tracker.java", "ScoreTracker.java", "Ball.rs", etc.), find
-    # them in the project tree and read their FULL contents. This handles
-    # the "break down X line by line" / "show me Y" class of questions
-    # where keyword grep would miss the actual file.
-    targets = _extract_filename_targets(question)
-    target_paths: list[str] = []
-    if targets:
-        await _step("filename_targets", ", ".join(targets[:5]))
-        target_paths = await _resolve_filename_targets(file_list, targets)
-        if target_paths:
-            await _step("matched_files", f"{len(target_paths)} file(s): " + ", ".join(p.rsplit('/', 1)[-1] for p in target_paths))
-            for path in target_paths:
-                # For targeted reads, use a generous limit so the model can
-                # walk the user through the whole file. ~12KB ≈ 300 lines of
-                # typical source — enough for almost any single-class file
-                # without blowing the prompt budget.
-                full = await _read_file_full(http, project_dir, path)
-                if full:
-                    snippet_blocks.append(
-                        f"### `{path}` (full contents — user asked for this file)\n"
-                        f"```\n{full[:12000]}\n```"
-                        + (f"\n[truncated; full file is {len(full)} chars]" if len(full) > 12000 else "")
-                    )
-                    files_examined.append(path)
-        else:
-            await _step("no_match", f"no files in tree match: {targets[:3]}")
-
-    # Phase 2b — keyword grep (still useful even when targets matched, so
-    # the model has cross-references for cited symbols).
-    keywords = _extract_keywords(question)
-    await _step("keywords", ", ".join(keywords) if keywords else "(none — using head-of-file fallback)")
-    hits = await _grep_for_keywords(http, project_dir, keywords) if keywords else []
-    await _step("grep", f"{len(hits)} hit(s) across the tree")
-
-    # Phase 3: pick top grep-files by hit-count, read short snippets around
-    # each anchor. Skip files we already loaded in Phase 2a — no need to
-    # double-include.
-    file_to_hits: dict[str, list[dict]] = {}
-    for h in hits:
-        if h["file"] in target_paths:
-            continue
-        file_to_hits.setdefault(h["file"], []).append(h)
-    ranked_files = sorted(
-        file_to_hits.items(),
-        key=lambda kv: (-len(kv[1]), min(h["line"] for h in kv[1])),
-    )
-    if not ranked_files and not target_paths:
-        # No grep hits AND no filename matches — fall back to reading the
-        # head of likely entry-point files so the model has *something* to
-        # ground in.
-        await _step("fallback", "no grep hits; reading entry-point candidates")
-        candidates = []
-        for path in file_list:
-            base = path.rsplit("/", 1)[-1].lower()
-            if base in ("main.rs", "main.py", "main.go", "main.java",
-                        "index.js", "index.ts", "index.html",
-                        "lib.rs", "mod.rs", "app.py", "server.py"):
-                candidates.append(path)
-            elif base.startswith("readme."):
-                candidates.append(path)
-            if len(candidates) >= 4:
-                break
-        for path in candidates[:4]:
-            snip = await _read_snippet(http, project_dir, path, line=0, radius=20)
-            if snip:
-                snippet_blocks.append(f"### `{path}` (head)\n```\n{snip[:1800]}\n```")
-                files_examined.append(path)
-    else:
-        for path, file_hits in ranked_files[:5]:
-            anchor = file_hits[0]["line"]
-            snip = await _read_snippet(http, project_dir, path, line=anchor, radius=15)
-            if snip:
-                snippet_blocks.append(
-                    f"### `{path}` (around line {anchor}; "
-                    f"{len(file_hits)} hit{'s' if len(file_hits) != 1 else ''})\n```\n{snip[:1800]}\n```"
+            try:
+                await db.update_run(
+                    run_id,
+                    status="succeeded" if envelope["status"] == "ok" else "failed",
+                    result_envelope=envelope, ended=True,
                 )
-                files_examined.append(path)
-    snippets_section = "\n\n".join(snippet_blocks) if snippet_blocks else "(no snippets retrieved)"
-    await _step("snippets", f"{len(files_examined)} file(s) inspected")
+            except Exception as e:
+                print(f"[QA] update_run failed (non-fatal): {e}")
 
-    # Phase 4: ask LLM to compose grounded answer.
-    # Prefer the chat's current model (persona's pinned model or user's
-    # chat-dropdown choice) so the QA voice matches the assistant the user is
-    # actually talking to. Fall back to settings only if the chat didn't pass
-    # one through.
-    # Per-agent override (config.QA_MODEL) wins if explicitly pinned; else
-    # respect the chat/persona model, then settings defaults.
-    qa_model = (config.QA_MODEL or conv_model or config.DEFAULT_MODEL or config.PLANNING_MODEL or "").strip()
-    if not qa_model:
-        envelope = {"status": "error",
-                    "summary": "No model configured for ProjectQA",
-                    "answer": "", "files_examined": files_examined,
-                    "looks_like_change_request": _is_change_request(question)}
-        if run_id:
-            try: await db.update_run(run_id, status="failed", result_envelope=envelope, ended=True)
-            except Exception: pass
         return envelope
 
-    # Build a compact file tree summary (just paths, not full content).
-    tree_text = "\n".join(file_list[:80])
-    if len(file_list) > 80:
-        tree_text += f"\n... ({len(file_list) - 80} more files)"
-
-    prompt = _QA_PROMPT.format(
-        project_dir=project_dir,
-        language=language or "(unknown)",
-        file_tree=tree_text,
-        question=question,
-        snippets_section=snippets_section,
-    )
-
-    await _step("compose", f"calling {qa_model}")
-    answer = ""
-    try:
-        r = await http.post(
-            f"{config.OLLAMA_URL}/api/chat",
-            json={
-                "model": qa_model,
-                "messages": [{"role": "user", "content": prompt}],
-                "stream": False,
-                "options": {"temperature": 0.3, "num_ctx": config.DEFAULT_NUM_CTX},
-            },
-            timeout=600,
-        )
-        if r.status_code == 200:
-            answer = (r.json().get("message", {}).get("content") or "").strip()
-        else:
-            answer = f"(LLM call failed: HTTP {r.status_code})"
-    except Exception as e:
-        answer = f"(LLM call failed: {type(e).__name__}: {e})"
-
-    looks_like_change = _is_change_request(question)
-    envelope = {
-        "status": "ok" if answer and not answer.startswith("(LLM call failed") else "error",
-        "summary": (f"Answered question by examining {len(files_examined)} file(s)"
-                    if answer else "Failed to compose answer"),
-        "answer": answer,
-        "files_examined": files_examined,
-        "keywords": keywords,
-        "grep_hits": len(hits),
-        "looks_like_change_request": looks_like_change,
-        "qa_model": qa_model,
-        "project_dir": project_dir,
-        "language": language,
-    }
-
-    await events.emit(conv_id, "tool_end", {
-        "tool": "ask_project", "icon": "help-circle",
-        "status": (f"❓ Answered using {len(files_examined)} file(s)"
-                   + (" — looks like a change request" if looks_like_change else "")),
-        "run_id": run_id,
-    })
-    if run_id:
-        try:
-            await db.update_run(
-                run_id,
-                status="succeeded" if envelope["status"] == "ok" else "failed",
-                result_envelope=envelope, ended=True,
-            )
-        except Exception as e:
-            print(f"[QA] update_run failed (non-fatal): {e}")
-
-    return envelope
+    finally:
+        if run_id:
+            cancel_registry.cleanup(run_id)

--- a/backend/agents/project_qa.py
+++ b/backend/agents/project_qa.py
@@ -528,7 +528,9 @@ async def run_project_qa(http, events, conv_id: str, *,
     # chat-dropdown choice) so the QA voice matches the assistant the user is
     # actually talking to. Fall back to settings only if the chat didn't pass
     # one through.
-    qa_model = (conv_model or config.DEFAULT_MODEL or config.PLANNING_MODEL or "").strip()
+    # Per-agent override (config.QA_MODEL) wins if explicitly pinned; else
+    # respect the chat/persona model, then settings defaults.
+    qa_model = (config.QA_MODEL or conv_model or config.DEFAULT_MODEL or config.PLANNING_MODEL or "").strip()
     if not qa_model:
         envelope = {"status": "error",
                     "summary": "No model configured for ProjectQA",

--- a/backend/agents/reviewer.py
+++ b/backend/agents/reviewer.py
@@ -344,7 +344,8 @@ def _try_parse_review_json(text: str) -> dict | None:
 
 
 async def run_review(http, events, conv_id: str, project_dir: str,
-                     project_id: str = "", parent_run_id: str = "") -> dict:
+                     project_id: str = "", parent_run_id: str = "",
+                     conv_model: str = "") -> dict:
     """Execute a Reviewer run on a project. Returns the result envelope.
 
     Side effects:
@@ -491,7 +492,7 @@ async def run_review(http, events, conv_id: str, project_dir: str,
         return envelope
 
     # 5. Slow path: feed everything to the planning-model LLM and parse JSON.
-    review_model = config.PLANNING_MODEL or config.DEFAULT_MODEL
+    review_model = config.CODER_MODEL or conv_model or config.DEFAULT_MODEL
     prompt = _REVIEW_PROMPT.format(
         build_cmd=build_cmd or "(none)",
         build_exit=build_result["exit_code"],

--- a/backend/agents/reviewer.py
+++ b/backend/agents/reviewer.py
@@ -344,7 +344,8 @@ def _try_parse_review_json(text: str) -> dict | None:
 
 
 async def run_review(http, events, conv_id: str, project_dir: str,
-                     project_id: str = "", parent_run_id: str = "") -> dict:
+                     project_id: str = "", parent_run_id: str = "",
+                     conv_model: str = "") -> dict:
     """Execute a Reviewer run on a project. Returns the result envelope.
 
     Side effects:
@@ -491,7 +492,7 @@ async def run_review(http, events, conv_id: str, project_dir: str,
         return envelope
 
     # 5. Slow path: feed everything to the planning-model LLM and parse JSON.
-    review_model = config.PLANNING_MODEL or config.DEFAULT_MODEL
+    review_model = config.PLANNING_MODEL or conv_model or config.DEFAULT_MODEL
     prompt = _REVIEW_PROMPT.format(
         build_cmd=build_cmd or "(none)",
         build_exit=build_result["exit_code"],

--- a/backend/agents/reviewer.py
+++ b/backend/agents/reviewer.py
@@ -24,7 +24,44 @@ import uuid
 
 import config
 import database as db
+import cancel_registry
 
+
+# Pin the venv python that Codebox provisions — same binary `run_tests` uses
+# (tools.py:2009). Using bare `python3` here meant pip install -e . hit Arch's
+# externally-managed system Python (silently failed under `|| true`) and the
+# pytest run that followed had no project deps installed → ImportError → the
+# `|| echo` chain swallowed it → exit 0 → reviewer reported "clean" while the
+# project was actually broken.
+_VENV_PY = "/root/venv/bin/python3"
+
+# Python test command that:
+#   - Uses the venv python so installed deps are visible
+#   - Distinguishes pytest exit 5 (no tests collected) from 1/3/4 (real
+#     failures) — only exit 5 is converted to success-with-note. All other
+#     non-zero exits propagate so the reviewer can flag them.
+#   - Falls back to unittest discover ONLY when pytest itself isn't installed
+#     in the venv. Previously the chain treated "tests failed" the same as
+#     "pytest missing" and quietly succeeded.
+#   - Lets stderr through (no `2>/dev/null`) so the LLM analysis path sees
+#     real diagnostics. The reviewer combines stdout+stderr at the Codebox
+#     wrapper level via `2>&1` already.
+_PY_TEST_CMD = (
+    f"if {_VENV_PY} -c 'import pytest' 2>/dev/null; then "
+    f"{_VENV_PY} -m pytest -q --no-header; ec=$?; "
+    "if [ $ec -eq 5 ]; then echo '(no tests collected)'; exit 0; fi; "
+    "exit $ec; "
+    f"else {_VENV_PY} -m unittest discover -q; fi"
+)
+
+# Lint = a syntax sweep using the venv python (system python may not match
+# project syntax level, e.g. PEP 695 generics on python 3.12+). Kept separate
+# from build_cmd so its exit code surfaces as `lint_exit` in the envelope.
+_PY_LINT_CMD = (
+    f"{_VENV_PY} -m py_compile "
+    "$(find . -name '*.py' -not -path '*/venv/*' -not -path '*/.venv/*' "
+    "-not -path '*/.git/*' -not -path '*/__pycache__/*')"
+)
 
 # Project-marker → (build_cmd, test_cmd, lint_cmd, language).
 # Order matters: more-specific markers first so monorepos hit the right one.
@@ -39,18 +76,19 @@ _PROJECT_MARKERS = [
     ("go.mod",          "go build ./...",                  "go test ./...",          "go vet ./...",       "go"),
     ("package.json",    "npm install --silent && npm run build --if-present",
                                                             "npm test --if-present",  "",                   "javascript"),
-    # Tail `|| echo '(no tests)'` matches the plain-python profile below: pytest
-    # exits 5 when no tests are collected, and unittest discover can also exit
-    # non-zero on empty trees. Without the echo, a greenfield scaffold with no
-    # tests yet looks like a "test failure" → reviewer flags it → fixer can't
-    # conjure tests → infinite review/fix loop.
-    ("pyproject.toml",  "python3 -m pip install -q -e . 2>/dev/null || true",
-                                                            "python3 -m pytest -q --no-header 2>/dev/null || python3 -m unittest discover -q 2>/dev/null || echo '(no tests)'",
-                                                                                      "python3 -m py_compile $(find . -name '*.py' -not -path '*/venv/*')",
+    # Python markers: install deps into the venv that codebox provisions, then
+    # run pytest with proper exit-code discrimination (see _PY_TEST_CMD above).
+    # Pip's exit code is NOT swallowed — if install fails (missing pkg, syntax
+    # error in setup.py, etc.) the reviewer flags it as a build issue. That's
+    # the right behavior; previously `|| true` meant a broken pip step looked
+    # the same as a successful one.
+    ("pyproject.toml",  f"{_VENV_PY} -m pip install -q -e .",
+                                                            _PY_TEST_CMD,
+                                                                                      _PY_LINT_CMD,
                                                                                                             "python"),
-    ("requirements.txt","python3 -m pip install -q -r requirements.txt 2>/dev/null || true",
-                                                            "python3 -m pytest -q --no-header 2>/dev/null || python3 -m unittest discover -q 2>/dev/null || echo '(no tests)'",
-                                                                                      "python3 -m py_compile $(find . -name '*.py' -not -path '*/venv/*')",
+    ("requirements.txt",f"{_VENV_PY} -m pip install -q -r requirements.txt",
+                                                            _PY_TEST_CMD,
+                                                                                      _PY_LINT_CMD,
                                                                                                             "python"),
     ("Makefile",        "make -s 2>&1 | head -200",         "make -s test 2>&1 | head -200", "",            ""),
     ("CMakeLists.txt",  "cmake -B build -S . && cmake --build build --quiet",
@@ -77,8 +115,14 @@ _PLAIN_LANG_PROFILES = {
                         "| sed 's|^\\./||;s|\\.class$||;s|/|.|g')) || echo '(no JUnit tests)'",
                "lint":  ""},
     "python": {"glob": "*.py",
-               "build": "python3 -m py_compile $(find . -name '*.py' -not -path '*/venv/*' -not -path '*/.git/*' -not -path '*/__pycache__/*')",
-               "test":  "python3 -m pytest -q 2>/dev/null || python3 -m unittest discover -q 2>/dev/null || echo '(no tests)'",
+               # Plain-source python: no pyproject/requirements means no
+               # `pip install` step; we just sweep with py_compile to catch
+               # syntax errors. Use the venv python so 3.12+ syntax (PEP 695,
+               # type alias) doesn't fail on a system 3.11. Same exit-code
+               # discrimination as the marker-driven path above so a
+               # greenfield "no tests" project doesn't look like a failure.
+               "build": _PY_LINT_CMD,
+               "test":  _PY_TEST_CMD,
                "lint":  ""},
     "go":     {"glob": "*.go",
                "build": "go build ./... 2>&1 || (find . -name '*.go' -exec gofmt -l {} \\;)",
@@ -368,6 +412,11 @@ async def run_review(http, events, conv_id: str, project_dir: str,
         print(f"[REVIEWER] create_run failed (non-fatal): {e}")
         run_id = ""
 
+    # Register cancel event so POST /api/runs/{id}/cancel can abort the
+    # in-flight Codebox + Ollama work. Cleaned up at the end of this run.
+    if run_id:
+        cancel_registry.register(run_id)
+
     async def _step(action: str, detail: str = ""):
         """Emit one structured step on both the live SSE channel and the durable log."""
         await events.emit(conv_id, "tool_progress", {
@@ -432,6 +481,7 @@ async def run_review(http, events, conv_id: str, project_dir: str,
                                     result_envelope=envelope, ended=True)
             except Exception:
                 pass
+            cancel_registry.cleanup(run_id)
         return envelope
 
     # 2. Run build / test / lint.
@@ -494,6 +544,7 @@ async def run_review(http, events, conv_id: str, project_dir: str,
                                     result_envelope=envelope, ended=True)
             except Exception:
                 pass
+            cancel_registry.cleanup(run_id)
         return envelope
 
     # 5. Slow path: feed everything to the planning-model LLM and parse JSON.
@@ -517,7 +568,7 @@ async def run_review(http, events, conv_id: str, project_dir: str,
     await _step("analyze", f"calling {review_model}")
     review_text = ""
     try:
-        r = await http.post(
+        coro = http.post(
             f"{config.OLLAMA_URL}/api/chat",
             json={
                 "model": review_model,
@@ -527,8 +578,39 @@ async def run_review(http, events, conv_id: str, project_dir: str,
             },
             timeout=600,
         )
+        r = await cancel_registry.await_cancellable(coro, run_id)
         if r.status_code == 200:
             review_text = (r.json().get("message", {}).get("content") or "").strip()
+    except cancel_registry.RunCancelled:
+        cancelled_env = {
+            "status": "cancelled",
+            "summary": "Reviewer cancelled by user (Stop pressed) during analysis call.",
+            "issues": [],
+            "build_cmd": build_cmd, "test_cmd": test_cmd, "lint_cmd": lint_cmd,
+            "build_exit": build_result["exit_code"],
+            "test_exit": test_result["exit_code"],
+            "lint_exit": lint_result["exit_code"],
+            "language": language, "marker": marker,
+            "review_model": review_model,
+            "project_dir": project_dir,
+            "run_id": run_id,
+        }
+        try:
+            await events.emit(conv_id, "tool_end", {
+                "tool": "run_review", "icon": "search-check",
+                "status": "⛔ Review cancelled by user",
+                "run_id": run_id,
+            })
+        except Exception:
+            pass
+        if run_id:
+            try:
+                await db.update_run(run_id, status="cancelled",
+                                    result_envelope=cancelled_env, ended=True)
+            except Exception:
+                pass
+            cancel_registry.cleanup(run_id)
+        return cancelled_env
     except Exception as e:
         print(f"[REVIEWER] LLM call failed: {e}")
 
@@ -574,5 +656,6 @@ async def run_review(http, events, conv_id: str, project_dir: str,
                                 result_envelope=envelope, ended=True)
         except Exception:
             pass
+        cancel_registry.cleanup(run_id)
 
     return envelope

--- a/backend/agents/reviewer.py
+++ b/backend/agents/reviewer.py
@@ -17,6 +17,7 @@ existing run-store, EventBus, and Codebox plumbing.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 import shlex
@@ -235,26 +236,31 @@ async def _detect_project(http, project_dir: str) -> dict:
             "language": "", "files": sorted(files)[:30]}
 
 
-async def _run_in_sandbox(http, project_dir: str, command: str, timeout: int = 300) -> dict:
-    """Run a shell command at project_dir via Codebox. Returns truncated stdout/stderr."""
+async def _run_in_sandbox(http, project_dir: str, command: str,
+                          timeout: int = 300, run_id: str = "") -> dict:
+    """Run a shell command at project_dir via Codebox. Returns truncated stdout/stderr.
+    When run_id is provided, the HTTP call is wrapped in cancel_registry so the
+    user's Stop button can abort it mid-flight."""
     if not command:
         return {"exit_code": -1, "stdout": "", "stderr": "(no command)"}
     try:
-        r = await http.post(
+        coro = http.post(
             f"{config.CODEBOX_URL}/command",
             json={"command": f"cd {shlex.quote(project_dir)} && ({command}) 2>&1",
                   "timeout": timeout},
             timeout=timeout + 30,
         )
+        r = await (cancel_registry.await_cancellable(coro, run_id) if run_id else coro)
         if r.status_code != 200:
             return {"exit_code": -1, "stdout": "",
                     "stderr": f"Codebox HTTP {r.status_code}: {r.text[:200]}"}
         d = r.json()
         out = (d.get("stdout") or "")
-        # Truncate to 4 KB tail — that's where errors live.
         if len(out) > 4096:
             out = "... [truncated head] ...\n" + out[-4096:]
         return {"exit_code": d.get("exit_code", 0), "stdout": out, "stderr": d.get("stderr", "")}
+    except cancel_registry.RunCancelled:
+        raise
     except Exception as e:
         return {"exit_code": -1, "stdout": "", "stderr": f"Exception: {e}"}
 
@@ -348,7 +354,7 @@ Produce a JSON object with this exact shape:
 ```
 
 Rules:
-- If both build_exit=0 and test_exit=0, emit `status:"clean"` and `issues:[]`.
+- If build_exit=0 AND test_exit=0 AND lint_exit=0 (all three), emit `status:"clean"` and `issues:[]`.
 - Otherwise list every distinct failure as one item. Group failures with the same root cause.
 - Each issue must name a real file (use one from the build output if you can't be sure).
 - `suggested_fix_scope` lists ONLY the files a fixer should edit to resolve that one issue.
@@ -484,90 +490,115 @@ async def run_review(http, events, conv_id: str, project_dir: str,
             cancel_registry.cleanup(run_id)
         return envelope
 
-    # 2. Run build / test / lint.
+    # 2. Run build / test / lint → snippets → fast path → LLM analysis.
+    # All wrapped in a single RunCancelled handler so Stop works during any phase.
     build_result = {"exit_code": 0, "stdout": "(skipped — no build command)"}
     test_result = {"exit_code": 0, "stdout": "(skipped — no test command)"}
     lint_result = {"exit_code": 0, "stdout": ""}
-
-    if build_cmd:
-        await _step("build", build_cmd)
-        build_result = await _run_in_sandbox(http, project_dir, build_cmd, timeout=300)
-        await _step("build_done", f"exit={build_result['exit_code']}")
-
-    if test_cmd:
-        await _step("test", test_cmd)
-        test_result = await _run_in_sandbox(http, project_dir, test_cmd, timeout=300)
-        await _step("test_done", f"exit={test_result['exit_code']}")
-
-    if lint_cmd:
-        await _step("lint", lint_cmd)
-        lint_result = await _run_in_sandbox(http, project_dir, lint_cmd, timeout=120)
-        await _step("lint_done", f"exit={lint_result['exit_code']}")
-
-    # 3. Pull file snippets for any failures.
-    failure_text = ""
-    if build_result["exit_code"] != 0:
-        failure_text += build_result.get("stdout", "")
-    if test_result["exit_code"] != 0:
-        failure_text += "\n" + test_result.get("stdout", "")
-    refs = _extract_file_refs(failure_text)
-    snippet_blocks = []
-    for ref in refs[:5]:
-        snip = await _read_file_snippet(http, project_dir, ref["file"], ref["line"])
-        if snip:
-            snippet_blocks.append(f"### {ref['file']}{':'+str(ref['line']) if ref['line'] else ''}\n```\n{snip[:1500]}\n```")
-    snippet_block = ""
-    if snippet_blocks:
-        await _step("read_files", f"{len(snippet_blocks)} files for context")
-        snippet_block = "\n\n## Failing-file snippets (for context only)\n\n" + "\n\n".join(snippet_blocks)
-
-    # 4. Fast path: clean build + tests → skip the LLM call entirely.
-    if build_result["exit_code"] == 0 and test_result["exit_code"] == 0 and not refs:
-        envelope = {
-            "status": "clean",
-            "summary": f"Build + tests pass for {marker} project",
-            "issues": [],
-            "build_exit": 0, "test_exit": 0,
-            "build_cmd": build_cmd, "test_cmd": test_cmd,
-            "language": language,
-            "project_dir": project_dir,
-            "run_id": run_id,
-        }
-        await events.emit(conv_id, "tool_end", {
-            "tool": "run_review", "icon": "search-check",
-            "status": "✅ Review clean — build + tests pass",
-            "run_id": run_id,
-        })
-        if run_id:
-            try:
-                await db.update_run(run_id, status="succeeded",
-                                    result_envelope=envelope, ended=True)
-            except Exception:
-                pass
-            cancel_registry.cleanup(run_id)
-        return envelope
-
-    # 5. Slow path: feed everything to the planning-model LLM and parse JSON.
-    # Per-agent override wins if set; else umbrella PLANNING_MODEL, then chat,
-    # then default.
-    review_model = config.REVIEWER_MODEL or config.PLANNING_MODEL or conv_model or config.DEFAULT_MODEL
-    prompt = _REVIEW_PROMPT.format(
-        build_cmd=build_cmd or "(none)",
-        build_exit=build_result["exit_code"],
-        test_cmd=test_cmd or "(none)",
-        test_exit=test_result["exit_code"],
-        lint_section=(f"Lint command: `{lint_cmd}`\nLint exit: {lint_result['exit_code']}" if lint_cmd else ""),
-        build_chars=len(build_result.get("stdout", "")),
-        test_chars=len(test_result.get("stdout", "")),
-        build_output=build_result.get("stdout", "")[:4000],
-        test_block=("\n## Test output\n```\n" + test_result.get("stdout", "")[:3000] + "\n```") if test_cmd else "",
-        lint_block=("\n## Lint output\n```\n" + lint_result.get("stdout", "")[:1500] + "\n```") if lint_cmd else "",
-        snippet_block=snippet_block,
-    )
-
-    await _step("analyze", f"calling {review_model}")
+    review_model = ""
     review_text = ""
+    _cancel_phase = "build"
+    _ticker = None
+
     try:
+        if build_cmd:
+            _cancel_phase = "build"
+            await _step("build", build_cmd)
+            build_result = await _run_in_sandbox(http, project_dir, build_cmd, timeout=300, run_id=run_id)
+            await _step("build_done", f"exit={build_result['exit_code']}")
+
+        if test_cmd:
+            _cancel_phase = "test"
+            await _step("test", test_cmd)
+            test_result = await _run_in_sandbox(http, project_dir, test_cmd, timeout=300, run_id=run_id)
+            await _step("test_done", f"exit={test_result['exit_code']}")
+
+        if lint_cmd:
+            _cancel_phase = "lint"
+            await _step("lint", lint_cmd)
+            lint_result = await _run_in_sandbox(http, project_dir, lint_cmd, timeout=120, run_id=run_id)
+            await _step("lint_done", f"exit={lint_result['exit_code']}")
+
+        # 3. Pull file snippets for any failures.
+        failure_text = ""
+        if build_result["exit_code"] != 0:
+            failure_text += build_result.get("stdout", "")
+        if test_result["exit_code"] != 0:
+            failure_text += "\n" + test_result.get("stdout", "")
+        if lint_result["exit_code"] != 0:
+            failure_text += "\n" + lint_result.get("stdout", "")
+        refs = _extract_file_refs(failure_text)
+        snippet_blocks = []
+        if refs:
+            _read_tasks = [
+                _read_file_snippet(http, project_dir, ref["file"], ref["line"])
+                for ref in refs[:5]
+            ]
+            _snippets = await asyncio.gather(*_read_tasks, return_exceptions=True)
+            for ref, snip in zip(refs[:5], _snippets):
+                if isinstance(snip, str) and snip:
+                    snippet_blocks.append(f"### {ref['file']}{':'+str(ref['line']) if ref['line'] else ''}\n```\n{snip[:1500]}\n```")
+        snippet_block = ""
+        if snippet_blocks:
+            await _step("read_files", f"{len(snippet_blocks)} files for context")
+            snippet_block = "\n\n## Failing-file snippets (for context only)\n\n" + "\n\n".join(snippet_blocks)
+
+        # 4. Fast path: clean build + tests + lint → skip the LLM call entirely.
+        if build_result["exit_code"] == 0 and test_result["exit_code"] == 0 and lint_result["exit_code"] == 0 and not refs:
+            envelope = {
+                "status": "clean",
+                "summary": f"Build + tests + lint pass for {marker} project",
+                "issues": [],
+                "build_exit": 0, "test_exit": 0, "lint_exit": 0,
+                "build_cmd": build_cmd, "test_cmd": test_cmd, "lint_cmd": lint_cmd,
+                "language": language, "marker": marker,
+                "project_dir": project_dir,
+                "run_id": run_id,
+            }
+            await events.emit(conv_id, "tool_end", {
+                "tool": "run_review", "icon": "search-check",
+                "status": "✅ Review clean — build + tests + lint pass",
+                "run_id": run_id,
+            })
+            if run_id:
+                try:
+                    await db.update_run(run_id, status="succeeded",
+                                        result_envelope=envelope, ended=True)
+                except Exception:
+                    pass
+                cancel_registry.cleanup(run_id)
+            return envelope
+
+        # 5. Slow path: feed everything to the planning-model LLM and parse JSON.
+        review_model = config.REVIEWER_MODEL or config.PLANNING_MODEL or conv_model or config.DEFAULT_MODEL
+        prompt = _REVIEW_PROMPT.format(
+            build_cmd=build_cmd or "(none)",
+            build_exit=build_result["exit_code"],
+            test_cmd=test_cmd or "(none)",
+            test_exit=test_result["exit_code"],
+            lint_section=(f"Lint command: `{lint_cmd}`\nLint exit: {lint_result['exit_code']}" if lint_cmd else ""),
+            build_chars=len(build_result.get("stdout", "")),
+            test_chars=len(test_result.get("stdout", "")),
+            build_output=build_result.get("stdout", "")[:4000],
+            test_block=("\n## Test output\n```\n" + test_result.get("stdout", "")[:3000] + "\n```") if test_cmd else "",
+            lint_block=("\n## Lint output\n```\n" + lint_result.get("stdout", "")[:1500] + "\n```") if lint_cmd else "",
+            snippet_block=snippet_block,
+        )
+
+        _cancel_phase = "analysis"
+        await _step("analyze", f"calling {review_model}")
+
+        async def _progress_ticker():
+            elapsed = 0
+            while True:
+                await asyncio.sleep(15)
+                elapsed += 15
+                try:
+                    await _step("analyzing", f"{elapsed}s elapsed…")
+                except Exception:
+                    pass
+
+        _ticker = asyncio.create_task(_progress_ticker())
         coro = http.post(
             f"{config.OLLAMA_URL}/api/chat",
             json={
@@ -581,10 +612,11 @@ async def run_review(http, events, conv_id: str, project_dir: str,
         r = await cancel_registry.await_cancellable(coro, run_id)
         if r.status_code == 200:
             review_text = (r.json().get("message", {}).get("content") or "").strip()
+
     except cancel_registry.RunCancelled:
         cancelled_env = {
             "status": "cancelled",
-            "summary": "Reviewer cancelled by user (Stop pressed) during analysis call.",
+            "summary": f"Reviewer cancelled by user during {_cancel_phase}.",
             "issues": [],
             "build_cmd": build_cmd, "test_cmd": test_cmd, "lint_cmd": lint_cmd,
             "build_exit": build_result["exit_code"],
@@ -598,7 +630,7 @@ async def run_review(http, events, conv_id: str, project_dir: str,
         try:
             await events.emit(conv_id, "tool_end", {
                 "tool": "run_review", "icon": "search-check",
-                "status": "⛔ Review cancelled by user",
+                "status": f"⛔ Review cancelled by user during {_cancel_phase}",
                 "run_id": run_id,
             })
         except Exception:
@@ -612,22 +644,77 @@ async def run_review(http, events, conv_id: str, project_dir: str,
             cancel_registry.cleanup(run_id)
         return cancelled_env
     except Exception as e:
-        print(f"[REVIEWER] LLM call failed: {e}")
+        print(f"[REVIEWER] review phase failed ({_cancel_phase}): {e}")
+    finally:
+        if _ticker:
+            _ticker.cancel()
+            try:
+                await _ticker
+            except asyncio.CancelledError:
+                pass
 
     parsed = _try_parse_review_json(review_text)
     if not parsed or "status" not in parsed:
         # Heuristic fallback when the model didn't emit clean JSON.
         await _step("parse_fallback", "model output was not valid JSON")
-        parsed = {
-            "status": "issues" if (build_result["exit_code"] != 0 or test_result["exit_code"] != 0) else "clean",
-            "summary": "Reviewer could not parse model output cleanly; reporting raw build/test exits.",
-            "issues": [{
-                "severity": "compile" if build_result["exit_code"] != 0 else "test",
+        _any_fail = (build_result["exit_code"] != 0
+                     or test_result["exit_code"] != 0
+                     or lint_result["exit_code"] != 0)
+        _fb_issues = []
+
+        # Extract FAILED/ERROR lines from test output for actionable summaries
+        # instead of using raw failure_text[:200] which grabs random traceback chunks.
+        _FAIL_LINE_RE = re.compile(
+            r"^(?:FAILED|ERROR)\s+([\w./\-]+\.py)(?:::([\w.\[\]<>:_\-]+))?(?:\s*-\s*(.{0,200}))?",
+            re.MULTILINE,
+        )
+
+        if build_result["exit_code"] != 0:
+            _fb_issues.append({
+                "severity": "compile",
                 "file": refs[0]["file"] if refs else "",
                 "lines": [refs[0]["line"]] if refs and refs[0]["line"] else [],
-                "summary": (failure_text[:200] or "build/test failed").strip(),
+                "summary": (build_result.get("stdout", "")[-500:].strip()[:200] or "build failed"),
                 "suggested_fix_scope": [r["file"] for r in refs[:3]],
-            }] if (build_result["exit_code"] != 0 or test_result["exit_code"] != 0) else [],
+            })
+        if test_result["exit_code"] != 0:
+            _test_out = test_result.get("stdout", "")
+            _fail_matches = _FAIL_LINE_RE.findall(_test_out)
+            if _fail_matches:
+                _by_file: dict[str, list[str]] = {}
+                for _fm_file, _fm_test, _fm_reason in _fail_matches:
+                    _by_file.setdefault(_fm_file, []).append(
+                        f"{_fm_test}: {_fm_reason}" if _fm_reason else _fm_test
+                    )
+                for _fm_file, _fm_descs in list(_by_file.items())[:3]:
+                    _fb_issues.append({
+                        "severity": "test",
+                        "file": _fm_file,
+                        "lines": [],
+                        "summary": f"{len(_fm_descs)} failing test(s): " + "; ".join(_fm_descs[:3])[:200],
+                        "suggested_fix_scope": [_fm_file],
+                    })
+            else:
+                _fb_issues.append({
+                    "severity": "test",
+                    "file": refs[0]["file"] if refs else "",
+                    "lines": [refs[0]["line"]] if refs and refs[0]["line"] else [],
+                    "summary": (_test_out[-500:].strip()[:200] or "tests failed"),
+                    "suggested_fix_scope": [r["file"] for r in refs[:3]],
+                })
+        if lint_result["exit_code"] != 0:
+            _lint_refs = _extract_file_refs(lint_result.get("stdout", ""))
+            _fb_issues.append({
+                "severity": "lint",
+                "file": _lint_refs[0]["file"] if _lint_refs else "",
+                "lines": [_lint_refs[0]["line"]] if _lint_refs and _lint_refs[0]["line"] else [],
+                "summary": (lint_result.get("stdout", "")[-500:].strip()[:200] or "lint failed"),
+                "suggested_fix_scope": [r["file"] for r in _lint_refs[:3]],
+            })
+        parsed = {
+            "status": "issues" if _any_fail else "clean",
+            "summary": "Reviewer could not parse model output cleanly; reporting raw build/test/lint exits.",
+            "issues": _fb_issues,
         }
 
     envelope = {
@@ -642,7 +729,7 @@ async def run_review(http, events, conv_id: str, project_dir: str,
         "run_id": run_id,
     }
 
-    final_status = "succeeded" if envelope.get("status") == "clean" else "succeeded"  # The Reviewer itself succeeded; the project state is what `status` reports.
+    final_status = "succeeded"  # The Reviewer itself succeeded; the project state is what envelope `status` reports.
     n_issues = len(envelope.get("issues") or [])
     await events.emit(conv_id, "tool_end", {
         "tool": "run_review", "icon": "search-check",

--- a/backend/agents/reviewer.py
+++ b/backend/agents/reviewer.py
@@ -39,12 +39,17 @@ _PROJECT_MARKERS = [
     ("go.mod",          "go build ./...",                  "go test ./...",          "go vet ./...",       "go"),
     ("package.json",    "npm install --silent && npm run build --if-present",
                                                             "npm test --if-present",  "",                   "javascript"),
+    # Tail `|| echo '(no tests)'` matches the plain-python profile below: pytest
+    # exits 5 when no tests are collected, and unittest discover can also exit
+    # non-zero on empty trees. Without the echo, a greenfield scaffold with no
+    # tests yet looks like a "test failure" → reviewer flags it → fixer can't
+    # conjure tests → infinite review/fix loop.
     ("pyproject.toml",  "python3 -m pip install -q -e . 2>/dev/null || true",
-                                                            "python3 -m pytest -q --no-header 2>/dev/null || python3 -m unittest discover -q",
+                                                            "python3 -m pytest -q --no-header 2>/dev/null || python3 -m unittest discover -q 2>/dev/null || echo '(no tests)'",
                                                                                       "python3 -m py_compile $(find . -name '*.py' -not -path '*/venv/*')",
                                                                                                             "python"),
     ("requirements.txt","python3 -m pip install -q -r requirements.txt 2>/dev/null || true",
-                                                            "python3 -m pytest -q --no-header 2>/dev/null || python3 -m unittest discover -q",
+                                                            "python3 -m pytest -q --no-header 2>/dev/null || python3 -m unittest discover -q 2>/dev/null || echo '(no tests)'",
                                                                                       "python3 -m py_compile $(find . -name '*.py' -not -path '*/venv/*')",
                                                                                                             "python"),
     ("Makefile",        "make -s 2>&1 | head -200",         "make -s test 2>&1 | head -200", "",            ""),
@@ -492,7 +497,9 @@ async def run_review(http, events, conv_id: str, project_dir: str,
         return envelope
 
     # 5. Slow path: feed everything to the planning-model LLM and parse JSON.
-    review_model = config.PLANNING_MODEL or conv_model or config.DEFAULT_MODEL
+    # Per-agent override wins if set; else umbrella PLANNING_MODEL, then chat,
+    # then default.
+    review_model = config.REVIEWER_MODEL or config.PLANNING_MODEL or conv_model or config.DEFAULT_MODEL
     prompt = _REVIEW_PROMPT.format(
         build_cmd=build_cmd or "(none)",
         build_exit=build_result["exit_code"],

--- a/backend/agents/reviewer.py
+++ b/backend/agents/reviewer.py
@@ -344,8 +344,7 @@ def _try_parse_review_json(text: str) -> dict | None:
 
 
 async def run_review(http, events, conv_id: str, project_dir: str,
-                     project_id: str = "", parent_run_id: str = "",
-                     conv_model: str = "") -> dict:
+                     project_id: str = "", parent_run_id: str = "") -> dict:
     """Execute a Reviewer run on a project. Returns the result envelope.
 
     Side effects:
@@ -492,7 +491,7 @@ async def run_review(http, events, conv_id: str, project_dir: str,
         return envelope
 
     # 5. Slow path: feed everything to the planning-model LLM and parse JSON.
-    review_model = config.CODER_MODEL or conv_model or config.DEFAULT_MODEL
+    review_model = config.PLANNING_MODEL or config.DEFAULT_MODEL
     prompt = _REVIEW_PROMPT.format(
         build_cmd=build_cmd or "(none)",
         build_exit=build_result["exit_code"],

--- a/backend/cancel_registry.py
+++ b/backend/cancel_registry.py
@@ -1,0 +1,120 @@
+"""Cancel registry — per-run asyncio.Event wired to the Stop button.
+
+When the user presses Stop in the UI, the frontend POSTs to
+`/api/runs/{run_id}/cancel`. That endpoint calls `signal(run_id)` here, which
+sets the registered Event for the run. Anywhere an agent (architect, reviewer,
+fixer, builder) is waiting on a long-running call, it should wrap that call in
+`await_cancellable(coro, run_id)` so the wait races the cancel event and aborts
+the in-flight work cleanly when Stop fires.
+
+Lives in-process — restarts clear the registry. That's fine because the routes
+also mark the DB row `cancelled` on signal, so frontend polling sees the right
+state regardless of whether the in-process wait actually returned.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Awaitable, Optional
+
+
+class RunCancelled(Exception):
+    """Raised by `await_cancellable` when the registered cancel event fires."""
+
+    def __init__(self, run_id: str = ""):
+        self.run_id = run_id
+        super().__init__(f"run cancelled: {run_id}" if run_id else "run cancelled")
+
+
+_events: dict[str, asyncio.Event] = {}
+
+
+def register(run_id: str) -> asyncio.Event:
+    """Register a cancel Event for `run_id`. Idempotent — returns the existing
+    event if already registered. Empty `run_id` returns a detached event."""
+    if not run_id:
+        return asyncio.Event()
+    ev = _events.get(run_id)
+    if ev is None:
+        ev = asyncio.Event()
+        _events[run_id] = ev
+    return ev
+
+
+def get_event(run_id: str) -> Optional[asyncio.Event]:
+    return _events.get(run_id) if run_id else None
+
+
+def is_cancelled(run_id: str) -> bool:
+    ev = _events.get(run_id) if run_id else None
+    return bool(ev and ev.is_set())
+
+
+def signal(run_id: str) -> bool:
+    """Set the cancel event. Returns True if a registered event was found.
+
+    A False return doesn't mean the cancel was useless — the run may have
+    finished before we got here, or it may not have registered yet (rare race
+    on very-early cancel). The route will still mark the DB row cancelled.
+    """
+    ev = _events.get(run_id) if run_id else None
+    if ev is None:
+        return False
+    if not ev.is_set():
+        ev.set()
+    return True
+
+
+def cleanup(run_id: str) -> None:
+    """Remove the event for a finished run. Safe on unknown ids."""
+    if run_id:
+        _events.pop(run_id, None)
+
+
+def active_run_ids() -> list[str]:
+    """All run_ids with a registered event. Useful for diagnostics."""
+    return list(_events.keys())
+
+
+async def await_cancellable(coro: Awaitable, run_id: str):
+    """Await `coro` but raise `RunCancelled` if the run's cancel event fires.
+
+    If `run_id` has no registered event, behaves exactly like `await coro`.
+    On cancel, the underlying coroutine task is cancelled — for httpx calls
+    that drops the connection cleanly so the upstream (Ollama / Codebox /
+    OpenHands worker) stops the in-flight request.
+    """
+    ev = _events.get(run_id) if run_id else None
+    if ev is None:
+        return await coro
+
+    if ev.is_set():
+        # Already cancelled before we entered — close the unused coro and bail.
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        raise RunCancelled(run_id)
+
+    work = asyncio.ensure_future(coro)
+    waiter = asyncio.ensure_future(ev.wait())
+    try:
+        done, _pending = await asyncio.wait(
+            {work, waiter}, return_when=asyncio.FIRST_COMPLETED,
+        )
+    finally:
+        if not waiter.done():
+            waiter.cancel()
+            try:
+                await waiter
+            except (asyncio.CancelledError, BaseException):
+                pass
+
+    if work in done:
+        return work.result()
+
+    # Cancel fired first — abort the work and surface RunCancelled
+    work.cancel()
+    try:
+        await work
+    except (asyncio.CancelledError, BaseException):
+        pass
+    raise RunCancelled(run_id)

--- a/backend/config.py
+++ b/backend/config.py
@@ -33,7 +33,7 @@ DATABASE_PATH = os.getenv("DATABASE_PATH", "/opt/hyprchat/data/hyprchat.db")
 UPLOAD_DIR = os.getenv("UPLOAD_DIR", "/opt/hyprchat/data/uploads")
 TOOLS_DIR = os.getenv("TOOLS_DIR", "/opt/hyprchat/data/tools")
 KB_DIR = os.getenv("KB_DIR", "/opt/hyprchat/data/knowledge_bases")
-MAX_UPLOAD_SIZE_MB = int(os.getenv("MAX_UPLOAD_SIZE_MB", "50"))
+MAX_UPLOAD_SIZE_MB = int(os.getenv("MAX_UPLOAD_SIZE_MB", "250"))
 
 # ============================================================
 # SANDBOX — isolated dir for all tool-generated output files
@@ -77,9 +77,25 @@ PLANNING_MODEL = os.getenv("PLANNING_MODEL", "qwen3.5:27b")
 CODER_MODEL = os.getenv("CODER_MODEL", "qwen2.5-coder:14b")
 CRITIC_MODEL = os.getenv("CRITIC_MODEL", "")  # Empty = falls back to PLANNING_MODEL. Independent code reviewer for generate_code output.
 CRITIC_ENABLED = os.getenv("CRITIC_ENABLED", "true").lower() == "true"
+
+# Coder Bot v2 — per-agent model overrides. Empty means each agent inherits
+# from its umbrella default (PLANNING_MODEL for analysis-style agents,
+# CODER_MODEL for code-writing agents) which in turn falls through to the
+# active chat model. Power users who want to pin a specific model per agent
+# can set these — most users leave them empty.
+ARCHITECT_MODEL = os.getenv("ARCHITECT_MODEL", "")  # Empty = use PLANNING_MODEL
+REVIEWER_MODEL  = os.getenv("REVIEWER_MODEL",  "")  # Empty = use PLANNING_MODEL
+BUILDER_MODEL   = os.getenv("BUILDER_MODEL",   "")  # Empty = use CODER_MODEL
+FIXER_MODEL     = os.getenv("FIXER_MODEL",     "")  # Empty = use CODER_MODEL
+QA_MODEL        = os.getenv("QA_MODEL",        "")  # Empty = use chat / persona model
 OPENHANDS_ENABLED = os.getenv("OPENHANDS_ENABLED", "true").lower() == "true"  # Toggle OpenHands for generate_code tool
 OPENHANDS_MAX_ROUNDS = int(os.getenv("OPENHANDS_MAX_ROUNDS", "20"))
 OPENHANDS_NUM_CTX = int(os.getenv("OPENHANDS_NUM_CTX", "16384"))
+# Reasoning effort for the OpenHands builder LLM. The SDK passes this through
+# to litellm; for OpenAI-style models it's "low" | "medium" | "high"; local
+# Ollama models silently ignore unsupported values. Default "medium" — "high"
+# adds a lot of think-token overhead per round on small/medium local models.
+OPENHANDS_REASONING_EFFORT = os.getenv("OPENHANDS_REASONING_EFFORT", "medium").strip().lower()
 DEFAULT_NUM_CTX = int(os.getenv("DEFAULT_NUM_CTX", "16384"))
 MAX_AGENT_ROUNDS = int(os.getenv("MAX_AGENT_ROUNDS", "12"))
 MAX_AGENT_ROUNDS_CODER = int(os.getenv("MAX_AGENT_ROUNDS_CODER", "30"))

--- a/backend/config.py
+++ b/backend/config.py
@@ -68,6 +68,13 @@ EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", "60"))
 SEARCH_RESULTS_COUNT = int(os.getenv("SEARCH_RESULTS_COUNT", "15"))
 MAX_FETCH_CHARS = int(os.getenv("MAX_FETCH_CHARS", "8000"))
 
+# Multi-round search agent (replaces the old single-shot quick_search rewrite
+# pipeline). Triage runs against the chat model by default to avoid VRAM-swap
+# latency on single-GPU homelabs; set QUICK_SEARCH_TRIAGE_MODEL to override
+# with e.g. a small workspace model (only worthwhile if it stays co-resident
+# in VRAM with the chat model).
+QUICK_SEARCH_TRIAGE_MODEL = os.getenv("QUICK_SEARCH_TRIAGE_MODEL", "")
+
 # ============================================================
 # DEFAULTS
 # ============================================================

--- a/backend/config.py
+++ b/backend/config.py
@@ -7,18 +7,18 @@ import os
 # ============================================================
 # INFRASTRUCTURE IPs
 # ============================================================
-OLLAMA_URL = os.getenv("OLLAMA_URL", "http://192.168.1.110:11434")
-CODEBOX_URL = os.getenv("CODEBOX_URL", "http://192.168.1.201:8585")
-OPENHANDS_URL = os.getenv("OPENHANDS_URL", "http://192.168.1.201:8586")
-SEARXNG_URL = os.getenv("SEARXNG_URL", "http://192.168.1.141:8888")
-N8N_URL = os.getenv("N8N_URL", "http://192.168.1.114:5678")
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://127.0.0.1:11434")
+CODEBOX_URL = os.getenv("CODEBOX_URL", "http://127.0.0.1:8585")
+OPENHANDS_URL = os.getenv("OPENHANDS_URL", "http://127.0.0.1:8586")
+SEARXNG_URL = os.getenv("SEARXNG_URL", "http://127.0.0.1:8888")
+N8N_URL = os.getenv("N8N_URL", "http://127.0.0.1:5678")
 N8N_WEBHOOK_PATH = os.getenv("N8N_WEBHOOK_PATH", "/webhook/execute-code")
 N8N_RESEARCH_PATH = os.getenv("N8N_RESEARCH_PATH", "/webhook/deep-research")
 
 # ============================================================
 # SERVER
 # ============================================================
-HOST = os.getenv("HOST", "0.0.0.0")
+HOST = os.getenv("HOST", "127.0.0.1")
 PORT = int(os.getenv("PORT", "8000"))
 DEBUG = os.getenv("DEBUG", "false").lower() == "true"
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -727,6 +727,23 @@ async def get_model_configs():
         await db.close()
 
 
+async def get_model_config(mc_id: str) -> dict | None:
+    """Return a single model config by id, or None if not found."""
+    db = await get_db()
+    try:
+        cursor = await db.execute("SELECT * FROM model_configs WHERE id = ?", (mc_id,))
+        row = await cursor.fetchone()
+        if not row:
+            return None
+        c = dict(row)
+        c["tool_ids"] = json.loads(c["tool_ids"])
+        c["kb_ids"] = json.loads(c["kb_ids"])
+        c["parameters"] = json.loads(c["parameters"])
+        return c
+    finally:
+        await db.close()
+
+
 async def update_model_config(id: str, **kwargs):
     db = await get_db()
     try:

--- a/backend/hyprchat.service
+++ b/backend/hyprchat.service
@@ -4,16 +4,21 @@ After=network.target
 
 [Service]
 Type=simple
-User=root
+User=hyprchat
+Group=hyprchat
 WorkingDirectory=/opt/hyprchat/backend
-ExecStart=/usr/bin/python3 -m uvicorn main:app --host 0.0.0.0 --port 8000 --workers 1
+EnvironmentFile=/opt/hyprchat/.env
+ExecStart=/usr/bin/python3 -m uvicorn main:app --host ${HOST} --port ${PORT} --workers 1
 Restart=always
 RestartSec=5
 Environment=PYTHONUNBUFFERED=1
-Environment=DATABASE_PATH=/opt/hyprchat/data/hyprchat.db
-Environment=UPLOAD_DIR=/opt/hyprchat/data/uploads
-Environment=TOOLS_DIR=/opt/hyprchat/data/tools
-Environment=KB_DIR=/opt/hyprchat/data/knowledge_bases
+
+# Hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+ReadWritePaths=/opt/hyprchat/data
 
 [Install]
 WantedBy=multi-user.target

--- a/backend/main.py
+++ b/backend/main.py
@@ -1383,6 +1383,54 @@ async def list_runs(conversation_id: str = Query(None), project_id: str = Query(
     raise HTTPException(400, "conversation_id or project_id is required")
 
 
+@app.post("/api/runs/{run_id}/cancel")
+async def cancel_run(run_id: str):
+    """Signal an in-flight run to abort.
+
+    Two effects:
+      1. Sets the asyncio.Event in `cancel_registry` so any agent waiting on a
+         long Ollama / Codebox / OpenHands call via `await_cancellable` aborts
+         its in-flight request immediately.
+      2. Updates the `runs` row to `status='cancelled'` if it was still running
+         or pending. Frontend polling sees the new status on its next tick,
+         even if the in-process signal arrived too late (e.g. after restart).
+
+    Always returns 200. Unknown / already-finished runs are a no-op rather
+    than an error so the frontend can fan out cancels without per-run guards.
+    """
+    import cancel_registry
+
+    signaled = cancel_registry.signal(run_id)
+
+    db_marked = False
+    try:
+        row = await db.get_run(run_id)
+        if row and row.get("status") in ("running", "pending"):
+            envelope = row.get("result_envelope") or {}
+            if not isinstance(envelope, dict):
+                envelope = {}
+            envelope = {
+                **envelope,
+                "status": "cancelled",
+                "summary": envelope.get("summary") or "Cancelled by user (Stop pressed)",
+            }
+            await db.update_run(run_id, status="cancelled",
+                                result_envelope=envelope, ended=True)
+            try:
+                await db.append_run_event(run_id, {
+                    "type": "step",
+                    "action": "cancelled",
+                    "detail": "user pressed Stop",
+                })
+            except Exception:
+                pass
+            db_marked = True
+    except Exception as e:
+        print(f"[CANCEL] DB update failed for {run_id}: {e}")
+
+    return {"run_id": run_id, "signaled": signaled, "db_marked": db_marked}
+
+
 # ============================================================
 # CONVERSATIONS
 # ============================================================

--- a/backend/main.py
+++ b/backend/main.py
@@ -190,6 +190,11 @@ async def lifespan(app: FastAPI):
     if "coder_model" in _settings:
         config.CODER_MODEL = _settings["coder_model"] or ""
         print(f"[Config] Loaded Coder Model from settings: {config.CODER_MODEL or '(use chat model)'}")
+    # Workspace model (small/fast model used for quick_search triage,
+    # auto-titles, and topic auto-detection). Empty = inherit chat model.
+    if "workspace_model" in _settings:
+        config.WORKSPACE_MODEL = _settings["workspace_model"] or ""
+        print(f"[Config] Loaded Workspace Model from settings: {config.WORKSPACE_MODEL or '(use chat model)'}")
     # Coder Bot v2 per-agent overrides — each empty by default; only seen here
     # when the user has explicitly pinned a model for that agent.
     for _key, _attr in (
@@ -2812,6 +2817,7 @@ async def get_app_settings():
         "current_ollama_url": config.OLLAMA_URL,
         "current_planning_model": config.PLANNING_MODEL,
         "current_coder_model": config.CODER_MODEL,
+        "current_workspace_model": config.WORKSPACE_MODEL,
         # Coder Bot v2 per-agent overrides — empty string = inherit from umbrella
         "current_architect_model": config.ARCHITECT_MODEL,
         "current_reviewer_model":  config.REVIEWER_MODEL,
@@ -2835,6 +2841,7 @@ async def get_app_settings():
 async def update_app_settings(body: dict = Body(...)):
     settings = load_settings()
     allowed = {"file_cleanup_days", "ollama_url", "rag", "planning_model", "coder_model",
+               "workspace_model",
                "architect_model", "reviewer_model", "builder_model", "fixer_model", "qa_model",
                "openhands_enabled", "openhands_max_rounds", "openhands_num_ctx",
                "openhands_reasoning_effort", "default_num_ctx"}
@@ -2862,6 +2869,9 @@ async def update_app_settings(body: dict = Body(...)):
     if "coder_model" in body:
         config.CODER_MODEL = body["coder_model"] or ""
         print(f"[Config] Updated Coder Model to: {config.CODER_MODEL or '(use orchestrator model)'}")
+    if "workspace_model" in body:
+        config.WORKSPACE_MODEL = body["workspace_model"] or ""
+        print(f"[Config] Updated Workspace Model to: {config.WORKSPACE_MODEL or '(use chat model)'}")
     # Coder Bot v2 per-agent overrides
     for _key, _attr, _label in (
         ("architect_model", "ARCHITECT_MODEL", "Architect"),
@@ -2899,6 +2909,7 @@ async def update_app_settings(body: dict = Body(...)):
         "current_ollama_url": config.OLLAMA_URL,
         "current_planning_model": config.PLANNING_MODEL,
         "current_coder_model": config.CODER_MODEL,
+        "current_workspace_model": config.WORKSPACE_MODEL,
         "current_architect_model": config.ARCHITECT_MODEL,
         "current_reviewer_model":  config.REVIEWER_MODEL,
         "current_builder_model":   config.BUILDER_MODEL,

--- a/backend/main.py
+++ b/backend/main.py
@@ -224,15 +224,23 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="HyprChat", version="2.0.0", lifespan=lifespan)
 
+ALLOWED_ORIGINS = [
+    o.strip() for o in os.getenv(
+        "ALLOWED_ORIGINS",
+        "http://localhost:8000,http://127.0.0.1:8000",
+    ).split(",") if o.strip()
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=False,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type", "X-API-Key"],
 )
 
-http = httpx.AsyncClient(timeout=httpx.Timeout(300.0, connect=10.0), verify=False)
+HTTP_VERIFY_SSL = os.getenv("HTTP_VERIFY_SSL", "true").lower() == "true"
+http = httpx.AsyncClient(timeout=httpx.Timeout(300.0, connect=10.0), verify=HTTP_VERIFY_SSL)
 
 # ============================================================
 # PYDANTIC MODELS
@@ -2814,7 +2822,7 @@ async def update_app_settings(body: dict = Body(...)):
         config.OLLAMA_URL = body["ollama_url"]
         print(f"[Config] Updated Ollama URL to: {config.OLLAMA_URL}")
     elif "ollama_url" in body and not body["ollama_url"]:
-        config.OLLAMA_URL = os.getenv("OLLAMA_URL", "http://192.168.1.110:11434")
+        config.OLLAMA_URL = os.getenv("OLLAMA_URL", "http://127.0.0.1:11434")
     if "planning_model" in body:
         config.PLANNING_MODEL = body["planning_model"] or ""
         print(f"[Config] Updated Planning Model to: {config.PLANNING_MODEL or '(use chat model)'}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -180,18 +180,41 @@ async def lifespan(app: FastAPI):
     if _settings.get("ollama_url"):
         config.OLLAMA_URL = _settings["ollama_url"]
         print(f"[Config] Loaded Ollama URL from settings: {config.OLLAMA_URL}")
-    if _settings.get("planning_model"):
-        config.PLANNING_MODEL = _settings["planning_model"]
-        print(f"[Config] Loaded Planning Model from settings: {config.PLANNING_MODEL}")
-    if _settings.get("coder_model"):
-        config.CODER_MODEL = _settings["coder_model"]
-        print(f"[Config] Loaded Coder Model from settings: {config.CODER_MODEL}")
+    # Use `in _settings` (not `.get(...)` truthy check) so an explicitly-saved
+    # empty string — meaning "inherit from chat model" in the UI — is honored
+    # on startup. Otherwise the env default (e.g. PLANNING_MODEL=qwen3.5:27b
+    # in config.py) silently overrides the user's choice every restart.
+    if "planning_model" in _settings:
+        config.PLANNING_MODEL = _settings["planning_model"] or ""
+        print(f"[Config] Loaded Planning Model from settings: {config.PLANNING_MODEL or '(use chat model)'}")
+    if "coder_model" in _settings:
+        config.CODER_MODEL = _settings["coder_model"] or ""
+        print(f"[Config] Loaded Coder Model from settings: {config.CODER_MODEL or '(use chat model)'}")
+    # Coder Bot v2 per-agent overrides — each empty by default; only seen here
+    # when the user has explicitly pinned a model for that agent.
+    for _key, _attr in (
+        ("architect_model", "ARCHITECT_MODEL"),
+        ("reviewer_model",  "REVIEWER_MODEL"),
+        ("builder_model",   "BUILDER_MODEL"),
+        ("fixer_model",     "FIXER_MODEL"),
+        ("qa_model",        "QA_MODEL"),
+    ):
+        if _key in _settings:
+            setattr(config, _attr, _settings[_key] or "")
+            if _settings[_key]:
+                print(f"[Config] Loaded {_attr} from settings: {_settings[_key]}")
     if "openhands_enabled" in _settings:
         config.OPENHANDS_ENABLED = _settings["openhands_enabled"]
         print(f"[Config] Loaded OpenHands enabled: {config.OPENHANDS_ENABLED}")
     if "openhands_max_rounds" in _settings:
         config.OPENHANDS_MAX_ROUNDS = int(_settings["openhands_max_rounds"])
         print(f"[Config] Loaded OpenHands max rounds: {config.OPENHANDS_MAX_ROUNDS}")
+    if "openhands_reasoning_effort" in _settings:
+        _re = (_settings["openhands_reasoning_effort"] or "medium").strip().lower()
+        if _re not in ("low", "medium", "high"):
+            _re = "medium"
+        config.OPENHANDS_REASONING_EFFORT = _re
+        print(f"[Config] Loaded OpenHands reasoning effort: {config.OPENHANDS_REASONING_EFFORT}")
     if "default_num_ctx" in _settings:
         # Single knob the user controls. Drives the chat-side fallback in chat.py and
         # every internal LLM call (plan_project, critic) — so increasing the chat ctx
@@ -1621,8 +1644,8 @@ async def extract_pdf(file: UploadFile = File(...)):
     if not file.filename or not file.filename.lower().endswith(".pdf"):
         raise HTTPException(400, "Only PDF files are accepted")
     content = await file.read()
-    if len(content) > 50 * 1024 * 1024:
-        raise HTTPException(413, "PDF too large (max 50MB)")
+    if len(content) > config.MAX_UPLOAD_SIZE_MB * 1024 * 1024:
+        raise HTTPException(413, f"PDF too large (max {config.MAX_UPLOAD_SIZE_MB}MB)")
     try:
         from pypdf import PdfReader
         import io
@@ -2789,9 +2812,16 @@ async def get_app_settings():
         "current_ollama_url": config.OLLAMA_URL,
         "current_planning_model": config.PLANNING_MODEL,
         "current_coder_model": config.CODER_MODEL,
+        # Coder Bot v2 per-agent overrides — empty string = inherit from umbrella
+        "current_architect_model": config.ARCHITECT_MODEL,
+        "current_reviewer_model":  config.REVIEWER_MODEL,
+        "current_builder_model":   config.BUILDER_MODEL,
+        "current_fixer_model":     config.FIXER_MODEL,
+        "current_qa_model":        config.QA_MODEL,
         "openhands_enabled": config.OPENHANDS_ENABLED,
         "openhands_max_rounds": config.OPENHANDS_MAX_ROUNDS,
         "openhands_num_ctx": config.OPENHANDS_NUM_CTX,
+        "openhands_reasoning_effort": config.OPENHANDS_REASONING_EFFORT,
         "default_num_ctx": config.DEFAULT_NUM_CTX,
         "sandbox_dir": config.SANDBOX_DIR,
         "sandbox_outputs_dir": config.SANDBOX_OUTPUTS_DIR,
@@ -2804,7 +2834,10 @@ async def get_app_settings():
 @app.patch("/api/settings")
 async def update_app_settings(body: dict = Body(...)):
     settings = load_settings()
-    allowed = {"file_cleanup_days", "ollama_url", "rag", "planning_model", "coder_model", "openhands_enabled", "openhands_max_rounds", "openhands_num_ctx", "default_num_ctx"}
+    allowed = {"file_cleanup_days", "ollama_url", "rag", "planning_model", "coder_model",
+               "architect_model", "reviewer_model", "builder_model", "fixer_model", "qa_model",
+               "openhands_enabled", "openhands_max_rounds", "openhands_num_ctx",
+               "openhands_reasoning_effort", "default_num_ctx"}
     for k, v in body.items():
         if k in allowed:
             settings[k] = v
@@ -2829,6 +2862,17 @@ async def update_app_settings(body: dict = Body(...)):
     if "coder_model" in body:
         config.CODER_MODEL = body["coder_model"] or ""
         print(f"[Config] Updated Coder Model to: {config.CODER_MODEL or '(use orchestrator model)'}")
+    # Coder Bot v2 per-agent overrides
+    for _key, _attr, _label in (
+        ("architect_model", "ARCHITECT_MODEL", "Architect"),
+        ("reviewer_model",  "REVIEWER_MODEL",  "Reviewer"),
+        ("builder_model",   "BUILDER_MODEL",   "Builder"),
+        ("fixer_model",     "FIXER_MODEL",     "Fixer"),
+        ("qa_model",        "QA_MODEL",        "ProjectQA"),
+    ):
+        if _key in body:
+            setattr(config, _attr, body[_key] or "")
+            print(f"[Config] Updated {_label} Model to: {body[_key] or '(inherit umbrella)'}")
     if "openhands_enabled" in body:
         config.OPENHANDS_ENABLED = bool(body["openhands_enabled"])
         print(f"[Config] OpenHands enabled: {config.OPENHANDS_ENABLED}")
@@ -2838,11 +2882,29 @@ async def update_app_settings(body: dict = Body(...)):
     if "openhands_num_ctx" in body:
         config.OPENHANDS_NUM_CTX = int(body["openhands_num_ctx"])
         print(f"[Config] OpenHands num_ctx: {config.OPENHANDS_NUM_CTX}")
+    if "openhands_reasoning_effort" in body:
+        _re_in = (body["openhands_reasoning_effort"] or "medium").strip().lower()
+        if _re_in not in ("low", "medium", "high"):
+            _re_in = "medium"
+        config.OPENHANDS_REASONING_EFFORT = _re_in
+        # Persist the validated value, not the raw input.
+        settings["openhands_reasoning_effort"] = _re_in
+        print(f"[Config] OpenHands reasoning effort: {config.OPENHANDS_REASONING_EFFORT}")
     if "default_num_ctx" in body:
         config.DEFAULT_NUM_CTX = int(body["default_num_ctx"])
         print(f"[Config] Default num_ctx: {config.DEFAULT_NUM_CTX}")
     save_settings(settings)
-    return {**settings, "current_ollama_url": config.OLLAMA_URL, "current_planning_model": config.PLANNING_MODEL, "current_coder_model": config.CODER_MODEL}
+    return {
+        **settings,
+        "current_ollama_url": config.OLLAMA_URL,
+        "current_planning_model": config.PLANNING_MODEL,
+        "current_coder_model": config.CODER_MODEL,
+        "current_architect_model": config.ARCHITECT_MODEL,
+        "current_reviewer_model":  config.REVIEWER_MODEL,
+        "current_builder_model":   config.BUILDER_MODEL,
+        "current_fixer_model":     config.FIXER_MODEL,
+        "current_qa_model":        config.QA_MODEL,
+    }
 
 
 @app.get("/api/rag/stats")

--- a/backend/openhands_worker.py
+++ b/backend/openhands_worker.py
@@ -102,7 +102,7 @@ def _derive_project_name(task: str, language: str) -> str:
 class RunRequest(BaseModel):
     task: str
     model: str = "qwen2.5:14b"
-    ollama_url: str = "http://192.168.1.110:11434"
+    ollama_url: str = "http://127.0.0.1:11434"
     max_rounds: int = 20
     num_ctx: int = 16384
     language: str = "python"
@@ -1095,4 +1095,6 @@ def clean_workspace():
 
 if __name__ == "__main__":
     import uvicorn
+    # Intentional 0.0.0.0 bind: this worker runs inside the Codebox LXC and must be
+    # reachable from the HyprChat host. Lock down at the network/firewall layer instead.
     uvicorn.run(app, host="0.0.0.0", port=8586)

--- a/backend/openhands_worker.py
+++ b/backend/openhands_worker.py
@@ -112,6 +112,9 @@ class RunRequest(BaseModel):
     # Phase 5 — Builder profile. Default "scaffold" preserves prior behavior
     # for any caller that doesn't pass one.
     profile: str = "scaffold"  # scaffold | continue | feature
+    # Reasoning effort passed to the SDK LLM. Default "medium"; "high" is
+    # heavy-think-token mode and slow on local Ollama models, "low" is fastest.
+    reasoning_effort: str = "medium"  # low | medium | high
     # Only meaningful when profile == "continue": list of manifest files the
     # last builder run failed to write. The worker focuses on these.
     manifest_missing: list[str] = []
@@ -298,7 +301,10 @@ def run_task(req: RunRequest):
         # exactly that value, and pass it nested under "options" so litellm
         # forwards it as options.num_ctx (Ollama ignores top-level num_ctx).
         _ensure_loaded(ollama_base, req.model, req.num_ctx)
-        llm = _LLM(
+        _re = (req.reasoning_effort or "medium").strip().lower()
+        if _re not in ("low", "medium", "high"):
+            _re = "medium"
+        _llm_kwargs = dict(
             model=f"ollama_chat/{req.model}",
             api_key="ollama",
             base_url=ollama_base,
@@ -309,6 +315,15 @@ def run_task(req: RunRequest):
             native_tool_calling=native_tc,
             litellm_extra_body={"options": {"num_ctx": req.num_ctx}},
         )
+        # SDK accepts `reasoning_effort` as a top-level kwarg; older builds may
+        # not. Try with it; if it's rejected, retry without (SDK falls back to
+        # its built-in default of "high").
+        try:
+            llm = _LLM(reasoning_effort=_re, **_llm_kwargs)
+            print(f"[OH-Worker] reasoning_effort={_re}")
+        except TypeError:
+            print(f"[OH-Worker] SDK rejected reasoning_effort kwarg — using default")
+            llm = _LLM(**_llm_kwargs)
 
         # ── Agent with core tools ──
         tools = [

--- a/backend/quick_search.py
+++ b/backend/quick_search.py
@@ -2,12 +2,17 @@
 Quick search — shared helper for chat injection (`agents/chat.py`) and the
 standalone `/api/quick-search` endpoint (`main.py`).
 
-Pipeline (chat path):
-  skip-gate → query-rewrite (WORKSPACE_MODEL) → SearXNG (safesearch=0) →
-  rank/dedup → selective page fetch → build context with proxied image URLs.
+Pipeline (chat path): dispatches to `search_agent.run_search_agent`, which
+runs skip-gate → triage (LLM, JSON-mode) → parallel SearXNG → relevance
+check → optional refine → page/OG-image enrichment → context build.
 
-Standalone API path skips rewrite/page-fetch and returns carousel-shaped data
-(with OG-image enrichment for missing thumbnails).
+This module hosts the shared helpers the agent reuses (skip-gate regexes,
+content-token extraction, follow-up detection, SearXNG cache, ranking +
+domain bias, page fetch, OG-image enrichment, context builder, image
+proxy URL builder). The agent itself lives in `search_agent.py`.
+
+Standalone API path (`run_quick_search_for_api`) skips triage and page-fetch
+and returns carousel-shaped data (with OG-image enrichment).
 """
 import asyncio
 import re
@@ -16,7 +21,7 @@ import urllib.parse
 from datetime import datetime
 
 import config
-from research import _search_searxng, _fetch_page, _rank_urls, _ask_ollama
+from research import _search_searxng, _fetch_page, _rank_urls
 
 
 # ── 10-min TTL cache, keyed by query string ──
@@ -60,118 +65,90 @@ def _should_skip(query: str) -> tuple[bool, str]:
     return False, ""
 
 
-# ── Query rewrite via small/fast workspace model ──
-async def _try_rewrite_call(http, ollama_url: str, prompt: str, model: str, timeout: float) -> str:
-    """Single rewrite attempt. Returns sanitized output or empty string on any failure."""
-    try:
-        out = await asyncio.wait_for(
-            _ask_ollama(http, ollama_url, prompt, model=model, max_tokens=40),
-            timeout=timeout,
-        )
-    except Exception:
-        return ""
-    if not out:
-        return ""
-    # `_ask_ollama` returns "[AI synthesis failed: ...]" on error — treat as empty
-    if out.startswith("["):
-        return ""
-    out = re.sub(r"<think>[\s\S]*?</think>", "", out, flags=re.IGNORECASE).strip()
-    if not out:
-        return ""
-    out = out.splitlines()[0].strip().strip('"').strip("'").rstrip(".")
-    if (
-        not out
-        or len(out) > 200
-        or out.lower().startswith(("here", "the query", "search:", "query:", "rewritten", "i ", "i'", "as "))
-        or "http" in out.lower()
-    ):
-        return ""
-    return out
+# Pronouns / vague references that always need replacement with prior-turn nouns
+_PRONOUN_RE = re.compile(
+    r"\b(she|he|it|they|them|her|him|his|its|their|this|that|these|those)\b",
+    re.IGNORECASE,
+)
+_VAGUE_REF_RE = re.compile(
+    r"\b(the (one|version|issue|thing|topic|story|news|results?)|"
+    r"that (one|stuff|thing|kind))\b",
+    re.IGNORECASE,
+)
+# Common follow-up openers — bare questions that lean entirely on prior context
+_FOLLOWUP_STARTERS_RE = re.compile(
+    r"^\s*(any|more|whats?\s+about|hows?\s+about|whats?\s+new|whats?\s+next|"
+    r"tell\s+me\s+more|continue|next|whos?|whose|wheres?)\b",
+    re.IGNORECASE,
+)
+
+# Stopwords used for content-token extraction. Intentionally aggressive: we want
+# only nouns/proper-nouns/distinctive verbs to count as "topic anchors".
+_STOPWORDS = frozenset({
+    "the","a","an","is","are","was","were","be","been","being","am",
+    "do","does","did","done","doing",
+    "have","has","had","having",
+    "will","would","could","should","can","may","might","must","shall",
+    "this","that","these","those","it","its","they","them","their",
+    "i","me","my","mine","you","your","yours","we","us","our","ours",
+    "he","she","him","her","his","hers",
+    "and","or","but","so","if","of","to","in","on","at","by","for","from","with",
+    "as","about","into","over","under","than","then","now","not","no","yes",
+    "ok","okay","just","still","yet","also","too","very","really","quite",
+    "what","whats","who","whos","when","where","wheres","why","how","hows","which","whose",
+    "any","more","next","else","other","another","like",
+    "tell","show","explain","describe","said","says","say",
+})
 
 
-async def _rewrite_query(
-    http, ollama_url: str, workspace_model: str, default_model: str,
-    messages: list, latest: str,
-) -> str:
-    """Rewrite latest user message into a focused search query using last few turns.
-    Tries WORKSPACE_MODEL first (fast), falls back to DEFAULT_MODEL if that fails
-    (e.g. workspace model not installed). Returns raw `latest` on total failure.
+def _content_tokens(text: str) -> set[str]:
+    """Lowercased non-stopword content tokens from `text`.
+
+    Includes 3+ char words (with naive singularization so `elections` matches
+    `election`) plus 2-5 char ALL-CAPS acronyms (UK, US, EU, NASA) which would
+    otherwise fall under the length floor and get dropped.
     """
-    fallback = latest[:500]
-    turns: list[str] = []
-    for m in messages[-6:]:
-        role = m.get("role", "")
-        content = (m.get("content") or "").strip()
-        if role not in ("user", "assistant") or not content:
+    tokens: set[str] = set()
+    for t in re.findall(r"[a-zA-Z][a-zA-Z0-9-]{2,}", text.lower()):
+        if t in _STOPWORDS:
             continue
-        if content == latest:
-            continue
-        turns.append(f"{role}: {content[:300]}")
-    if not turns:
-        # No conversation history — nothing to expand. Skip the rewrite call.
-        return fallback
-    prompt = (
-        "You are a search query generator. Rewrite the user's latest message "
-        "into a complete, search-engine-friendly query.\n\n"
-        "CRITICAL RULE: If the latest message contains a pronoun "
-        "(she, he, it, they, this, that, these, those) or a vague reference "
-        "(the one, that thing, the version, the issue), you MUST replace it "
-        "with the specific noun from the prior turns. Pronouns are NEVER "
-        "acceptable in the output.\n\n"
-        "Examples:\n"
-        "  Conversation: user asked 'who is taylor swift?'\n"
-        "  Latest: 'what does she look like?'\n"
-        "  Output: Taylor Swift photos appearance\n\n"
-        "  Conversation: user asked 'what is React 19?'\n"
-        "  Latest: 'what about for v18?'\n"
-        "  Output: React v18 features release\n\n"
-        "  Conversation: discussion about Rust borrow checker\n"
-        "  Latest: 'how do I fix it?'\n"
-        "  Output: Rust borrow checker error fix\n\n"
-        "Output ONE line only, max 12 words, no quotes, no preamble, "
-        "no explanation, no 'Output:' prefix.\n\n"
-        "Recent turns:\n" + "\n".join(turns[-4:]) + "\n\n"
-        f"Latest: {latest}\n"
-        "Rewritten query:"
-    )
+        if t.endswith("s") and not t.endswith("ss") and len(t) > 3:
+            t = t[:-1]
+        tokens.add(t)
+    for t in re.findall(r"\b[A-Z]{2,5}\b", text):
+        tokens.add(t.lower())
+    return tokens
 
-    # If the latest message has a pronoun and the rewriter doesn't expand it,
-    # the rewrite is useless — retry with the bigger model.
-    has_pronoun = bool(re.search(
-        r"\b(she|he|it|they|them|her|him|its|their|this|that|these|those)\b",
-        latest, re.IGNORECASE,
-    ))
 
-    def _good(rewritten: str) -> bool:
-        if not rewritten:
-            return False
-        # Same as input → useless rewrite.
-        if rewritten.strip().lower() == latest.strip().lower():
-            return False
-        # Pronoun didn't get resolved.
-        if has_pronoun and re.search(
-            r"\b(she|he|it|they|them|her|him|its|their)\b",
-            rewritten, re.IGNORECASE,
-        ):
-            return False
+def _needs_context(latest: str, prior_tokens: set[str] | None = None) -> bool:
+    """True when `latest` is a follow-up that won't search well on its own.
+
+    Triggers on pronouns, vague references ("the one"), follow-up openers
+    ("whos winning?", "any updates?"), short messages (≤6 words), or
+    definite-article anaphora ("the reform party" when "reform" was discussed
+    earlier — the latest message is referring back to a prior topic).
+    """
+    if _PRONOUN_RE.search(latest) or _VAGUE_REF_RE.search(latest):
         return True
-
-    out = await _try_rewrite_call(http, ollama_url, prompt, workspace_model, timeout=8.0)
-    if _good(out):
-        print(f"[QS]   rewrite via {workspace_model!r}: {latest[:60]!r} → {out!r}")
-        return out
-
-    # Workspace model failed or didn't resolve pronouns — try the default model.
-    if default_model and default_model != workspace_model:
-        why = "didn't expand pronouns" if (out and has_pronoun) else "returned empty"
-        print(f"[QS]   rewrite via {workspace_model!r} {why}, retrying with {default_model!r}")
-        out = await _try_rewrite_call(http, ollama_url, prompt, default_model, timeout=15.0)
-        if _good(out):
-            print(f"[QS]   rewrite via {default_model!r}: {latest[:60]!r} → {out!r}")
-            return out
-
-    print(f"[QS]   rewrite failed, using raw query: {latest[:80]!r}")
-    return fallback
+    if _FOLLOWUP_STARTERS_RE.match(latest):
+        return True
+    if len(re.findall(r"\b\w+\b", latest)) <= 6:
+        return True
+    # Anaphoric "the X" / "that X" / "this X" where X was discussed earlier.
+    # Catches long messages like "what is the reform party and how does it
+    # compare to..." where the noun is anchored in prior turns rather than
+    # being a fresh topic introduction.
+    if prior_tokens:
+        for noun in re.findall(
+            r"\b(?:the|that|this)\s+([a-zA-Z][a-zA-Z-]{2,})\b",
+            latest, re.IGNORECASE,
+        ):
+            n = noun.lower()
+            if n.endswith("s") and not n.endswith("ss") and len(n) > 3:
+                n = n[:-1]
+            if n in prior_tokens:
+                return True
+    return False
 
 
 # ── Filtering / ranking / dedup ──
@@ -197,15 +174,101 @@ def _dedupe_by_domain(results: list, max_per_domain: int = 2) -> list:
     return out
 
 
-def _rank_and_filter_for_chat(results: list) -> list:
-    """For model context: drop YouTube/image, rank by quality, dedup, keep top 6."""
+# ── Query classification → domain-aware ranking ──
+# Each category maps to (a) keywords that detect it from the search query
+# and (b) domains we want to demote when results in that category come back.
+# We *demote*, not delete — sometimes a Stack Overflow link IS what someone
+# wants for a political question (e.g. data analysis of polling) — they just
+# shouldn't outrank actual news outlets.
+_NEWS_RE = re.compile(
+    r"\b(election|vote|votes|voter|poll|polls|polling|"
+    r"president|prime\s+minister|\bpm\b|government|parliament|"
+    r"congress|senate|cabinet|minister|"
+    r"war|attack|protest|economy|inflation|recession|"
+    r"news|breaking|recent|today|yesterday|"
+    r"labour|conservative|democrat|republican|tory|tories|reform|liberal|"
+    r"green\s+party|farage|starmer|biden|trump|harris|"
+    r"\b20[2-3]\d\b|"
+    r"died|killed|elected|resigned|appointed|sworn\s+in)\b",
+    re.IGNORECASE,
+)
+_CODE_RE = re.compile(
+    r"\b(function|method|variable|exception|stack\s+trace|traceback|"
+    r"compile|debug|syntax\s+error|regex|pip\b|npm\b|cargo|docker|kubernetes|k8s|"
+    r"python|javascript|typescript|rust|golang|kotlin|swift|ruby|"
+    r"react|vue|angular|node\.?js|django|flask|rails|spring|fastapi|"
+    r"github|gitlab|repo|commit|branch|merge|pull\s+request|"
+    r"sql|postgres|mysql|sqlite|mongodb|redis|"
+    r"endpoint|http\b|json|xml|yaml|"
+    r"linux|ubuntu|bash|zsh|terminal|"
+    r"\.py\b|\.js\b|\.ts\b|\.rs\b|\.cpp|\.java\b)\b",
+    re.IGNORECASE,
+)
+_RECIPE_RE = re.compile(
+    r"\b(recipe|cook|cooking|bake|baking|ingredient|calorie|"
+    r"breakfast|lunch|dinner|dessert|salad|soup|sauce|"
+    r"vegetarian|vegan|gluten[\s-]free|keto|paleo)\b",
+    re.IGNORECASE,
+)
+
+_DOWNRANK_DOMAINS: dict[str, frozenset[str]] = {
+    "news": frozenset({
+        "stackoverflow.com", "stackexchange.com", "askubuntu.com",
+        "serverfault.com", "superuser.com", "geeksforgeeks.org",
+        "tutorialspoint.com", "w3schools.com", "github.com", "gitlab.com",
+        "leetcode.com", "hackerrank.com", "freecodecamp.org",
+    }),
+    "code": frozenset({
+        "cnn.com", "bbc.com", "bbc.co.uk", "foxnews.com", "msnbc.com",
+        "nbcnews.com", "abcnews.go.com", "cbsnews.com",
+        "nytimes.com", "washingtonpost.com", "bloomberg.com",
+        "theguardian.com", "telegraph.co.uk", "dailymail.co.uk",
+        "allrecipes.com", "foodnetwork.com", "epicurious.com",
+    }),
+    "recipe": frozenset({
+        "stackoverflow.com", "github.com", "gitlab.com",
+        "cnn.com", "bbc.com", "reuters.com", "nytimes.com",
+    }),
+    "general": frozenset(),
+}
+
+
+def _classify_query(q: str) -> str:
+    """Rough query category for domain-aware ranking."""
+    if _NEWS_RE.search(q):
+        return "news"
+    if _CODE_RE.search(q):
+        return "code"
+    if _RECIPE_RE.search(q):
+        return "recipe"
+    return "general"
+
+
+def _apply_domain_bias(results: list, category: str) -> list:
+    """Push downranked-for-category domains to the bottom; keep order otherwise."""
+    bad = _DOWNRANK_DOMAINS.get(category) or frozenset()
+    if not bad:
+        return results
+    keep, defer = [], []
+    for r in results:
+        d = _registrable_domain(r.get("url", ""))
+        (defer if d in bad else keep).append(r)
+    return keep + defer
+
+
+def _rank_and_filter_for_chat(results: list, query: str = "") -> list:
+    """For model context: drop YouTube/image, rank by quality, dedup, apply
+    category bias against off-fit domains, keep top 6.
+    """
     text_only = [r for r in results if r.get("type", "web") not in ("youtube", "image")]
     ranked_urls = _rank_urls(text_only)
     by_url = {r.get("url"): r for r in text_only if r.get("url")}
     ranked = [by_url[u] for u in ranked_urls if u in by_url]
     seen = {r.get("url") for r in ranked}
     leftover = [r for r in text_only if r.get("url") not in seen]
-    return _dedupe_by_domain(ranked + leftover, max_per_domain=2)[:6]
+    deduped = _dedupe_by_domain(ranked + leftover, max_per_domain=2)
+    biased = _apply_domain_bias(deduped, _classify_query(query))
+    return biased[:6]
 
 
 # ── Selective page fetch when snippets are too thin to answer from ──
@@ -365,104 +428,36 @@ async def _enrich_og_images(http, results: list, max_fetch: int = 6) -> None:
 
 async def run_quick_search_for_chat(
     http, ollama_url: str, workspace_model: str, events, conv_id: str, messages: list,
-    *, default_model: str = "",
+    *, default_model: str = "", chat_model: str = "",
 ) -> dict:
     """Used by `agents/chat.py` to inject fresh search context.
 
+    Dispatches to `search_agent.run_search_agent` for the full multi-round
+    pipeline (skip-gate → triage → parallel SearXNG → relevance check →
+    optional refine → fetch → context build).
+
+    Triage model selection: explicit `QUICK_SEARCH_TRIAGE_MODEL` override,
+    otherwise the small workspace model (fast — ~1-2s per call vs 10-30s on a
+    27B chat model — and on multi-GPU / sufficient-VRAM setups it stays
+    co-resident with the chat model so there's no swap penalty), otherwise
+    the chat model, otherwise the default.
+
     Returns: {"context": str, "rewritten_query": str, "skipped": bool, "reason": str}
     """
-    latest = ""
-    for m in reversed(messages):
-        if m.get("role") == "user" and m.get("content"):
-            latest = m["content"].strip()
-            break
-    if not latest:
-        return {"context": "", "rewritten_query": "", "skipped": True, "reason": "no user message"}
-
-    skip, reason = _should_skip(latest)
-    if skip:
-        if events and conv_id:
-            try:
-                await events.emit(conv_id, "tool_done", {
-                    "tool": "quick_search", "icon": "search",
-                    "status": f"Skipped ({reason})",
-                })
-            except Exception:
-                pass
-        return {"context": "", "rewritten_query": "", "skipped": True, "reason": reason}
-
-    if events and conv_id:
-        try:
-            await events.emit(conv_id, "tool_start", {
-                "tool": "quick_search",
-                "status": f"Searching: {latest[:60]}",
-                "icon": "search",
-            })
-        except Exception:
-            pass
-
-    rewritten = await _rewrite_query(
-        http, ollama_url, workspace_model, default_model or workspace_model, messages, latest,
+    triage_model = (
+        getattr(config, "QUICK_SEARCH_TRIAGE_MODEL", "")
+        or workspace_model
+        or chat_model
+        or default_model
     )
-
-    # Always show the actual search query in the UI — whether rewritten or raw.
-    if events and conv_id:
-        try:
-            label = (
-                f"→ {rewritten[:80]}" if rewritten.strip() != latest.strip()
-                else f"(no rewrite) {rewritten[:80]}"
-            )
-            await events.emit(conv_id, "tool_progress", {
-                "tool": "quick_search", "icon": "search", "status": label,
-            })
-        except Exception:
-            pass
-
-    raw = await _cached_search(http, rewritten)
-    if not raw:
-        if events and conv_id:
-            try:
-                await events.emit(conv_id, "tool_done", {
-                    "tool": "quick_search", "icon": "search",
-                    "status": "No results found",
-                })
-            except Exception:
-                pass
-        return {"context": "", "rewritten_query": rewritten, "skipped": False, "reason": "no results"}
-
-    top = _rank_and_filter_for_chat(raw)
-
-    # Page-fetch (for thin snippets) and OG-image enrichment run in parallel —
-    # they hit the same top URLs but extract different signals. Without OG
-    # enrichment, web-type SearXNG results often have no thumbnail and the
-    # model has no images to embed.
-    page_text, _ = await asyncio.gather(
-        _enrich_with_pages(http, top, top_n=3),
-        _enrich_og_images(http, top, max_fetch=4),
-        return_exceptions=False,
+    # Lazy import to avoid circular dependency — search_agent imports helpers
+    # from this module.
+    from search_agent import run_search_agent
+    return await run_search_agent(
+        http, ollama_url, triage_model, triage_model,
+        events, conv_id, messages,
+        default_model=default_model or workspace_model,
     )
-
-    # Top 2-3 image candidates (proxied) the model is allowed to embed
-    allowed: set[str] = set()
-    for r in top:
-        thumb = r.get("thumbnail")
-        if thumb and len(allowed) < 3:
-            allowed.add(proxy_image_url(thumb))
-    print(f"[QS]   image candidates: {len(allowed)} (of {sum(1 for r in top if r.get('thumbnail'))} thumbs)")
-
-    ctx = _build_context(top, rewritten, page_text, allowed)
-
-    if events and conv_id:
-        try:
-            await events.emit(conv_id, "tool_done", {
-                "tool": "quick_search", "icon": "search",
-                "status": f"Found {len(top)} result{'s' if len(top) != 1 else ''}",
-            })
-        except Exception:
-            pass
-
-    print(f"[QS]   {len(top)} results for {rewritten!r} (was {latest[:60]!r})")
-    return {"context": ctx, "rewritten_query": rewritten, "skipped": False, "reason": ""}
 
 
 async def run_quick_search_for_api(http, query: str, count: int = 6) -> dict:

--- a/backend/quick_search.py
+++ b/backend/quick_search.py
@@ -3,30 +3,93 @@ Quick search — shared helper for chat injection (`agents/chat.py`) and the
 standalone `/api/quick-search` endpoint (`main.py`).
 
 Pipeline (chat path): dispatches to `search_agent.run_search_agent`, which
-runs skip-gate → triage (LLM, JSON-mode) → parallel SearXNG → relevance
-check → optional refine → page/OG-image enrichment → context build.
+runs skip-gate → triage (LLM, JSON-mode, returns standalone_query +
+queries + category) → per-conversation subquery dedup → parallel SearXNG
+(time_range="month" for news + recency cue) → heuristic rank + category
+bias → embedding rerank/dedup against nomic-embed-text → relevance check
+(prior-tokens-aware for follow-ups) → optional refine → trafilatura page
+extraction + OG-image enrichment → context build.
 
-This module hosts the shared helpers the agent reuses (skip-gate regexes,
-content-token extraction, follow-up detection, SearXNG cache, ranking +
-domain bias, page fetch, OG-image enrichment, context builder, image
-proxy URL builder). The agent itself lives in `search_agent.py`.
+This module hosts the shared helpers the agent reuses: skip-gate regexes,
+content-token extraction, follow-up detection, bounded LRU SearXNG cache,
+per-conversation subquery dedup, ranking + domain bias, embedding-batch
+helper, fetch concurrency semaphore, SSRF guard, trafilatura page
+extraction, OG-image enrichment, context builder, image proxy URL builder.
+The agent itself lives in `search_agent.py`.
 
 Standalone API path (`run_quick_search_for_api`) skips triage and page-fetch
 and returns carousel-shaped data (with OG-image enrichment).
 """
 import asyncio
+import ipaddress
+import math
+import os
 import re
+import socket
 import time
 import urllib.parse
+from collections import OrderedDict
 from datetime import datetime
 
 import config
-from research import _search_searxng, _fetch_page, _rank_urls
+from research import _search_searxng, _rank_urls
 
 
-# ── 10-min TTL cache, keyed by query string ──
-_CACHE: dict[str, tuple[float, list]] = {}
+# ── 10-min TTL cache, keyed by (query, time_range), bounded LRU ──
+_CACHE: "OrderedDict[tuple[str, str | None], tuple[float, list]]" = OrderedDict()
 _CACHE_TTL = 600
+_CACHE_MAX = 512
+
+
+# ── Concurrency cap on outbound HTTP fetches ──
+# SearXNG fanout (3 queries) + page-fetch (3) + OG-image-fetch (4) +
+# refine-search (1) can hit ~11 concurrent outbound HTTPs against a
+# single LXC instance routed through ProtonVPN. Cap page+OG fetches
+# to smooth bursts. SearXNG already has internal 429 retry so we
+# don't gate it here.
+_FETCH_SEMA = asyncio.Semaphore(6)
+
+
+# ── Per-conversation subquery dedup (Khoj pattern) ──
+# When the user iterates on a topic, triage often re-emits queries already
+# searched in earlier turns. Track them per-conversation so we skip the
+# redundant SearXNG round-trip.
+_PREV_SUBQUERIES: "OrderedDict[str, tuple[float, set[str]]]" = OrderedDict()
+_PREV_SUBQUERIES_TTL = 3600  # 1 hour
+_PREV_SUBQUERIES_MAX = 256
+
+
+def _filter_novel_queries(conv_id: str, queries: list[str]) -> list[str]:
+    """Return queries not seen in this conversation. Adds them to the set.
+
+    Lowercase-normalized comparison. Always preserves at least one query —
+    if every query is a duplicate, we still let the latest one through so
+    the agent doesn't return empty-handed when the user repeats a question.
+    """
+    if not conv_id or not queries:
+        return queries
+    now = time.time()
+    entry = _PREV_SUBQUERIES.get(conv_id)
+    if entry and (now - entry[0]) < _PREV_SUBQUERIES_TTL:
+        seen = entry[1]
+    else:
+        seen = set()
+    novel: list[str] = []
+    for q in queries:
+        key = q.strip().lower()
+        if key and key not in seen:
+            novel.append(q)
+            seen.add(key)
+    if not novel:
+        # All duplicates — let the first one through anyway. Caches downstream
+        # will absorb the cost; the user gets fresh ranking against current
+        # standalone_query.
+        novel = [queries[0]]
+    _PREV_SUBQUERIES[conv_id] = (now, seen)
+    _PREV_SUBQUERIES.move_to_end(conv_id)
+    while len(_PREV_SUBQUERIES) > _PREV_SUBQUERIES_MAX:
+        _PREV_SUBQUERIES.popitem(last=False)
+    return novel
 
 
 # ── Skip-gate: only skip when search is clearly pointless ──
@@ -256,9 +319,15 @@ def _apply_domain_bias(results: list, category: str) -> list:
     return keep + defer
 
 
-def _rank_and_filter_for_chat(results: list, query: str = "") -> list:
+def _rank_and_filter_for_chat(
+    results: list, query: str = "", category: str | None = None,
+) -> list:
     """For model context: drop YouTube/image, rank by quality, dedup, apply
     category bias against off-fit domains, keep top 6.
+
+    `category` should come from triage when available — it has full
+    conversation context. Falls back to regex query-classification when
+    not supplied (triage-failure path).
     """
     text_only = [r for r in results if r.get("type", "web") not in ("youtube", "image")]
     ranked_urls = _rank_urls(text_only)
@@ -267,8 +336,133 @@ def _rank_and_filter_for_chat(results: list, query: str = "") -> list:
     seen = {r.get("url") for r in ranked}
     leftover = [r for r in text_only if r.get("url") not in seen]
     deduped = _dedupe_by_domain(ranked + leftover, max_per_domain=2)
-    biased = _apply_domain_bias(deduped, _classify_query(query))
+    cat = category if category in _DOWNRANK_DOMAINS else _classify_query(query)
+    biased = _apply_domain_bias(deduped, cat)
     return biased[:6]
+
+
+# ── Embedding-based rerank + dedup (Perplexica pattern) ──
+# Batched embed call against Ollama's nomic-embed-text. We score every
+# snippet against the standalone query (cosine sim, drop below 0.45),
+# then drop near-duplicate pairs (sim > 0.85) — catches the SearXNG
+# mirror problem where the same article comes back via 3 different
+# domains with different titles.
+#
+# Falls back to the input order on any Ollama error so the pipeline
+# is strictly best-effort over the legacy ranking.
+_EMBED_MODEL = os.getenv("EMBED_MODEL", "nomic-embed-text")
+_EMBED_QUERY_FLOOR = 0.45
+_EMBED_DUP_THRESHOLD = 0.85
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+async def _ollama_embed_batch(http, ollama_url: str, texts: list[str]) -> list[list[float]] | None:
+    """Single batched embed call. Returns list of embeddings (same order as
+    input) or None on any failure. Tries the modern /api/embed endpoint
+    first, falls back to per-prompt /api/embeddings calls if the batch
+    endpoint is unavailable.
+    """
+    if not texts:
+        return []
+    try:
+        r = await http.post(
+            f"{ollama_url}/api/embed",
+            json={"model": _EMBED_MODEL, "input": texts, "keep_alive": "10m"},
+            timeout=15,
+        )
+        if r.status_code == 200:
+            body = r.json()
+            embs = body.get("embeddings")
+            if isinstance(embs, list) and len(embs) == len(texts):
+                return embs
+    except Exception as e:
+        print(f"[QS]   /api/embed failed, falling back: {type(e).__name__}: {e!r}")
+    # Fallback: parallel per-prompt calls against the legacy endpoint
+    try:
+        results = await asyncio.gather(
+            *[
+                http.post(
+                    f"{ollama_url}/api/embeddings",
+                    json={"model": _EMBED_MODEL, "prompt": t, "keep_alive": "10m"},
+                    timeout=10,
+                )
+                for t in texts
+            ],
+            return_exceptions=True,
+        )
+        embs: list[list[float]] = []
+        for r in results:
+            if isinstance(r, Exception):
+                return None
+            if r.status_code != 200:
+                return None
+            e = r.json().get("embedding")
+            if not isinstance(e, list):
+                return None
+            embs.append(e)
+        return embs
+    except Exception as e:
+        print(f"[QS]   /api/embeddings fallback failed: {type(e).__name__}: {e!r}")
+        return None
+
+
+async def _embed_score_and_dedup(
+    http, ollama_url: str, query: str, results: list,
+) -> list:
+    """Score each result against `query`, drop sim < 0.45, dedup near-dups
+    (sim > 0.85), sort by query-similarity desc.
+
+    Returns the input list unchanged on any embed failure.
+    """
+    if not results or not query:
+        return results
+    snippet_texts = [
+        ((r.get("title") or "") + " " + (r.get("content") or r.get("snippet") or ""))[:600]
+        for r in results
+    ]
+    embs = await _ollama_embed_batch(http, ollama_url, [query] + snippet_texts)
+    if not embs or len(embs) != len(results) + 1:
+        return results
+    q_emb = embs[0]
+    snip_embs = embs[1:]
+
+    scored: list[tuple[float, int]] = []
+    for i, e in enumerate(snip_embs):
+        s = _cosine(q_emb, e)
+        if s >= _EMBED_QUERY_FLOOR:
+            scored.append((s, i))
+    if not scored:
+        # Everything scored below the floor — likely a tail-end query the
+        # embed model isn't great at. Keep input order rather than zero out.
+        print(f"[QS]   embed: all results below floor {_EMBED_QUERY_FLOOR}; preserving order")
+        return results
+    scored.sort(key=lambda x: -x[0])
+
+    # Dedup: walk in score order, drop any item whose snippet embedding is
+    # > _EMBED_DUP_THRESHOLD from a kept item.
+    kept_indices: list[int] = []
+    for score, idx in scored:
+        is_dup = False
+        for kept_i in kept_indices:
+            if _cosine(snip_embs[idx], snip_embs[kept_i]) > _EMBED_DUP_THRESHOLD:
+                is_dup = True
+                break
+        if not is_dup:
+            kept_indices.append(idx)
+
+    out = [results[i] for i in kept_indices]
+    print(f"[QS]   embed-rerank: {len(results)} → {len(out)} (top sim={scored[0][0]:.2f})")
+    return out
 
 
 # ── Selective page fetch when snippets are too thin to answer from ──
@@ -278,6 +472,15 @@ _MENU_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Trafilatura is the de-facto standard Python article extractor. Optional —
+# we fall back to the same regex strip _fetch_page uses if it's not installed
+# or fails on a particular page.
+try:
+    import trafilatura  # type: ignore
+    _HAS_TRAFILATURA = True
+except Exception:
+    _HAS_TRAFILATURA = False
+
 
 def _looks_thin(snippet: str) -> bool:
     s = (snippet or "").strip()
@@ -286,17 +489,91 @@ def _looks_thin(snippet: str) -> bool:
     return bool(_MENU_RE.search(s))
 
 
+def _regex_strip_html(text: str) -> str:
+    """Same strip logic as research._fetch_page — kept inline so we can run
+    trafilatura first on the same HTML we already fetched, falling back here
+    without paying for a second HTTP round-trip."""
+    for tag in ["script", "style", "nav", "header", "footer", "aside", "noscript"]:
+        text = re.sub(rf"<{tag}[^>]*>.*?</{tag}>", "", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<h[1-3][^>]*>(.*?)</h[1-3]>", r"\n## \1\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<li[^>]*>(.*?)</li>", r"\n• \1", text, flags=re.IGNORECASE | re.DOTALL)
+    text = re.sub(r"<p[^>]*>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"&amp;", "&", text)
+    text = re.sub(r"&lt;", "<", text)
+    text = re.sub(r"&gt;", ">", text)
+    text = re.sub(r"&nbsp;", " ", text)
+    text = re.sub(r"&\w+;", " ", text)
+    text = re.sub(r"-----BEGIN PGP [A-Z ]+-----.*?-----END PGP [A-Z ]+-----",
+                  "[PGP block removed]", text, flags=re.DOTALL)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n\s*\n\s*\n+", "\n\n", text).strip()
+    return text
+
+
+_FETCH_SKIP = ["youtube.com", "twitter.com", "x.com", "facebook.com", "instagram.com",
+               ".pdf", "linkedin.com", "tiktok.com",
+               "snopes.com", "politifact.com", "factcheck.org", "leadstories.com",
+               "fullfact.org", "mediabiasfactcheck.com"]
+
+
+async def _fetch_clean_page(http, url: str) -> dict | None:
+    """Single-fetch page extraction. Tries trafilatura on the response HTML;
+    falls back to the same regex strip research._fetch_page uses, on the
+    same already-fetched HTML (no double round-trip).
+
+    Returns {"url", "content"} or None.
+    """
+    if any(s in url.lower() for s in _FETCH_SKIP):
+        return None
+    try:
+        async with _FETCH_SEMA:
+            r = await http.get(
+                url, timeout=15, follow_redirects=True,
+                headers={"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                                       "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"},
+            )
+        if r.status_code >= 400:
+            return None
+        ct = r.headers.get("content-type", "")
+        if "text" not in ct and "html" not in ct and "json" not in ct:
+            return None
+        html = r.text
+    except Exception:
+        return None
+
+    if _HAS_TRAFILATURA:
+        try:
+            extracted = trafilatura.extract(
+                html, include_comments=False, include_tables=True,
+                favor_precision=True, no_fallback=False,
+            )
+            if extracted and len(extracted) >= 200:
+                return {"url": url, "content": extracted[:6000]}
+        except Exception as e:
+            print(f"[QS]   trafilatura failed for {url}: {type(e).__name__}: {e!r}")
+
+    text = _regex_strip_html(html)
+    if len(text) < 200:
+        return None
+    return {"url": url, "content": text[:6000]}
+
+
 async def _enrich_with_pages(http, results: list, top_n: int = 3) -> dict[str, str]:
     targets = [
         r["url"] for r in results[:top_n]
-        if r.get("url") and _looks_thin(r.get("content") or r.get("snippet", ""))
+        if r.get("url")
+        and _looks_thin(r.get("content") or r.get("snippet", ""))
+        and _url_safe(r["url"])
     ]
     if not targets:
         return {}
+
     try:
         fetched = await asyncio.wait_for(
-            asyncio.gather(*[_fetch_page(http, u) for u in targets], return_exceptions=True),
-            timeout=4.0,
+            asyncio.gather(*[_fetch_clean_page(http, u) for u in targets], return_exceptions=True),
+            timeout=8.0,
         )
     except asyncio.TimeoutError:
         return {}
@@ -305,6 +582,61 @@ async def _enrich_with_pages(http, results: list, top_n: int = 3) -> dict[str, s
         if isinstance(f, dict) and f.get("url") and f.get("content"):
             out[f["url"]] = f["content"][:1500]
     return out
+
+
+# ── SSRF guard ──
+# A malicious search result can redirect to a private/internal address. Resolve
+# the hostname and reject if any answer is private, loopback, link-local, or
+# multicast. Resolution failures also reject (safe default).
+_DNS_CACHE: dict[str, tuple[float, bool]] = {}
+_DNS_CACHE_TTL = 300  # 5 min — DNS rarely flips faster than that for our use
+
+
+def _url_safe(url: str) -> bool:
+    """True if URL hostname resolves to public, routable IPs only."""
+    try:
+        host = urllib.parse.urlparse(url).hostname
+    except Exception:
+        return False
+    if not host:
+        return False
+    host = host.lower()
+
+    # Reject literal private IP hostnames before DNS lookup
+    try:
+        ip = ipaddress.ip_address(host)
+        return _ip_is_public(ip)
+    except ValueError:
+        pass  # not a literal IP — fall through to DNS
+
+    now = time.time()
+    cached = _DNS_CACHE.get(host)
+    if cached and (now - cached[0]) < _DNS_CACHE_TTL:
+        return cached[1]
+    try:
+        infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except (socket.gaierror, socket.herror, OSError):
+        _DNS_CACHE[host] = (now, False)
+        return False
+    safe = True
+    for info in infos:
+        try:
+            ip = ipaddress.ip_address(info[4][0])
+        except ValueError:
+            safe = False
+            break
+        if not _ip_is_public(ip):
+            safe = False
+            break
+    _DNS_CACHE[host] = (now, safe)
+    return safe
+
+
+def _ip_is_public(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return not (
+        ip.is_private or ip.is_loopback or ip.is_link_local
+        or ip.is_multicast or ip.is_reserved or ip.is_unspecified
+    )
 
 
 # ── Image proxy URL builder ──
@@ -350,16 +682,28 @@ def _build_context(results: list, query: str, page_text: dict[str, str], allowed
 
 
 # ── Cached SearXNG (safesearch=0 per project config) ──
-async def _cached_search(http, query: str, count: int = 10) -> list:
+async def _cached_search(
+    http, query: str, count: int = 10, time_range: str | None = None,
+) -> list:
+    """Cached SearXNG search. Cache key is (query, time_range) so news
+    queries with time_range=month don't collide with evergreen searches
+    of the same string.
+    """
     now = time.time()
-    cached = _CACHE.get(query)
+    key = (query, time_range)
+    cached = _CACHE.get(key)
     if cached and (now - cached[0]) < _CACHE_TTL:
+        _CACHE.move_to_end(key)
         return cached[1]
     results = await _search_searxng(
-        http, config.SEARXNG_URL, query, count=count, safesearch="0",
+        http, config.SEARXNG_URL, query, count=count,
+        safesearch="0", time_range=time_range,
     )
     if results:
-        _CACHE[query] = (now, results)
+        _CACHE[key] = (now, results)
+        _CACHE.move_to_end(key)
+        while len(_CACHE) > _CACHE_MAX:
+            _CACHE.popitem(last=False)
     return results
 
 
@@ -382,16 +726,19 @@ _OG_SKIP = ["youtube.com", "twitter.com", "x.com", "facebook.com", "instagram.co
 async def _fetch_og_image(http, page_url: str) -> str:
     if any(s in page_url.lower() for s in _OG_SKIP):
         return ""
+    if not _url_safe(page_url):
+        return ""
     try:
-        resp = await http.get(
-            page_url, timeout=6, follow_redirects=True,
-            headers={
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-                              "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-                "Accept-Language": "en-US,en;q=0.5",
-            },
-        )
+        async with _FETCH_SEMA:
+            resp = await http.get(
+                page_url, timeout=6, follow_redirects=True,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                                  "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+                    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                    "Accept-Language": "en-US,en;q=0.5",
+                },
+            )
         html = resp.text[:30000]
         for pattern in _OG_PATTERNS:
             m = re.search(pattern, html, re.IGNORECASE)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ aiosqlite==0.20.0
 python-multipart==0.0.12
 pypdf>=4.0.0
 chromadb>=0.4.0
+trafilatura>=1.10.0

--- a/backend/research.py
+++ b/backend/research.py
@@ -443,11 +443,13 @@ def _rank_urls(findings: list, exclude: set = None) -> list:
 
 async def _ask_ollama(http, ollama_url: str, prompt: str, model: str = None, default_model: str = "qwen3.5:27b", max_tokens: int = 4096) -> str:
     """Call Ollama for AI synthesis."""
+    import config as _cfg
+    _num_ctx = _cfg.DEFAULT_NUM_CTX or 16384
     try:
         r = await http.post(f"{ollama_url}/api/generate", json={
             "model": model or default_model,
             "prompt": prompt, "stream": False,
-            "options": {"temperature": 0.3, "num_predict": max_tokens},
+            "options": {"temperature": 0.3, "num_predict": max_tokens, "num_ctx": _num_ctx},
         }, timeout=180)
         data = r.json()
         return (data.get("response", "") or "").strip()
@@ -461,13 +463,15 @@ async def _ask_ollama_streamed(
     max_tokens: int = 4096, status_prefix: str = "🧠 Synthesizing",
 ) -> str:
     """Stream from Ollama, emitting periodic status events so the user sees live progress."""
+    import config as _cfg
+    _num_ctx = _cfg.DEFAULT_NUM_CTX or 16384
     accumulated = ""
     last_emit_len = 0
     try:
         async with http.stream("POST", f"{ollama_url}/api/generate", json={
             "model": model or default_model,
             "prompt": prompt, "stream": True,
-            "options": {"temperature": 0.3, "num_predict": max_tokens},
+            "options": {"temperature": 0.3, "num_predict": max_tokens, "num_ctx": _num_ctx},
         }, timeout=300) as stream:
             async for line in stream.aiter_lines():
                 if not line.strip():

--- a/backend/research.py
+++ b/backend/research.py
@@ -57,13 +57,19 @@ async def _search_google_fallback(http, query: str, count: int = 10) -> list:
         return []
 
 
-async def _search_searxng(http, searxng_url: str, query: str, count: int = 10, categories: str = "general", safesearch: str | None = None) -> list:
-    """Search SearXNG and return structured results. Falls back to Google scrape if SearXNG returns nothing."""
+async def _search_searxng(http, searxng_url: str, query: str, count: int = 10, categories: str = "general", safesearch: str | None = None, time_range: str | None = None) -> list:
+    """Search SearXNG and return structured results. Falls back to Google scrape if SearXNG returns nothing.
+
+    `time_range`: SearXNG accepts day|week|month|year. Set to "month" for news
+    queries with explicit time-cues so 2019 articles don't outrank current ones.
+    """
     results = []
     try:
         _params = {"q": query, "format": "json", "language": "en", "categories": categories}
         if safesearch is not None:
             _params["safesearch"] = safesearch
+        if time_range:
+            _params["time_range"] = time_range
         params = urllib.parse.urlencode(_params)
         r = await http.get(f"{searxng_url}/search?{params}", timeout=12)
         if r.status_code == 429:
@@ -89,7 +95,10 @@ async def _search_searxng(http, searxng_url: str, query: str, count: int = 10, c
                     vid_id = url.split("youtu.be/")[1].split("?")[0].split("/")[0]
                 if vid_id:
                     thumbnail = f"https://img.youtube.com/vi/{vid_id}/mqdefault.jpg"
-            elif thumbnail or any(url_lower.endswith(ext) for ext in [".jpg", ".jpeg", ".png", ".gif", ".webp"]):
+            elif any(url_lower.endswith(ext) for ext in [".jpg", ".jpeg", ".png", ".gif", ".webp"]):
+                # The URL itself points at an image file. A web page that
+                # merely advertises an og:image thumbnail is still a "web"
+                # result — keep its type so the chat ranker doesn't drop it.
                 r_type = "image"
             results.append({
                 "title": item.get("title", ""), "url": url,

--- a/backend/search_agent.py
+++ b/backend/search_agent.py
@@ -1,0 +1,496 @@
+"""
+Multi-round search agent — replaces single-shot `_rewrite_query` + search +
+fetch with an internal loop that:
+
+  1. triage()        — one LLM call (JSON-mode) returns {needs_search, queries,
+                        category}. Replaces today's three-stage rewrite chain.
+  2. parallel search — 1-3 SearXNG calls fanned out at once.
+  3. relevance check — cheap content-token overlap heuristic. No LLM.
+  4. refine          — if relevance is low and rounds remain, ask the model
+                        for ONE different query and search once more.
+  5. fetch + context — same OG-image / page-text enrichment as legacy.
+
+Falls back to legacy `_rewrite_query` on any triage failure — never a
+regression vs today's behavior. Keeps the same return shape:
+  {"context": str, "rewritten_query": str, "skipped": bool, "reason": str}
+
+Reuses helpers from `quick_search`: `_content_tokens`, `_cached_search`,
+`_rank_and_filter_for_chat`, `_enrich_with_pages`, `_enrich_og_images`,
+`_build_context`, `proxy_image_url`, `_rewrite_query`.
+"""
+import asyncio
+import json
+import re
+from typing import Any
+
+import quick_search as _qs
+
+
+_VALID_CATEGORIES = ("news", "code", "recipe", "general")
+_REFINE_THRESHOLD_DEFAULT = 0.30
+
+
+# ── JSON-mode Ollama call ──
+async def _ask_ollama_json(
+    http, ollama_url: str, prompt: str, model: str,
+    max_tokens: int = 200, timeout: float = 45.0,
+) -> dict | None:
+    """Single Ollama call with format='json'. Returns parsed dict or None on
+    any failure (network, non-JSON, empty).
+
+    Default timeout 45s allows for cold-load on a large chat model — the
+    triage stage is per-turn so worst case is one slow first turn after a
+    long idle, then the model stays warm in Ollama's keep-alive.
+    """
+    raw = ""
+    try:
+        r = await asyncio.wait_for(
+            http.post(f"{ollama_url}/api/generate", json={
+                "model": model,
+                "prompt": prompt,
+                "stream": False,
+                "format": "json",
+                # Reasoning-mode models (qwen3.5, deepseek-r1, etc.) emit a
+                # <think> block; with format=json that block ends up in the
+                # `thinking` field and `response` comes back empty. Disable
+                # thinking for this short structured call — we want the JSON
+                # directly, not chain-of-thought.
+                "think": False,
+                "options": {
+                    "temperature": 0.2,
+                    "num_predict": max_tokens,
+                    # Cap KV-cache to what triage actually needs (prompt is
+                    # ~3KB ≈ 1000 tokens, output is ≤240 tokens). Without
+                    # this, Ollama allocates the model's default num_ctx
+                    # (often 16-32K) which on a 4B can balloon to 15-20GB
+                    # of VRAM and evict a co-resident chat model — turning
+                    # ~1s triage into ~25s under contention.
+                    "num_ctx": 4096,
+                },
+                "keep_alive": "10m",
+            }, timeout=timeout),
+            timeout=timeout + 2,
+        )
+    except Exception as e:
+        # httpx errors often have empty str() — use repr so the cause is visible
+        print(f"[SA]   ollama JSON call failed: {type(e).__name__}: {e!r}")
+        return None
+    try:
+        body = r.json()
+        raw = (body.get("response", "") or "").strip()
+        # Fallback: some Ollama versions / model templates ignore think=False
+        # and put structured output in the `thinking` field anyway. Read it
+        # if response is empty.
+        if not raw:
+            raw = (body.get("thinking", "") or "").strip()
+        if not raw:
+            print(f"[SA]   ollama returned empty response and thinking (status={getattr(r, 'status_code', '?')})")
+            return None
+        # format=json should give us valid JSON, but some models still wrap
+        # in code fences or trailing text. Strip a leading ```json fence and
+        # take the first {...} block as a safety net.
+        raw = re.sub(r"^```(?:json)?\s*", "", raw).rstrip("`").strip()
+        m = re.search(r"\{[\s\S]*\}", raw)
+        if m:
+            raw = m.group(0)
+        return json.loads(raw)
+    except Exception as e:
+        print(f"[SA]   JSON parse failed: {type(e).__name__}: {e!r} (raw[:200]={raw[:200]!r})")
+        return None
+
+
+# ── Triage ──
+def _build_triage_prompt(turns: list[str], latest: str) -> str:
+    history_block = "\n".join(turns[-6:]) if turns else "(no prior turns — this is the first message)"
+    return (
+        "You are a search planner. Given the conversation and the user's LATEST "
+        "message, decide whether to search the web and what to search for.\n\n"
+        "Output a single JSON object with EXACTLY these fields:\n"
+        '  "needs_search": boolean\n'
+        '  "queries":      array of 1-3 self-contained search query strings\n'
+        '  "category":     one of "news" | "code" | "recipe" | "general"\n'
+        '  "reason":       short string, ≤80 chars (telemetry only)\n\n'
+        "RULES:\n"
+        "1. The latest message continues the conversation. Resolve pronouns "
+        "(she/he/it/they/this/that), vague references (\"the one\", \"the issue\"), "
+        "and definite-article anaphora (\"the X\" referring to a prior-mentioned "
+        "topic) using the SPECIFIC noun from prior turns.\n"
+        "2. Bare follow-ups — short messages without their own subject "
+        "('whos winning?', 'any updates?', 'what next?') — inherit the topic "
+        "from prior turns.\n"
+        "3. Default to ONE query. Output TWO queries ONLY when the latest "
+        "message explicitly compares two subjects with a comparison word "
+        "('compare', 'vs', 'versus', 'difference between'). Mentioning two "
+        "subjects without explicitly comparing them is still ONE query.\n"
+        "4. Topic shifts — when the latest message clearly introduces a NEW "
+        "subject unrelated to prior turns — ignore the prior turns and search "
+        "only the new topic.\n"
+        "5. Set needs_search=false for: greetings, pure arithmetic, requests "
+        "to rewrite/translate/summarize/proofread attached text, and pure-"
+        "opinion questions ('what do you think of X').\n"
+        "6. Each query: ≤12 words, no quotes, no URLs, no 'site:', no booleans.\n\n"
+        "EXAMPLES BELOW ARE TEMPLATES showing the rule pattern. The entities "
+        "(sourdough, Rust, Brazil, etc.) are placeholders — DO NOT copy them "
+        "into your output unless they actually appear in the user's conversation. "
+        "Adapt the structure to the user's actual topic.\n\n"
+        '  Pattern: pronoun anaphora\n'
+        '    Prior: user asked about sourdough bread\n'
+        '    Latest: "how do I store it?"\n'
+        '    → {"needs_search":true,"queries":["sourdough bread storage"],'
+        '"category":"recipe","reason":"pronoun it → sourdough bread"}\n\n'
+        '  Pattern: bare follow-up inherits topic\n'
+        '    Prior: user asked about Rust borrow checker\n'
+        '    Latest: "any examples?"\n'
+        '    → {"needs_search":true,"queries":["Rust borrow checker examples"],'
+        '"category":"code","reason":"bare follow-up"}\n\n'
+        '  Pattern: topic shift — ignore prior\n'
+        '    Prior: extended discussion about Python async\n'
+        '    Latest: "what is the capital of Brazil?"\n'
+        '    → {"needs_search":true,"queries":["capital of Brazil"],'
+        '"category":"general","reason":"topic shift"}\n\n'
+        '  Pattern: skip greeting\n'
+        '    Prior: (none)\n'
+        '    Latest: "hi"\n'
+        '    → {"needs_search":false,"queries":[],"category":"general","reason":"greeting"}\n\n'
+        '  Pattern: skip operate-on-attached\n'
+        '    Prior: discussing FastAPI deployment\n'
+        '    Latest: "rewrite this paragraph: <paste>"\n'
+        '    → {"needs_search":false,"queries":[],"category":"general","reason":"operate on attached"}\n\n'
+        f"Recent conversation:\n{history_block}\n\n"
+        f"Latest message: {latest}\n\n"
+        "Output JSON only:"
+    )
+
+
+def _validate_triage(out: Any, latest: str, prior_tokens: set[str]) -> dict | None:
+    """Return a sanitized triage dict or None if validation fails."""
+    if not isinstance(out, dict):
+        return None
+    needs = out.get("needs_search")
+    if not isinstance(needs, bool):
+        return None
+    raw_queries = out.get("queries")
+    if not isinstance(raw_queries, list):
+        return None
+    queries: list[str] = []
+    for q in raw_queries[:3]:
+        if not isinstance(q, str):
+            continue
+        q = q.strip().strip('"').strip("'")
+        if not q or len(q) > 200:
+            continue
+        if "http://" in q.lower() or "https://" in q.lower():
+            continue
+        if not _qs._content_tokens(q):
+            # No real content — likely 'yes' or 'okay' hallucinated as a query
+            continue
+        queries.append(q)
+
+    if needs and not queries:
+        return None  # claimed needs_search but produced no usable queries
+    if not needs:
+        queries = []  # consistency: skip → empty
+
+    # Follow-up validation: if latest message is anaphora / pronoun / very short,
+    # at least one query must share a content token with prior turns. This is the
+    # "carry topic forward" guarantee — matches today's _good() check.
+    if needs and prior_tokens and _qs._needs_context(latest, prior_tokens):
+        if not any(_qs._content_tokens(q) & prior_tokens for q in queries):
+            print(f"[SA]   triage queries dropped prior topic: {queries!r}")
+            return None
+
+    cat = out.get("category", "general")
+    if cat not in _VALID_CATEGORIES:
+        cat = "general"
+
+    reason = out.get("reason", "")
+    if not isinstance(reason, str):
+        reason = ""
+
+    return {
+        "needs_search": needs,
+        "queries": queries,
+        "category": cat,
+        "reason": reason[:120],
+    }
+
+
+async def triage(
+    http, ollama_url: str, model: str, messages: list, latest: str,
+) -> dict | None:
+    """Run the triage LLM call. Returns validated dict or None on any failure."""
+    if not model:
+        return None
+    turns: list[str] = []
+    for m in messages[-6:]:
+        role = m.get("role", "")
+        content = (m.get("content") or "").strip()
+        if role not in ("user", "assistant") or not content:
+            continue
+        if content == latest:
+            continue
+        turns.append(f"{role}: {content[:300]}")
+    prior_tokens: set[str] = set()
+    for t in turns[-4:]:
+        body = t.split(":", 1)[-1] if ":" in t else t
+        prior_tokens |= _qs._content_tokens(body)
+
+    prompt = _build_triage_prompt(turns, latest)
+    raw = await _ask_ollama_json(http, ollama_url, prompt, model, max_tokens=240, timeout=45.0)
+    if raw is None:
+        return None
+    return _validate_triage(raw, latest, prior_tokens)
+
+
+# ── Relevance scoring (cheap heuristic) ──
+def relevance_score(user_message: str, queries: list[str], top_results: list[dict]) -> float:
+    """Fraction of original-message content tokens that appear in the
+    concatenated titles+snippets of the top results. 0.0..1.0.
+
+    Compares against the user's message, NOT the rewritten queries — if the
+    rewrite was bad, we want to detect that the results miss what was asked.
+    """
+    user_tokens = _qs._content_tokens(user_message)
+    if not user_tokens:
+        # Nothing to match against → assume results are fine; don't trigger refine.
+        return 1.0
+    blob_parts: list[str] = []
+    for r in top_results[:3]:
+        blob_parts.append(r.get("title") or "")
+        blob_parts.append(r.get("content") or r.get("snippet") or "")
+    blob = " ".join(blob_parts)
+    if not blob.strip():
+        return 0.0
+    result_tokens = _qs._content_tokens(blob)
+    if not result_tokens:
+        return 0.0
+    overlap = user_tokens & result_tokens
+    return len(overlap) / len(user_tokens)
+
+
+# ── Refine ──
+async def refine_query(
+    http, ollama_url: str, model: str,
+    original_message: str, tried_queries: list[str], weak_results: list[dict],
+) -> str:
+    """Ask the model for ONE different query given that prior queries returned
+    off-topic results. Returns a single query string or empty on failure."""
+    if not model:
+        return ""
+    samples = []
+    for r in weak_results[:3]:
+        title = (r.get("title") or "")[:120]
+        snip = (r.get("content") or r.get("snippet") or "")[:200]
+        samples.append(f"- {title}: {snip}")
+    samples_block = "\n".join(samples) if samples else "(no results)"
+    prompt = (
+        "You wrote search queries that returned OFF-TOPIC results. Propose ONE "
+        "different query that would better match the user's original question.\n\n"
+        f"User's original question: {original_message}\n\n"
+        f"Queries you tried: {tried_queries}\n\n"
+        f"Off-topic results received:\n{samples_block}\n\n"
+        "Output JSON: {\"query\": \"...\"}\n"
+        "Rules: ≤12 words, no quotes, no URLs, must include the specific noun "
+        "from the user's question. Output JSON only."
+    )
+    out = await _ask_ollama_json(http, ollama_url, prompt, model, max_tokens=80, timeout=30.0)
+    if not isinstance(out, dict):
+        return ""
+    q = out.get("query", "")
+    if not isinstance(q, str):
+        return ""
+    q = q.strip().strip('"').strip("'")
+    if not q or len(q) > 200 or "http" in q.lower():
+        return ""
+    if not _qs._content_tokens(q):
+        return ""
+    return q
+
+
+# ── Orchestrator ──
+async def run_search_agent(
+    http, ollama_url: str, triage_model: str, refine_model: str,
+    events, conv_id: str, messages: list,
+    *, default_model: str = "",
+    max_rounds: int = 2,
+    relevance_threshold: float = _REFINE_THRESHOLD_DEFAULT,
+) -> dict:
+    """Orchestrate skip → triage → multi-query search → relevance check →
+    optional refine → page/OG enrichment → context build.
+
+    Returns the same shape as `run_quick_search_for_chat`:
+      {"context", "rewritten_query", "skipped", "reason"}
+
+    On triage failure, falls back to legacy `_rewrite_query` path so the new
+    architecture is strictly best-effort over today's behavior.
+    """
+    latest = ""
+    for m in reversed(messages):
+        if m.get("role") == "user" and m.get("content"):
+            latest = m["content"].strip()
+            break
+    if not latest:
+        return {"context": "", "rewritten_query": "", "skipped": True, "reason": "no user message"}
+
+    skip, reason = _qs._should_skip(latest)
+    if skip:
+        await _emit(events, conv_id, "tool_done", {
+            "tool": "quick_search", "icon": "search", "status": f"Skipped ({reason})",
+        })
+        return {"context": "", "rewritten_query": "", "skipped": True, "reason": reason}
+
+    await _emit(events, conv_id, "tool_start", {
+        "tool": "quick_search", "icon": "search",
+        "status": f"Searching: {latest[:60]}",
+    })
+
+    # ── Triage ──
+    plan = await triage(http, ollama_url, triage_model, messages, latest)
+    triage_ok = plan is not None
+    if not triage_ok:
+        # Triage failed (model down, JSON parse, or validation rejection).
+        # Search the raw user message as a last resort — the relevance check
+        # and refine path will still try to recover bad results.
+        print(f"[SA]   triage failed; searching raw user message")
+        plan = {
+            "needs_search": True,
+            "queries": [latest[:200]],
+            "category": "general",
+            "reason": "triage failed",
+        }
+
+    if not plan["needs_search"] or not plan["queries"]:
+        await _emit(events, conv_id, "tool_done", {
+            "tool": "quick_search", "icon": "search",
+            "status": f"Skipped ({plan.get('reason') or 'not needed'})",
+        })
+        return {
+            "context": "", "rewritten_query": "",
+            "skipped": True, "reason": plan.get("reason") or "triage skip",
+        }
+
+    queries: list[str] = list(plan["queries"])
+    category: str = plan["category"]
+
+    progress_label = " | ".join(q[:40] for q in queries[:2])
+    await _emit(events, conv_id, "tool_progress", {
+        "tool": "quick_search", "icon": "search",
+        "status": f"→ {progress_label[:120]}",
+    })
+
+    # ── Round 1: parallel search ──
+    rounds_used = 1
+    raw_lists = await asyncio.gather(
+        *[_qs._cached_search(http, q) for q in queries],
+        return_exceptions=True,
+    )
+    raw = _merge_unique([r for r in raw_lists if isinstance(r, list)])
+
+    if not raw:
+        await _emit(events, conv_id, "tool_done", {
+            "tool": "quick_search", "icon": "search", "status": "No results found",
+        })
+        return {"context": "", "rewritten_query": queries[0],
+                "skipped": False, "reason": "no results"}
+
+    primary = queries[0]
+    top = _qs._rank_and_filter_for_chat(raw, primary)
+    score = relevance_score(latest, queries, top)
+    print(f"[SA]   triage_ok={triage_ok} round={rounds_used} q={queries!r} relevance={score:.2f}")
+
+    # ── Round 2: refine if relevance is low ──
+    if (
+        score < relevance_threshold
+        and rounds_used < max_rounds
+        and len(_qs._content_tokens(latest)) >= 3
+    ):
+        refined = await refine_query(http, ollama_url, refine_model, latest, queries, top)
+        if refined and refined not in queries:
+            await _emit(events, conv_id, "tool_progress", {
+                "tool": "quick_search", "icon": "search",
+                "status": f"Round 2: refining → {refined[:60]}",
+            })
+            try:
+                more = await _qs._cached_search(http, refined)
+            except Exception:
+                more = []
+            if more:
+                raw = _merge_unique([raw, more])
+                queries = queries + [refined]
+                primary = refined  # the refined query is what found the answer
+                top = _qs._rank_and_filter_for_chat(raw, primary)
+                rounds_used = 2
+                new_score = relevance_score(latest, queries, top)
+                print(f"[SA]   round={rounds_used} refined={refined!r} relevance={new_score:.2f}")
+
+    # ── Page-fetch + OG-image enrichment (parallel) ──
+    page_text, _ = await asyncio.gather(
+        _qs._enrich_with_pages(http, top, top_n=3),
+        _qs._enrich_og_images(http, top, max_fetch=4),
+        return_exceptions=False,
+    )
+
+    allowed: set[str] = set()
+    for r in top:
+        thumb = r.get("thumbnail")
+        if thumb and len(allowed) < 3:
+            allowed.add(_qs.proxy_image_url(thumb))
+
+    # Feed the same results into the frontend's QUICK SEARCH carousel via SSE,
+    # tagged with `source: "quick_search"` so the listener routes them to
+    # `quickResults` (separate from the `research` tool's carousel). This
+    # replaces the frontend's parallel `/api/quick-search` POST — the chat
+    # and the carousel now see the same triage-rewritten results.
+    carousel = [
+        {
+            "title": r.get("title", ""),
+            "url": r.get("url", ""),
+            "snippet": (r.get("content") or r.get("snippet") or "")[:300],
+            "thumbnail": r.get("thumbnail", ""),
+            "engine": r.get("engine", ""),
+            "type": r.get("type", "web"),
+        }
+        for r in top
+    ]
+    await _emit(events, conv_id, "search_results", {
+        "query": primary,
+        "results": carousel,
+        "source": "quick_search",
+    })
+
+    ctx = _qs._build_context(top, primary, page_text, allowed)
+
+    await _emit(events, conv_id, "tool_done", {
+        "tool": "quick_search", "icon": "search",
+        "status": f"Found {len(top)} result{'s' if len(top) != 1 else ''}"
+                  f"{' (refined)' if rounds_used > 1 else ''}",
+    })
+
+    print(f"[SA]   {len(top)} results, category={category}, rounds={rounds_used}")
+    return {"context": ctx, "rewritten_query": primary, "skipped": False, "reason": ""}
+
+
+# ── Helpers ──
+def _merge_unique(lists: list[list]) -> list:
+    """Merge multiple result lists, dedup by URL, preserving first-seen order."""
+    seen: set[str] = set()
+    out: list = []
+    for lst in lists:
+        if not lst:
+            continue
+        for r in lst:
+            url = r.get("url") if isinstance(r, dict) else None
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            out.append(r)
+    return out
+
+
+async def _emit(events, conv_id: str, evt: str, data: dict) -> None:
+    if not (events and conv_id):
+        return
+    try:
+        await events.emit(conv_id, evt, data)
+    except Exception:
+        pass

--- a/backend/search_agent.py
+++ b/backend/search_agent.py
@@ -1,22 +1,29 @@
 """
-Multi-round search agent — replaces single-shot `_rewrite_query` + search +
-fetch with an internal loop that:
+Multi-round search agent. Each chat turn runs:
 
-  1. triage()        — one LLM call (JSON-mode) returns {needs_search, queries,
-                        category}. Replaces today's three-stage rewrite chain.
-  2. parallel search — 1-3 SearXNG calls fanned out at once.
-  3. relevance check — cheap content-token overlap heuristic. No LLM.
-  4. refine          — if relevance is low and rounds remain, ask the model
+  1. triage()        — one LLM call (JSON-mode) returns
+                        {needs_search, standalone_query, queries, category}.
+  2. subquery dedup  — drop queries already searched this conversation.
+  3. parallel search — 1-3 SearXNG calls fanned out at once;
+                        time_range="month" when category=news + recency cue.
+  4. heuristic rank  — quality + domain dedup + category bias.
+  5. embedding rerank — cosine vs nomic-embed-text; drop sim<0.45;
+                         dedup pairs sim>0.85. Falls back to (4) on any
+                         embed failure.
+  6. relevance check — cheap content-token overlap (with prior_tokens
+                        folded in for follow-ups). No LLM.
+  7. refine          — if relevance is low and rounds remain, ask the model
                         for ONE different query and search once more.
-  5. fetch + context — same OG-image / page-text enrichment as legacy.
+  8. fetch + context — trafilatura-extracted page text + OG-image enrichment.
 
-Falls back to legacy `_rewrite_query` on any triage failure — never a
-regression vs today's behavior. Keeps the same return shape:
+Falls back to a raw-message search on any triage failure — never a
+regression vs today's behavior. Returns:
   {"context": str, "rewritten_query": str, "skipped": bool, "reason": str}
 
 Reuses helpers from `quick_search`: `_content_tokens`, `_cached_search`,
-`_rank_and_filter_for_chat`, `_enrich_with_pages`, `_enrich_og_images`,
-`_build_context`, `proxy_image_url`, `_rewrite_query`.
+`_rank_and_filter_for_chat`, `_embed_score_and_dedup`, `_enrich_with_pages`,
+`_enrich_og_images`, `_build_context`, `proxy_image_url`,
+`_filter_novel_queries`.
 """
 import asyncio
 import json
@@ -28,6 +35,31 @@ import quick_search as _qs
 
 _VALID_CATEGORIES = ("news", "code", "recipe", "general")
 _REFINE_THRESHOLD_DEFAULT = 0.30
+
+# Time-cues that indicate the user wants *current* news, not background.
+# Combined with category=="news" → pass time_range="month" to SearXNG so
+# 2019 articles don't outrank current ones.
+_NEWS_TIME_CUE_RE = re.compile(
+    r"\b(today|now|latest|current|currently|breaking|recent|recently|"
+    r"this\s+(?:week|month)|"
+    r"yesterday|last\s+(?:week|month)|"
+    r"happening|going\s+on|update|updates)\b",
+    re.IGNORECASE,
+)
+
+
+def _news_time_range(category: str, latest: str) -> str | None:
+    """Return SearXNG time_range when the query is news + has a recency cue."""
+    if category != "news":
+        return None
+    if _NEWS_TIME_CUE_RE.search(latest):
+        return "month"
+    # Bare-year mentions of the current/recent year imply recency
+    from datetime import datetime
+    yr = datetime.now().year
+    if str(yr) in latest or str(yr - 1) in latest:
+        return "month"
+    return None
 
 
 # ── JSON-mode Ollama call ──
@@ -106,15 +138,19 @@ def _build_triage_prompt(turns: list[str], latest: str) -> str:
         "You are a search planner. Given the conversation and the user's LATEST "
         "message, decide whether to search the web and what to search for.\n\n"
         "Output a single JSON object with EXACTLY these fields:\n"
-        '  "needs_search": boolean\n'
-        '  "queries":      array of 1-3 self-contained search query strings\n'
-        '  "category":     one of "news" | "code" | "recipe" | "general"\n'
-        '  "reason":       short string, ≤80 chars (telemetry only)\n\n'
+        '  "needs_search":     boolean\n'
+        '  "standalone_query": string — the LATEST message rephrased as a '
+        'context-independent question, with all pronouns/anaphora resolved '
+        'using prior turns. Empty string if needs_search=false.\n'
+        '  "queries":          array of 1-3 self-contained search query strings\n'
+        '  "category":         one of "news" | "code" | "recipe" | "general"\n'
+        '  "reason":           short string, ≤80 chars (telemetry only)\n\n'
         "RULES:\n"
         "1. The latest message continues the conversation. Resolve pronouns "
         "(she/he/it/they/this/that), vague references (\"the one\", \"the issue\"), "
         "and definite-article anaphora (\"the X\" referring to a prior-mentioned "
-        "topic) using the SPECIFIC noun from prior turns.\n"
+        "topic) using the SPECIFIC noun from prior turns. Both standalone_query "
+        "AND each search query MUST contain the resolved noun.\n"
         "2. Bare follow-ups — short messages without their own subject "
         "('whos winning?', 'any updates?', 'what next?') — inherit the topic "
         "from prior turns.\n"
@@ -128,7 +164,9 @@ def _build_triage_prompt(turns: list[str], latest: str) -> str:
         "5. Set needs_search=false for: greetings, pure arithmetic, requests "
         "to rewrite/translate/summarize/proofread attached text, and pure-"
         "opinion questions ('what do you think of X').\n"
-        "6. Each query: ≤12 words, no quotes, no URLs, no 'site:', no booleans.\n\n"
+        "6. Each query: ≤12 words, no quotes, no URLs, no 'site:', no booleans.\n"
+        "7. standalone_query may be longer than a search query — it should read "
+        "like a complete, self-contained question.\n\n"
         "EXAMPLES BELOW ARE TEMPLATES showing the rule pattern. The entities "
         "(sourdough, Rust, Brazil, etc.) are placeholders — DO NOT copy them "
         "into your output unless they actually appear in the user's conversation. "
@@ -136,26 +174,34 @@ def _build_triage_prompt(turns: list[str], latest: str) -> str:
         '  Pattern: pronoun anaphora\n'
         '    Prior: user asked about sourdough bread\n'
         '    Latest: "how do I store it?"\n'
-        '    → {"needs_search":true,"queries":["sourdough bread storage"],'
+        '    → {"needs_search":true,'
+        '"standalone_query":"how do I store sourdough bread?",'
+        '"queries":["sourdough bread storage"],'
         '"category":"recipe","reason":"pronoun it → sourdough bread"}\n\n'
         '  Pattern: bare follow-up inherits topic\n'
         '    Prior: user asked about Rust borrow checker\n'
         '    Latest: "any examples?"\n'
-        '    → {"needs_search":true,"queries":["Rust borrow checker examples"],'
+        '    → {"needs_search":true,'
+        '"standalone_query":"examples of the Rust borrow checker",'
+        '"queries":["Rust borrow checker examples"],'
         '"category":"code","reason":"bare follow-up"}\n\n'
         '  Pattern: topic shift — ignore prior\n'
         '    Prior: extended discussion about Python async\n'
         '    Latest: "what is the capital of Brazil?"\n'
-        '    → {"needs_search":true,"queries":["capital of Brazil"],'
+        '    → {"needs_search":true,'
+        '"standalone_query":"what is the capital of Brazil?",'
+        '"queries":["capital of Brazil"],'
         '"category":"general","reason":"topic shift"}\n\n'
         '  Pattern: skip greeting\n'
         '    Prior: (none)\n'
         '    Latest: "hi"\n'
-        '    → {"needs_search":false,"queries":[],"category":"general","reason":"greeting"}\n\n'
+        '    → {"needs_search":false,"standalone_query":"",'
+        '"queries":[],"category":"general","reason":"greeting"}\n\n'
         '  Pattern: skip operate-on-attached\n'
         '    Prior: discussing FastAPI deployment\n'
         '    Latest: "rewrite this paragraph: <paste>"\n'
-        '    → {"needs_search":false,"queries":[],"category":"general","reason":"operate on attached"}\n\n'
+        '    → {"needs_search":false,"standalone_query":"",'
+        '"queries":[],"category":"general","reason":"operate on attached"}\n\n'
         f"Recent conversation:\n{history_block}\n\n"
         f"Latest message: {latest}\n\n"
         "Output JSON only:"
@@ -207,20 +253,36 @@ def _validate_triage(out: Any, latest: str, prior_tokens: set[str]) -> dict | No
     if not isinstance(reason, str):
         reason = ""
 
+    # standalone_query: pronoun-resolved, context-independent rephrasing of
+    # the latest message. Used as the canonical query for ranking + carousel.
+    # Falls back to queries[0] if missing/empty/unsafe.
+    sq = out.get("standalone_query", "")
+    if not isinstance(sq, str):
+        sq = ""
+    sq = sq.strip().strip('"').strip("'")
+    if (
+        not sq
+        or len(sq) > 400
+        or "http://" in sq.lower()
+        or "https://" in sq.lower()
+    ):
+        sq = queries[0] if queries else ""
+
     return {
         "needs_search": needs,
+        "standalone_query": sq,
         "queries": queries,
         "category": cat,
         "reason": reason[:120],
     }
 
 
-async def triage(
-    http, ollama_url: str, model: str, messages: list, latest: str,
-) -> dict | None:
-    """Run the triage LLM call. Returns validated dict or None on any failure."""
-    if not model:
-        return None
+def _build_prior_tokens(messages: list, latest: str) -> tuple[list[str], set[str]]:
+    """Extract recent conversation turns and the union of their content tokens.
+
+    Used by triage (for the prompt + follow-up validation) and by the
+    orchestrator (for follow-up-aware relevance scoring).
+    """
     turns: list[str] = []
     for m in messages[-6:]:
         role = m.get("role", "")
@@ -234,7 +296,16 @@ async def triage(
     for t in turns[-4:]:
         body = t.split(":", 1)[-1] if ":" in t else t
         prior_tokens |= _qs._content_tokens(body)
+    return turns, prior_tokens
 
+
+async def triage(
+    http, ollama_url: str, model: str, messages: list, latest: str,
+) -> dict | None:
+    """Run the triage LLM call. Returns validated dict or None on any failure."""
+    if not model:
+        return None
+    turns, prior_tokens = _build_prior_tokens(messages, latest)
     prompt = _build_triage_prompt(turns, latest)
     raw = await _ask_ollama_json(http, ollama_url, prompt, model, max_tokens=240, timeout=45.0)
     if raw is None:
@@ -243,14 +314,26 @@ async def triage(
 
 
 # ── Relevance scoring (cheap heuristic) ──
-def relevance_score(user_message: str, queries: list[str], top_results: list[dict]) -> float:
+def relevance_score(
+    user_message: str,
+    queries: list[str],
+    top_results: list[dict],
+    prior_tokens: set[str] | None = None,
+) -> float:
     """Fraction of original-message content tokens that appear in the
     concatenated titles+snippets of the top results. 0.0..1.0.
 
     Compares against the user's message, NOT the rewritten queries — if the
     rewrite was bad, we want to detect that the results miss what was asked.
+
+    For follow-ups ("any updates?", "tell me more"), the user message itself
+    has no content tokens. When `prior_tokens` is supplied AND the message
+    looks like a follow-up, fold the prior topic in so we can still detect
+    off-topic results. Without this, refine never fires for follow-ups.
     """
     user_tokens = _qs._content_tokens(user_message)
+    if prior_tokens and _qs._needs_context(user_message, prior_tokens):
+        user_tokens = user_tokens | prior_tokens
     if not user_tokens:
         # Nothing to match against → assume results are fine; don't trigger refine.
         return 1.0
@@ -321,8 +404,7 @@ async def run_search_agent(
     Returns the same shape as `run_quick_search_for_chat`:
       {"context", "rewritten_query", "skipped", "reason"}
 
-    On triage failure, falls back to legacy `_rewrite_query` path so the new
-    architecture is strictly best-effort over today's behavior.
+    On triage failure, falls back to searching the raw user message.
     """
     latest = ""
     for m in reversed(messages):
@@ -345,6 +427,7 @@ async def run_search_agent(
     })
 
     # ── Triage ──
+    _, prior_tokens = _build_prior_tokens(messages, latest)
     plan = await triage(http, ollama_url, triage_model, messages, latest)
     triage_ok = plan is not None
     if not triage_ok:
@@ -354,6 +437,7 @@ async def run_search_agent(
         print(f"[SA]   triage failed; searching raw user message")
         plan = {
             "needs_search": True,
+            "standalone_query": latest[:400],
             "queries": [latest[:200]],
             "category": "general",
             "reason": "triage failed",
@@ -371,6 +455,10 @@ async def run_search_agent(
 
     queries: list[str] = list(plan["queries"])
     category: str = plan["category"]
+    standalone: str = plan.get("standalone_query") or (queries[0] if queries else latest)
+
+    # Filter out queries already searched earlier in this conversation.
+    queries = _qs._filter_novel_queries(conv_id, queries)
 
     progress_label = " | ".join(q[:40] for q in queries[:2])
     await _emit(events, conv_id, "tool_progress", {
@@ -380,8 +468,9 @@ async def run_search_agent(
 
     # ── Round 1: parallel search ──
     rounds_used = 1
+    time_range = _news_time_range(category, latest)
     raw_lists = await asyncio.gather(
-        *[_qs._cached_search(http, q) for q in queries],
+        *[_qs._cached_search(http, q, time_range=time_range) for q in queries],
         return_exceptions=True,
     )
     raw = _merge_unique([r for r in raw_lists if isinstance(r, list)])
@@ -393,10 +482,18 @@ async def run_search_agent(
         return {"context": "", "rewritten_query": queries[0],
                 "skipped": False, "reason": "no results"}
 
-    primary = queries[0]
-    top = _qs._rank_and_filter_for_chat(raw, primary)
-    score = relevance_score(latest, queries, top)
-    print(f"[SA]   triage_ok={triage_ok} round={rounds_used} q={queries!r} relevance={score:.2f}")
+    # Use standalone_query as the canonical query for ranking + carousel.
+    # It carries the pronoun-resolved form; queries[] are the (often shorter)
+    # search-optimized variants fanned out to SearXNG.
+    primary = standalone
+    top = _qs._rank_and_filter_for_chat(raw, primary, category=category)
+    # Embedding rerank + dedup. Cheap (~50ms with warm nomic-embed-text) and
+    # catches synonym/paraphrase mismatches the heuristic ranker misses,
+    # plus the SearXNG-mirror dup case. Falls back to `top` unchanged on
+    # any embed failure.
+    top = await _qs._embed_score_and_dedup(http, ollama_url, primary, top)
+    score = relevance_score(latest, queries, top, prior_tokens)
+    print(f"[SA]   triage_ok={triage_ok} round={rounds_used} sq={standalone!r} q={queries!r} relevance={score:.2f}")
 
     # ── Round 2: refine if relevance is low ──
     if (
@@ -411,16 +508,18 @@ async def run_search_agent(
                 "status": f"Round 2: refining → {refined[:60]}",
             })
             try:
-                more = await _qs._cached_search(http, refined)
+                more = await _qs._cached_search(http, refined, time_range=time_range)
             except Exception:
                 more = []
             if more:
                 raw = _merge_unique([raw, more])
                 queries = queries + [refined]
-                primary = refined  # the refined query is what found the answer
-                top = _qs._rank_and_filter_for_chat(raw, primary)
+                # Keep ranking against the standalone query — the refined query
+                # is just another search-optimized variant.
+                top = _qs._rank_and_filter_for_chat(raw, primary, category=category)
+                top = await _qs._embed_score_and_dedup(http, ollama_url, primary, top)
                 rounds_used = 2
-                new_score = relevance_score(latest, queries, top)
+                new_score = relevance_score(latest, queries, top, prior_tokens)
                 print(f"[SA]   round={rounds_used} refined={refined!r} relevance={new_score:.2f}")
 
     # ── Page-fetch + OG-image enrichment (parallel) ──

--- a/backend/tests/test_search_agent.py
+++ b/backend/tests/test_search_agent.py
@@ -1,0 +1,417 @@
+"""
+Unit tests for `backend/search_agent.py` — the multi-round search agent.
+
+These are pure-logic tests with mocked Ollama and mocked SearXNG cache. No
+network. Run with:
+    pytest backend/tests/test_search_agent.py -v
+"""
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, AsyncMock
+
+# Ensure backend/ is importable when pytest runs from repo root or backend/.
+_BACKEND = Path(__file__).resolve().parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+import search_agent  # noqa: E402
+import quick_search  # noqa: E402  (we patch helpers on this module)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── Fake HTTP client for the JSON-mode call ──
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeHTTP:
+    """Captures POST calls and returns a queued response."""
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    async def post(self, url, json=None, timeout=None):
+        self.calls.append({"url": url, "json": json, "timeout": timeout})
+        if not self._responses:
+            raise RuntimeError("no more responses queued")
+        nxt = self._responses.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return _FakeResponse(nxt)
+
+
+def _ollama_response(text: str) -> dict:
+    """Shape Ollama's /api/generate non-streaming response."""
+    return {"response": text, "done": True}
+
+
+# ── relevance_score ──
+def test_relevance_score_strong_match():
+    user_msg = "tell me about UK Reform Party 2026 elections"
+    queries = ["UK Reform Party platform"]
+    results = [
+        {"title": "Reform UK 2026 elections", "content": "The UK Reform Party..."},
+        {"title": "Election results UK", "content": "Reform Party gains..."},
+    ]
+    score = search_agent.relevance_score(user_msg, queries, results)
+    assert score >= 0.5, f"expected strong overlap, got {score}"
+
+
+def test_relevance_score_off_topic():
+    # Genuinely off-topic results (different vocabulary) → score below the
+    # refine threshold (0.30). Note: when the user's question and the wrong
+    # entity share the literal name (e.g. "UK Reform Party" vs "US Reform
+    # Party"), token-overlap can't tell them apart — that's the domain-bias
+    # layer's job, not the relevance heuristic's. This test validates the
+    # *mechanics* of the heuristic on cleanly-disjoint cases.
+    user_msg = "tell me about UK general election results politics"
+    queries = ["UK election"]
+    results = [
+        {"title": "Best chocolate chip cookie recipes", "content": "baking ingredients..."},
+        {"title": "Python regex tutorial", "content": "matching strings with patterns..."},
+    ]
+    score = search_agent.relevance_score(user_msg, queries, results)
+    assert score < 0.30, f"expected refine threshold trigger, got {score}"
+
+
+def test_relevance_score_empty_results():
+    assert search_agent.relevance_score("test query", ["test"], []) == 0.0
+
+
+def test_relevance_score_no_user_content():
+    # User message has no content tokens (just stopwords) — assume results fine.
+    assert search_agent.relevance_score("the and is to", ["x"], [{"title": "y"}]) == 1.0
+
+
+# ── _validate_triage ──
+def test_validate_triage_accepts_valid():
+    out = search_agent._validate_triage(
+        {
+            "needs_search": True,
+            "queries": ["UK general election 2026 results"],
+            "category": "news",
+            "reason": "follow-up about UK elections",
+        },
+        latest="whos winning?",
+        prior_tokens={"election", "uk"},
+    )
+    assert out is not None
+    assert out["needs_search"] is True
+    assert out["queries"] == ["UK general election 2026 results"]
+    assert out["category"] == "news"
+
+
+def test_validate_triage_rejects_non_dict():
+    assert search_agent._validate_triage("not a dict", "hi", set()) is None
+    assert search_agent._validate_triage(None, "hi", set()) is None
+
+
+def test_validate_triage_rejects_missing_fields():
+    assert search_agent._validate_triage({"queries": []}, "hi", set()) is None
+    assert search_agent._validate_triage(
+        {"needs_search": True, "queries": []}, "hi", set(),
+    ) is None  # claims search but produced no usable queries
+
+
+def test_validate_triage_drops_url_queries():
+    out = search_agent._validate_triage(
+        {
+            "needs_search": True,
+            "queries": ["good query about cats", "https://example.com/ignore"],
+            "category": "general",
+        },
+        latest="cats",
+        prior_tokens=set(),
+    )
+    assert out is not None
+    assert out["queries"] == ["good query about cats"]
+
+
+def test_validate_triage_followup_must_carry_topic():
+    # Latest is a bare follow-up, prior is about UK elections, but the queries
+    # don't share any prior content tokens → reject.
+    out = search_agent._validate_triage(
+        {
+            "needs_search": True,
+            "queries": ["random unrelated topic about whales"],
+            "category": "general",
+        },
+        latest="whos winning?",
+        prior_tokens={"uk", "election", "general"},
+    )
+    assert out is None, "follow-up that drops prior topic must be rejected"
+
+
+def test_validate_triage_normalizes_bad_category():
+    out = search_agent._validate_triage(
+        {
+            "needs_search": True,
+            "queries": ["python regex tutorial"],
+            "category": "weather",  # not in allowed set
+        },
+        latest="python regex",
+        prior_tokens=set(),
+    )
+    assert out is not None
+    assert out["category"] == "general"
+
+
+def test_validate_triage_skip_path_normalized():
+    out = search_agent._validate_triage(
+        {"needs_search": False, "queries": ["leftover"], "category": "general"},
+        latest="hi",
+        prior_tokens=set(),
+    )
+    assert out is not None
+    assert out["needs_search"] is False
+    assert out["queries"] == []
+
+
+# ── triage with mocked HTTP ──
+def test_triage_valid_json_returns_plan():
+    plan_json = json.dumps({
+        "needs_search": True,
+        "queries": ["UK election 2026 results"],
+        "category": "news",
+        "reason": "follow-up",
+    })
+    http = _FakeHTTP([_ollama_response(plan_json)])
+
+    messages = [
+        {"role": "user", "content": "tell me about elections in the UK"},
+        {"role": "assistant", "content": "The UK holds general elections..."},
+    ]
+    out = _run(search_agent.triage(http, "http://ollama", "test-model", messages, "whos winning?"))
+    assert out is not None
+    assert out["needs_search"] is True
+    assert out["queries"] == ["UK election 2026 results"]
+    assert out["category"] == "news"
+    # Ollama call uses format=json
+    assert http.calls[0]["json"]["format"] == "json"
+
+
+def test_triage_invalid_json_returns_none():
+    http = _FakeHTTP([_ollama_response("this is not json at all, just words")])
+    out = _run(search_agent.triage(http, "http://ollama", "test-model", [], "hi there"))
+    assert out is None
+
+
+def test_triage_strips_code_fence():
+    fenced = "```json\n" + json.dumps({
+        "needs_search": False, "queries": [], "category": "general", "reason": "greeting",
+    }) + "\n```"
+    http = _FakeHTTP([_ollama_response(fenced)])
+    out = _run(search_agent.triage(http, "http://ollama", "test-model", [], "hello"))
+    assert out is not None
+    assert out["needs_search"] is False
+
+
+def test_triage_returns_none_on_empty_model():
+    out = _run(search_agent.triage(None, "http://ollama", "", [], "hi"))
+    assert out is None
+
+
+def test_triage_returns_none_on_http_error():
+    http = _FakeHTTP([RuntimeError("network down")])
+    out = _run(search_agent.triage(http, "http://ollama", "test-model", [], "hi"))
+    assert out is None
+
+
+# ── _merge_unique ──
+def test_merge_unique_dedupes_by_url():
+    a = [{"url": "https://a.com", "title": "A"}, {"url": "https://b.com", "title": "B"}]
+    b = [{"url": "https://b.com", "title": "B-dup"}, {"url": "https://c.com", "title": "C"}]
+    merged = search_agent._merge_unique([a, b])
+    assert [r["url"] for r in merged] == ["https://a.com", "https://b.com", "https://c.com"]
+    # First-seen wins
+    assert merged[1]["title"] == "B"
+
+
+# ── run_search_agent orchestration ──
+def _searxng_results(*titles_urls):
+    return [{"title": t, "url": u, "content": f"snippet about {t}"} for t, u in titles_urls]
+
+
+def test_run_search_agent_skip_gate():
+    """Greetings short-circuit before any LLM call."""
+    http = _FakeHTTP([])  # no responses queued — would error if triage ran
+    messages = [{"role": "user", "content": "hi"}]
+    out = _run(search_agent.run_search_agent(
+        http, "http://ollama", "test-model", "test-model",
+        events=None, conv_id=None, messages=messages,
+    ))
+    assert out["skipped"] is True
+    assert out["reason"] == "greeting"
+    assert http.calls == []  # zero LLM calls
+
+
+def test_run_search_agent_triage_skip():
+    """Triage returns needs_search=false → no SearXNG, return skip."""
+    plan = json.dumps({
+        "needs_search": False, "queries": [], "category": "general", "reason": "operate on attached",
+    })
+    http = _FakeHTTP([_ollama_response(plan)])
+    messages = [{"role": "user", "content": "rewrite this paragraph for me: foo bar baz"}]
+
+    with patch.object(quick_search, "_cached_search", new=AsyncMock()) as mock_search:
+        out = _run(search_agent.run_search_agent(
+            http, "http://ollama", "test-model", "test-model",
+            events=None, conv_id=None, messages=messages,
+        ))
+        assert out["skipped"] is True
+        assert mock_search.await_count == 0  # triage said no, no search ran
+
+
+def test_run_search_agent_high_relevance_no_refine():
+    """One round when relevance is high — refine_query is never called."""
+    plan = json.dumps({
+        "needs_search": True,
+        "queries": ["UK general election 2026 results"],
+        "category": "news",
+        "reason": "follow-up",
+    })
+    http = _FakeHTTP([_ollama_response(plan)])
+
+    fake_results = _searxng_results(
+        ("UK general election 2026 results", "https://bbc.co.uk/election"),
+        ("Reform UK gains in election", "https://guardian.co.uk/x"),
+    )
+
+    messages = [
+        {"role": "user", "content": "tell me about the UK general election 2026 results"},
+    ]
+
+    with patch.object(quick_search, "_cached_search", new=AsyncMock(return_value=fake_results)) as mock_search, \
+         patch.object(quick_search, "_enrich_with_pages", new=AsyncMock(return_value={})), \
+         patch.object(quick_search, "_enrich_og_images", new=AsyncMock(return_value=None)), \
+         patch.object(search_agent, "refine_query", new=AsyncMock(return_value="should-not-be-called")) as mock_refine:
+        out = _run(search_agent.run_search_agent(
+            http, "http://ollama", "test-model", "test-model",
+            events=None, conv_id=None, messages=messages,
+        ))
+        assert out["skipped"] is False
+        assert mock_search.await_count == 1   # single round
+        assert mock_refine.await_count == 0   # no refinement
+
+
+def test_run_search_agent_low_relevance_refines():
+    """Low relevance → refine_query is called once and the refined query is searched."""
+    plan = json.dumps({
+        "needs_search": True,
+        "queries": ["election"],  # too vague — returns off-topic vocabulary
+        "category": "news",
+        "reason": "follow-up",
+    })
+    http = _FakeHTTP([_ollama_response(plan)])
+
+    # Off-topic results share NO content tokens with the user message — that's
+    # what the relevance heuristic is designed to catch.
+    off_topic = _searxng_results(
+        ("chocolate chip cookie recipes", "https://example.com/cookies"),
+        ("python regex tutorial", "https://example.com/regex"),
+    )
+    on_topic_after_refine = _searxng_results(
+        ("UK general election 2026 results", "https://bbc.co.uk/uk-elect"),
+    )
+
+    messages = [
+        {"role": "user", "content": "tell me about UK general election 2026 results politics"},
+    ]
+
+    cached_calls = {"n": 0}
+
+    async def fake_cached_search(http, query, count=10):
+        cached_calls["n"] += 1
+        return off_topic if cached_calls["n"] == 1 else on_topic_after_refine
+
+    with patch.object(quick_search, "_cached_search", new=fake_cached_search), \
+         patch.object(quick_search, "_enrich_with_pages", new=AsyncMock(return_value={})), \
+         patch.object(quick_search, "_enrich_og_images", new=AsyncMock(return_value=None)), \
+         patch.object(search_agent, "refine_query", new=AsyncMock(return_value="UK Reform Party 2026 election")) as mock_refine:
+        out = _run(search_agent.run_search_agent(
+            http, "http://ollama", "test-model", "test-model",
+            events=None, conv_id=None, messages=messages,
+        ))
+        assert out["skipped"] is False
+        assert mock_refine.await_count == 1   # refined exactly once
+        assert cached_calls["n"] == 2          # round 1 + refined round
+
+
+def test_run_search_agent_max_rounds_caps():
+    """Even with persistently low relevance, refinement runs at most once."""
+    plan = json.dumps({
+        "needs_search": True, "queries": ["bad query"],
+        "category": "general", "reason": "x",
+    })
+    http = _FakeHTTP([_ollama_response(plan)])
+
+    off_topic = _searxng_results(("totally unrelated", "https://x.com/a"))
+    messages = [{"role": "user", "content": "tell me about UK Reform Party 2026 elections politics"}]
+
+    async def fake_cached_search(http, query, count=10):
+        return off_topic  # always off topic
+
+    with patch.object(quick_search, "_cached_search", new=fake_cached_search) as mock_search, \
+         patch.object(quick_search, "_enrich_with_pages", new=AsyncMock(return_value={})), \
+         patch.object(quick_search, "_enrich_og_images", new=AsyncMock(return_value=None)), \
+         patch.object(search_agent, "refine_query", new=AsyncMock(return_value="another query")) as mock_refine:
+        out = _run(search_agent.run_search_agent(
+            http, "http://ollama", "test-model", "test-model",
+            events=None, conv_id=None, messages=messages,
+            max_rounds=2,
+        ))
+        assert mock_refine.await_count == 1   # refined exactly once even though still bad
+
+
+def test_run_search_agent_no_results():
+    """SearXNG returns nothing → return early with reason='no results'."""
+    plan = json.dumps({
+        "needs_search": True, "queries": ["something"],
+        "category": "general", "reason": "x",
+    })
+    http = _FakeHTTP([_ollama_response(plan)])
+    messages = [{"role": "user", "content": "something obscure that has no results"}]
+
+    with patch.object(quick_search, "_cached_search", new=AsyncMock(return_value=[])):
+        out = _run(search_agent.run_search_agent(
+            http, "http://ollama", "test-model", "test-model",
+            events=None, conv_id=None, messages=messages,
+        ))
+        assert out["skipped"] is False
+        assert out["reason"] == "no results"
+
+
+def test_run_search_agent_triage_failure_searches_raw_message():
+    """If triage returns invalid JSON, the agent searches the raw user message."""
+    http = _FakeHTTP([_ollama_response("garbage that is not json")])
+    user_msg = "tell me about UK Reform Party recent gains"
+    messages = [{"role": "user", "content": user_msg}]
+
+    fake_results = _searxng_results(("UK Reform results", "https://bbc.co.uk/x"))
+    captured_queries: list[str] = []
+
+    async def fake_cached_search(http, query, count=10):
+        captured_queries.append(query)
+        return fake_results
+
+    with patch.object(quick_search, "_cached_search", new=fake_cached_search), \
+         patch.object(quick_search, "_enrich_with_pages", new=AsyncMock(return_value={})), \
+         patch.object(quick_search, "_enrich_og_images", new=AsyncMock(return_value=None)):
+        out = _run(search_agent.run_search_agent(
+            http, "http://ollama", "test-model", "test-model",
+            events=None, conv_id=None, messages=messages,
+            default_model="test-model",
+        ))
+        assert out["skipped"] is False
+        # Triage failed → searched the raw user message verbatim
+        assert captured_queries == [user_msg]
+        assert out["rewritten_query"] == user_msg

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -9,6 +9,7 @@ import re
 import shlex
 import time
 import uuid
+from datetime import datetime
 
 import config
 import database as db
@@ -18,6 +19,24 @@ from research import run_deep_research, run_conspiracy_research, _fetch_page, _s
 _ANSI_RE = re.compile(r'\x1b\[[0-9;]*[a-zA-Z]')
 def _strip_ansi(text: str) -> str:
     return _ANSI_RE.sub('', text)
+
+
+def _parse_ts_loose(s) -> "datetime | None":
+    """Parse timestamps from either Python isoformat (runs.started_at, has 'T'
+    and microseconds) or SQLite CURRENT_TIMESTAMP (messages.created_at, space
+    separator, no microseconds, sometimes a trailing 'Z'). Returns None on
+    unrecognized input rather than raising — callers treat missing as 'before
+    the current turn' which is the safe default."""
+    if not s:
+        return None
+    s = str(s).strip().rstrip("Z")
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S",
+                "%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(s, fmt)
+        except ValueError:
+            continue
+    return None
 
 
 # ── Ollama-native tool definitions ──
@@ -938,11 +957,169 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                             + (("\n" + "\n".join(_issue_lines)) if _issue_lines else "")
                             + "\n  3. Asks the user for guidance — what behavior they actually "
                             f"want, or whether to skip this issue and ship anyway.\n\n"
-                            f"Do NOT call run_fixer, run_review, generate_code, write_file, or "
-                            f"any other tool. Respond to the user with text."
+                            f"Do NOT call run_fixer, run_review, generate_code, write_file, "
+                            f"run_shell, or plan_project. You MAY call download_project / "
+                            f"download_file to deliver what was built so far if the user wants "
+                            f"to ship as-is. Otherwise, respond to the user with text."
                         )
             except Exception as _ce:
                 print(f"[v2-gate] cycle cap check failed (non-fatal): {_ce}")
+
+            # Phantom run_fixer guard: block run_fixer when the latest run
+            # isn't a reviewer with status='issues'/'error'. Without this,
+            # a hallucinated reviewer_run_id (the model sometimes invents
+            # one right after generate_code) falls through to fixer.py,
+            # which returns "no envelope to fix" — burning a cap slot for
+            # zero work AND giving the model false signal that a fix
+            # happened. State 2 of the gate (PENDING_FIX) covers the
+            # legitimate "reviewer just ran with issues → call run_fixer"
+            # case; this guard handles every other case.
+            try:
+                _is_v2_pf = False
+                try:
+                    _conv_row_pf = await db.get_conversation(conv_id)
+                    _mc_id_pf = (_conv_row_pf or {}).get("model_config_id") if _conv_row_pf else None
+                    if _mc_id_pf:
+                        _all_mc_pf = await db.get_model_configs()
+                        _mc_pf = next((m for m in _all_mc_pf if m.get("id") == _mc_id_pf), None)
+                        if _mc_pf and "v2" in (_mc_pf.get("name") or "").lower():
+                            _is_v2_pf = True
+                except Exception as _pe_inner:
+                    print(f"[v2-gate] phantom-fixer persona lookup failed (non-fatal): {_pe_inner}")
+
+                if _is_v2_pf:
+                    _runs_pf = await db.get_runs_by_conversation(conv_id, limit=20)
+                    _latest_meaningful = None
+                    _MEANINGFUL_STATUSES = {"succeeded", "issues", "clean", "partial",
+                                            "stuck", "failed", "error"}
+                    for _r in _runs_pf:
+                        _role_pf = _r.get("role", "")
+                        _st_pf = (_r.get("status") or "").lower()
+                        if (_role_pf == "reviewer" or _role_pf.startswith("builder")
+                                or _role_pf == "fixer") and _st_pf in _MEANINGFUL_STATUSES:
+                            _latest_meaningful = _r
+                            break
+
+                    _allow_fixer = False
+                    if _latest_meaningful and _latest_meaningful.get("role") == "reviewer":
+                        _env_pf = _latest_meaningful.get("result_envelope") or {}
+                        _rstatus_pf = (_env_pf.get("status") or "").lower()
+                        if _rstatus_pf in ("issues", "error"):
+                            _allow_fixer = True
+
+                    if not _allow_fixer:
+                        _trig_role = (_latest_meaningful or {}).get("role", "(none)")
+                        _trig_id = (_latest_meaningful or {}).get("id", "?")
+                        _trig_status = (_latest_meaningful or {}).get("status", "?")
+                        # Surface a project_dir if we can find one.
+                        _pd_hint = ""
+                        for _r in _runs_pf:
+                            _env_h = _r.get("result_envelope") or {}
+                            _pd_try = (_env_h.get("project_dir") or "").strip()
+                            if _pd_try:
+                                _pd_hint = _pd_try
+                                break
+                        await events.emit(conv_id, "tool_end", {
+                            "tool": "run_fixer", "icon": "wrench",
+                            "status": "⛔ run_fixer needs a reviewer envelope first",
+                        })
+                        print(f"[v2-gate] PHANTOM FIXER: blocking run_fixer "
+                              f"(latest meaningful run is {_trig_role}/{_trig_status} "
+                              f"{(_trig_id or '')[:14]}, not a reviewer with issues)", flush=True)
+                        return (
+                            f"BLOCKED — run_fixer requires a recent reviewer envelope with "
+                            f"issues, but the most recent meaningful run is "
+                            f"'{_trig_role}' (status={_trig_status}). There is no "
+                            f"actionable envelope to fix.\n\n"
+                            f"Your VERY NEXT tool call MUST be:\n"
+                            f"  run_review(project_dir='{_pd_hint or '/root/projects/...'}')\n\n"
+                            f"Do not pass a hallucinated reviewer_run_id. Run the reviewer "
+                            f"first; if it returns issues, call run_fixer with that real id."
+                        )
+            except Exception as _pe:
+                print(f"[v2-gate] phantom-fixer check failed (non-fatal): {_pe}")
+
+        # ─── Anti-rebuild guard for generate_code (Bug 7) ────────────────
+        # If a builder.* run already succeeded since the most recent user
+        # message, refuse a 2nd generate_code in the same turn. The model
+        # otherwise tends to fall into "let me try generate_code again" for
+        # bug-fix turns where reviewer returned clean (because runtime bugs
+        # like unconnected Qt signals or invalid font strings compile fine).
+        # Re-running generate_code is ~60–90s of OpenHands work that almost
+        # always produces a worse result than 2 surgical write_file edits.
+        if conv_id and name == "generate_code":
+            try:
+                _is_v2_rb = False
+                _conv_full = None
+                try:
+                    _conv_full = await db.get_conversation(conv_id)
+                    _mc_id_rb = (_conv_full or {}).get("model_config_id")
+                    if _mc_id_rb:
+                        _all_mc_rb = await db.get_model_configs()
+                        _mc_rb = next((m for m in _all_mc_rb if m.get("id") == _mc_id_rb), None)
+                        if _mc_rb and "v2" in (_mc_rb.get("name") or "").lower():
+                            _is_v2_rb = True
+                except Exception as _pe_rb:
+                    print(f"[v2-gate] anti-rebuild persona lookup failed (non-fatal): {_pe_rb}")
+
+                if _is_v2_rb:
+                    # Find the most recent user message timestamp.
+                    _msgs_rb = (_conv_full or {}).get("messages") or []
+                    _latest_user_ts = None
+                    for _m in reversed(_msgs_rb):
+                        if _m.get("role") == "user":
+                            _latest_user_ts = _parse_ts_loose(_m.get("created_at"))
+                            break
+
+                    if _latest_user_ts is not None:
+                        _runs_rb = await db.get_runs_by_conversation(conv_id, limit=20)
+                        _builder_succ_this_turn = 0
+                        _last_builder_role = ""
+                        for _r in _runs_rb:
+                            if not (_r.get("role", "").startswith("builder")
+                                    and _r.get("status") == "succeeded"):
+                                continue
+                            _r_ts = _parse_ts_loose(_r.get("started_at"))
+                            if _r_ts and _r_ts >= _latest_user_ts:
+                                _builder_succ_this_turn += 1
+                                if not _last_builder_role:
+                                    _last_builder_role = _r.get("role", "builder")
+
+                        if _builder_succ_this_turn >= 1:
+                            # Surface a concrete project_dir for the
+                            # write_file / run_review next-step hint.
+                            _pd_rb = ""
+                            for _r in _runs_rb:
+                                _envrb = _r.get("result_envelope") or {}
+                                _pdrb = (_envrb.get("project_dir") or "").strip()
+                                if _pdrb:
+                                    _pd_rb = _pdrb
+                                    break
+                            await events.emit(conv_id, "tool_end", {
+                                "tool": "generate_code", "icon": "package",
+                                "status": "⛔ generate_code already ran this turn — use write_file",
+                            })
+                            print(f"[v2-gate] ANTI-REBUILD: blocking generate_code "
+                                  f"({_builder_succ_this_turn} {_last_builder_role} run(s) "
+                                  f"since user msg)", flush=True)
+                            return (
+                                f"BLOCKED — generate_code already ran "
+                                f"{_builder_succ_this_turn} time(s) this turn "
+                                f"(latest: {_last_builder_role}). The OpenHands "
+                                f"feature-builder is for substantial NEW functionality "
+                                f"(3+ new files, major refactor) — not for fixing 1–3 "
+                                f"line bugs in existing files. Re-running it almost "
+                                f"always produces a worse result than targeted edits.\n\n"
+                                f"For the current user request, do this instead:\n"
+                                f"  1. read_file(path='{_pd_rb or '/root/projects/.../main.py'}')\n"
+                                f"  2. write_file(path='...', content='...')  with the fix\n"
+                                f"  3. run_review(project_dir='{_pd_rb or '/root/projects/...'}')  to verify\n\n"
+                                f"If the user actually wants a major new feature you haven't "
+                                f"built yet, respond with plain text asking them to confirm — "
+                                f"don't silently rebuild what's already there."
+                            )
+            except Exception as _rbe:
+                print(f"[v2-gate] anti-rebuild check failed (non-fatal): {_rbe}")
 
         if conv_id and name not in ("run_review", "run_fixer", "ask_project"):
             try:
@@ -1009,20 +1186,41 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                 elif _pending_review is not None:
                     _rid = _pending_review.get("id", "?")
                     _rstatus_disp = (_pending_review.get("result_envelope") or {}).get("status", "?")
-                    _gate_msg = (
-                        "state", "fix-needed",
-                        f"BLOCKED — run_review ({_rid}) returned status='{_rstatus_disp}' "
-                        f"with issues that have not been addressed.\n\n"
-                        f"Your VERY NEXT tool call MUST be:\n"
-                        f"  run_fixer(reviewer_run_id='{_rid}')\n\n"
-                        f"The Fixer reads each issue's fix-scope files, generates targeted "
-                        f"edits via the coder model, and writes them back. Do NOT manually "
-                        f"call read_file / write_file for these issues — that's the v1 "
-                        f"antipattern that burns rounds. After run_fixer completes, call "
-                        f"run_review again to verify.",
-                        f"⛔ Blocked — call run_fixer first (review {_rid[:14]}… has issues)",
-                        _rid,
+                    # Cap-aware release: once the 3-cycle fixer cap has been
+                    # hit, the same review issues will keep blocking the
+                    # conversation forever. Allow the model to deliver what
+                    # was actually built (download_project / download_file)
+                    # and to inspect the tree (read_file / list_files) so the
+                    # user gets the partial result instead of a dead session.
+                    # write_file / run_shell / generate_code stay blocked —
+                    # further code work won't help once we're past 3 cycles.
+                    _fixer_succ_gate = sum(
+                        1 for _r in _runs_for_v2_gate
+                        if _r.get("role") == "fixer" and _r.get("status") == "succeeded"
                     )
+                    _DELIVERY_OK_AFTER_CAP = {
+                        "download_project", "download_file",
+                        "read_file", "list_files",
+                    }
+                    if _fixer_succ_gate >= 3 and name in _DELIVERY_OK_AFTER_CAP:
+                        print(f"[v2-gate] cap-release: allowing {name} despite "
+                              f"fix-needed (cap reached, {_fixer_succ_gate} fixers)", flush=True)
+                        # Skip _gate_msg entirely → tool runs normally.
+                    else:
+                        _gate_msg = (
+                            "state", "fix-needed",
+                            f"BLOCKED — run_review ({_rid}) returned status='{_rstatus_disp}' "
+                            f"with issues that have not been addressed.\n\n"
+                            f"Your VERY NEXT tool call MUST be:\n"
+                            f"  run_fixer(reviewer_run_id='{_rid}')\n\n"
+                            f"The Fixer reads each issue's fix-scope files, generates targeted "
+                            f"edits via the coder model, and writes them back. Do NOT manually "
+                            f"call read_file / write_file for these issues — that's the v1 "
+                            f"antipattern that burns rounds. After run_fixer completes, call "
+                            f"run_review again to verify.",
+                            f"⛔ Blocked — call run_fixer first (review {_rid[:14]}… has issues)",
+                            _rid,
+                        )
                 elif _terminal_qa is not None:
                     _qid = _terminal_qa.get("id", "?")
                     _gate_msg = (
@@ -2273,7 +2471,9 @@ Be specific. Name actual files, functions, classes, and routes. This plan will b
                 context = (context + "\n\n" + args["code"]).strip()
             elif args.get("code") and task:
                 context = (context + "\n\nReference code:\n" + args["code"]).strip()
-            coder_model = config.CODER_MODEL or conv_model or config.DEFAULT_MODEL
+            # Per-agent override (config.BUILDER_MODEL) wins if pinned; else
+            # umbrella CODER_MODEL, then chat model, then default.
+            coder_model = config.BUILDER_MODEL or config.CODER_MODEL or conv_model or config.DEFAULT_MODEL
 
             # Inject KB context so OpenHands agent has access to uploaded documentation.
             # Bias retrieval toward filenames matching the requested language/framework so a
@@ -2467,11 +2667,15 @@ Be specific. Name actual files, functions, classes, and routes. This plan will b
                         if _ohp:
                             _oh_project_id = _ohp
                             _has_active_project = True
-                            # Stays "scaffold" — no prior builder run means
-                            # the project either was uploaded but never built,
-                            # or the row is a placeholder. Either way the next
-                            # generate_code is creating, not amending.
-                            print(f"[CODEGEN:OH] Active project {_oh_project_id} via coding_projects fallback")
+                            # Promote profile to "feature": an active project
+                            # via coding_projects means files exist on disk
+                            # (uploaded by the user, or written by write_file
+                            # without a generate_code run). Calling generate_code
+                            # against it is amending an existing tree, NOT
+                            # scaffolding a new one. Scaffold-mode would
+                            # clobber the user's code (Bug 8).
+                            _builder_profile = "feature"
+                            print(f"[CODEGEN:OH] Active project {_oh_project_id} via coding_projects fallback (profile=feature)")
                 except Exception as _ap_e:
                     print(f"[CODEGEN:OH] coding_projects lookup failed (non-fatal): {_ap_e}")
 
@@ -2622,6 +2826,9 @@ Be specific. Name actual files, functions, classes, and routes. This plan will b
                 # other profiles ignore it.
                 "profile": _builder_profile,
                 "manifest_missing": _profile_continue_missing,
+                # User-tunable reasoning_effort — drops think-token overhead
+                # significantly on slow local models when set to "low".
+                "reasoning_effort": getattr(config, "OPENHANDS_REASONING_EFFORT", "medium"),
             }
 
             async def _signal_oh_cancel(reason: str):

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -2104,6 +2104,7 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                     http, events, conv_id,
                     task=task, language_hint=language,
                     kb_chunks=_kb_chunks,
+                    conv_model=conv_model,
                 )
                 return architect.format_plan_for_chat(plan)
 

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -1793,7 +1793,8 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
 
             envelope = await reviewer.run_review(http, events, conv_id,
                                                   project_dir=project_dir,
-                                                  project_id=project_id)
+                                                  project_id=project_id,
+                                                  conv_model=conv_model)
             # Format the envelope as a tool-result string the chat agent can read
             # without needing to know the JSON schema. Keep it compact.
             status = envelope.get("status", "?")
@@ -2104,6 +2105,7 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                     http, events, conv_id,
                     task=task, language_hint=language,
                     kb_chunks=_kb_chunks,
+                    conv_model=conv_model,
                 )
                 return architect.format_plan_for_chat(plan)
 
@@ -2946,7 +2948,7 @@ Be specific. Name actual files, functions, classes, and routes. This plan will b
                 # Uses a separate model from the coder so it can't rationalize its own mistakes.
                 critique = ""
                 if code_review and config.CRITIC_ENABLED:
-                    critic_model = config.CRITIC_MODEL or config.PLANNING_MODEL or config.DEFAULT_MODEL
+                    critic_model = config.CRITIC_MODEL or config.PLANNING_MODEL or conv_model or config.DEFAULT_MODEL
                     await events.emit(conv_id, "tool_progress", {
                         "tool": "generate_code", "icon": "wand",
                         "status": f"🔍 Reviewing code with {critic_model}...",

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -39,6 +39,119 @@ def _parse_ts_loose(s) -> "datetime | None":
     return None
 
 
+# In-process cache of the most recent deep_research result per conversation.
+# The full research report only exists in the orchestrator's in-memory tool
+# history for the current turn — saved_events keeps a summary but not the
+# body. Caching it here lets the Fixer dispatcher pick it up across the
+# orchestrator/fixer boundary without persisting research bodies to SQLite
+# or breaking the Fixer's network-free contract. Bounded to the most-recent
+# 32 conversations (LRU-ish via insertion order); freshness window enforced
+# at read time, not write time.
+_RECENT_RESEARCH: "dict[str, dict]" = {}
+_RECENT_RESEARCH_MAX = 32
+_RESEARCH_FRESH_SECONDS = 600  # 10 min — drop on next read past this
+
+
+def _stash_research_result(conv_id: str, topic: str, report: str) -> None:
+    """Record the most recent deep_research result for this conv. Bounded:
+    when the cache exceeds the cap, the oldest insertion is evicted."""
+    if not conv_id or not report:
+        return
+    _RECENT_RESEARCH[conv_id] = {
+        "topic": topic or "",
+        "report": report,
+        "ts": time.time(),
+    }
+    if len(_RECENT_RESEARCH) > _RECENT_RESEARCH_MAX:
+        # Drop oldest by insertion order (dict preserves it in 3.7+).
+        _oldest = next(iter(_RECENT_RESEARCH))
+        _RECENT_RESEARCH.pop(_oldest, None)
+
+
+def _get_recent_research(conv_id: str) -> "dict | None":
+    """Return the cached research entry for conv_id if it's still within the
+    freshness window, else None. Stale entries are dropped on read."""
+    entry = _RECENT_RESEARCH.get(conv_id)
+    if not entry:
+        return None
+    if (time.time() - entry.get("ts", 0)) > _RESEARCH_FRESH_SECONDS:
+        _RECENT_RESEARCH.pop(conv_id, None)
+        return None
+    return entry
+
+
+def _issue_signatures(envelope: dict) -> set:
+    """Reduce a reviewer envelope to a set of (file, summary_prefix) tuples
+    suitable for set-overlap comparison. Used by the v2 gate to detect
+    'same problem returned' across run_review cycles. Summary prefix is
+    lowercased + stripped + truncated to 60 chars so trivial wording diffs
+    don't defeat the overlap check, but the file path must match exactly."""
+    sigs = set()
+    for iss in (envelope or {}).get("issues") or []:
+        f = (iss.get("file") or "").strip()
+        s = (iss.get("summary") or "").strip().lower()[:60]
+        if f and s:
+            sigs.add((f, s))
+    return sigs
+
+
+async def _deep_research_called_since(conv_id: str, since_iso: str | None) -> bool:
+    """Return True iff at least one assistant message after `since_iso` has a
+    persisted tool_start event for the deep_research tool. Used by the v2
+    gate to verify the model actually researched a recurring error before
+    retrying run_fixer."""
+    if not since_iso:
+        return False
+    try:
+        conv = await db.get_conversation(conv_id)
+        msgs = (conv or {}).get("messages") or []
+        since_ts = _parse_ts_loose(since_iso)
+        for m in reversed(msgs):
+            if m.get("role") != "assistant":
+                continue
+            m_ts = _parse_ts_loose(m.get("created_at"))
+            if since_ts and m_ts and m_ts < since_ts:
+                # Once we walk past the trigger run, we can stop.
+                return False
+            md = m.get("metadata") or {}
+            if isinstance(md, str):
+                try:
+                    md = json.loads(md)
+                except Exception:
+                    md = {}
+            for ev in md.get("saved_events") or []:
+                if ev.get("type") != "tool_start":
+                    continue
+                if (ev.get("data") or {}).get("tool") == "deep_research":
+                    return True
+        return False
+    except Exception as _e:
+        print(f"[v2-gate] deep_research history check failed (non-fatal): {_e}")
+        return False
+
+
+async def _is_v2_persona(conv_id: str, conv_row: dict | None = None) -> bool:
+    """Return True iff this conversation's persona name contains 'v2'.
+
+    Centralised so the workflow gate doesn't repeat the same db lookup +
+    string match in five different places. Pass conv_row if the caller has
+    already fetched it to avoid a second db query. Failures are non-fatal
+    and return False (fail-safe — gate stays off rather than mis-firing on
+    a v1 persona)."""
+    try:
+        if conv_row is None:
+            conv_row = await db.get_conversation(conv_id)
+        _mc_id = (conv_row or {}).get("model_config_id") if conv_row else None
+        if not _mc_id:
+            return False
+        _all_mc = await db.get_model_configs()
+        _mc = next((m for m in _all_mc if m.get("id") == _mc_id), None)
+        return bool(_mc and "v2" in (_mc.get("name") or "").lower())
+    except Exception as _e:
+        print(f"[v2-gate] persona lookup failed (non-fatal): {_e}")
+        return False
+
+
 # ── Ollama-native tool definitions ──
 # Keep descriptions SHORT and CLEAR. Models perform better with concise tool docs.
 CODEAGENT_TOOLS = {
@@ -904,21 +1017,8 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                     if r.get("role") == "fixer" and r.get("status") == "succeeded"
                 )
                 if _fixer_succ >= 3:
-                    # Detect v2 persona; v1 doesn't run this loop, so no need
-                    # to enforce the cap there.
-                    _is_v2_cap = False
-                    try:
-                        _conv_row = await db.get_conversation(conv_id)
-                        _mc_id = (_conv_row or {}).get("model_config_id") if _conv_row else None
-                        if _mc_id:
-                            _all_mc = await db.get_model_configs()
-                            _mc = next((m for m in _all_mc if m.get("id") == _mc_id), None)
-                            if _mc and "v2" in (_mc.get("name") or "").lower():
-                                _is_v2_cap = True
-                    except Exception as _pe:
-                        print(f"[v2-gate] cap persona lookup failed (non-fatal): {_pe}")
-
-                    if _is_v2_cap:
+                    # v1 doesn't run this loop, so cap only applies to v2.
+                    if await _is_v2_persona(conv_id):
                         # Pull the latest reviewer's summary so the model has
                         # specifics to relay to the user.
                         _last_rev = next(
@@ -965,6 +1065,113 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
             except Exception as _ce:
                 print(f"[v2-gate] cycle cap check failed (non-fatal): {_ce}")
 
+            # ─── State 5+6 — STUCK_FIX / FINAL_CYCLE — research nudge ───────
+            # If the model is about to call run_fixer for the 2nd or 3rd time
+            # AND either (a) the same issue signatures returned across reviewer
+            # cycles, or (b) this would be the 3rd (last-allowed) fixer run,
+            # block until deep_research has been called. The persona prompt
+            # tells the model to do this; the gate enforces it server-side.
+            #
+            # Uses the same _runs_for_cap walk as the cycle cap — cheap because
+            # we already paid for that db hit above, but defensive in case the
+            # cap try-block bailed before populating it.
+            try:
+                _runs_sf = locals().get("_runs_for_cap")
+                if _runs_sf is None:
+                    _runs_sf = await db.get_runs_by_conversation(conv_id, limit=20)
+                _fsucc_sf = sum(
+                    1 for r in _runs_sf
+                    if r.get("role") == "fixer" and r.get("status") == "succeeded"
+                )
+                # 1 ≤ fixer_succ ≤ 2: between first failure and final cycle.
+                # 0 = first attempt, no gate. ≥3 = cap (handled above).
+                if 1 <= _fsucc_sf <= 2 and await _is_v2_persona(conv_id):
+                    _latest_rev_sf = next(
+                        (r for r in _runs_sf if r.get("role") == "reviewer"),
+                        None,
+                    )
+                    if _latest_rev_sf:
+                        _cur_iss = _issue_signatures(_latest_rev_sf.get("result_envelope") or {})
+                        _research_done = await _deep_research_called_since(
+                            conv_id, _latest_rev_sf.get("started_at")
+                        )
+
+                        # State 5 — STUCK: same issue signature seen in a prior
+                        # reviewer run AND no research call since.
+                        _is_stuck = False
+                        if _cur_iss:
+                            _prior_revs_sf = [
+                                r for r in _runs_sf
+                                if r.get("role") == "reviewer"
+                                and r.get("id") != _latest_rev_sf.get("id")
+                            ]
+                            if _prior_revs_sf:
+                                _prior_rev_sf = _prior_revs_sf[0]
+                                _prior_iss = _issue_signatures(
+                                    _prior_rev_sf.get("result_envelope") or {}
+                                )
+                                if _cur_iss & _prior_iss:
+                                    _is_stuck = True
+
+                        # State 6 — FINAL CYCLE: about to use the last fixer
+                        # slot (3rd attempt). Research before the last shot.
+                        _is_final = (_fsucc_sf == 2)
+
+                        if (_is_stuck or _is_final) and not _research_done:
+                            _why_label = ("STUCK" if _is_stuck else "FINAL_CYCLE")
+                            _gate_status = (
+                                "⛔ Same issue returned — call deep_research first"
+                                if _is_stuck else
+                                "⛔ Final fixer cycle — call deep_research first"
+                            )
+                            # Pull a representative error to seed the research topic.
+                            _seed_iss = (_latest_rev_sf.get("result_envelope") or {}).get("issues") or []
+                            _seed_lines = []
+                            for _i, _iss in enumerate(_seed_iss[:2], 1):
+                                _seed_lines.append(
+                                    f"  {_i}. [{_iss.get('severity','?')}] "
+                                    f"{_iss.get('file','?')}"
+                                    + (f":{','.join(str(x) for x in _iss.get('lines') or [])}" if _iss.get('lines') else "")
+                                    + f" — {(_iss.get('summary','') or '')[:160]}"
+                                )
+                            _seed_block = ("\n" + "\n".join(_seed_lines)) if _seed_lines else ""
+
+                            await events.emit(conv_id, "tool_end", {
+                                "tool": "run_fixer", "icon": "wrench",
+                                "status": _gate_status,
+                            })
+                            print(f"[v2-gate] {_why_label}: blocking run_fixer "
+                                  f"(fixer_succ={_fsucc_sf}, stuck={_is_stuck}, "
+                                  f"final={_is_final}, research_done={_research_done})", flush=True)
+
+                            if _is_stuck:
+                                _reason = (
+                                    f"BLOCKED — run_review returned the same issue(s) you already "
+                                    f"attempted to fix in a previous run_fixer cycle ({_fsucc_sf} fixer "
+                                    f"run(s) so far). Calling run_fixer again without new information "
+                                    f"will produce the same result.\n"
+                                )
+                            else:
+                                _reason = (
+                                    f"BLOCKED — this would be your 3rd (final) run_fixer call. "
+                                    f"After it, the cycle cap blocks any further fixer runs. "
+                                    f"Spend one round on web research before the last shot.\n"
+                                )
+
+                            return (
+                                _reason
+                                + "\nRecurring issue(s):" + _seed_block + "\n\n"
+                                + "Your VERY NEXT tool call MUST be:\n"
+                                + "  deep_research(topic='<exact error message + library/version>', depth=2)\n\n"
+                                + "After deep_research returns, call run_fixer — the Fixer will see the "
+                                + "research result in your conversation and use it to ground the next "
+                                + "edit. Use depth=2 (fast); only use depth=3 if the issue is genuinely "
+                                + "obscure. Do NOT call run_fixer, generate_code, write_file, run_shell, "
+                                + "or run_review until deep_research has run."
+                            )
+            except Exception as _sfe:
+                print(f"[v2-gate] stuck/final-cycle check failed (non-fatal): {_sfe}")
+
             # Phantom run_fixer guard: block run_fixer when the latest run
             # isn't a reviewer with status='issues'/'error'. Without this,
             # a hallucinated reviewer_run_id (the model sometimes invents
@@ -975,19 +1182,7 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
             # legitimate "reviewer just ran with issues → call run_fixer"
             # case; this guard handles every other case.
             try:
-                _is_v2_pf = False
-                try:
-                    _conv_row_pf = await db.get_conversation(conv_id)
-                    _mc_id_pf = (_conv_row_pf or {}).get("model_config_id") if _conv_row_pf else None
-                    if _mc_id_pf:
-                        _all_mc_pf = await db.get_model_configs()
-                        _mc_pf = next((m for m in _all_mc_pf if m.get("id") == _mc_id_pf), None)
-                        if _mc_pf and "v2" in (_mc_pf.get("name") or "").lower():
-                            _is_v2_pf = True
-                except Exception as _pe_inner:
-                    print(f"[v2-gate] phantom-fixer persona lookup failed (non-fatal): {_pe_inner}")
-
-                if _is_v2_pf:
+                if await _is_v2_persona(conv_id):
                     _runs_pf = await db.get_runs_by_conversation(conv_id, limit=20)
                     _latest_meaningful = None
                     _MEANINGFUL_STATUSES = {"succeeded", "issues", "clean", "partial",
@@ -1049,20 +1244,8 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
         # always produces a worse result than 2 surgical write_file edits.
         if conv_id and name == "generate_code":
             try:
-                _is_v2_rb = False
-                _conv_full = None
-                try:
-                    _conv_full = await db.get_conversation(conv_id)
-                    _mc_id_rb = (_conv_full or {}).get("model_config_id")
-                    if _mc_id_rb:
-                        _all_mc_rb = await db.get_model_configs()
-                        _mc_rb = next((m for m in _all_mc_rb if m.get("id") == _mc_id_rb), None)
-                        if _mc_rb and "v2" in (_mc_rb.get("name") or "").lower():
-                            _is_v2_rb = True
-                except Exception as _pe_rb:
-                    print(f"[v2-gate] anti-rebuild persona lookup failed (non-fatal): {_pe_rb}")
-
-                if _is_v2_rb:
+                _conv_full = await db.get_conversation(conv_id)
+                if await _is_v2_persona(conv_id, conv_row=_conv_full):
                     # Find the most recent user message timestamp.
                     _msgs_rb = (_conv_full or {}).get("messages") or []
                     _latest_user_ts = None
@@ -1241,21 +1424,9 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                     )
 
                 if _gate_msg is not None:
-                    # Detect v2 persona before actually blocking. v1 has no
-                    # run_review or run_fixer in its workflow.
-                    _is_v2 = False
-                    try:
-                        _conv_row = await db.get_conversation(conv_id)
-                        _mc_id = (_conv_row or {}).get("model_config_id") if _conv_row else None
-                        if _mc_id:
-                            _all_mc = await db.get_model_configs()
-                            _mc = next((m for m in _all_mc if m.get("id") == _mc_id), None)
-                            if _mc and "v2" in (_mc.get("name") or "").lower():
-                                _is_v2 = True
-                    except Exception as _pe:
-                        print(f"[v2-gate] persona lookup failed (non-fatal): {_pe}")
-
-                    if _is_v2:
+                    # v1 has no run_review or run_fixer in its workflow, so
+                    # the gate only blocks v2 personas.
+                    if await _is_v2_persona(conv_id):
                         _, _state_label, _body, _short_status, _trigger_id = _gate_msg
                         await events.emit(conv_id, "tool_end", {
                             "tool": name, "icon": "code",
@@ -2082,8 +2253,26 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                 "status": f"🛠 Starting Fixer for review {reviewer_run_id[:14]}…",
             })
 
+            # If a recent deep_research call happened on this conv, hand its
+            # report to the Fixer as supporting context. Cached at the call
+            # site (see _stash_research_result), so this stays in-process and
+            # doesn't break the Fixer's network-free invariant. Stale entries
+            # (>10 min) are dropped on read by _get_recent_research.
+            _research_for_fixer = ""
+            try:
+                _r_entry = _get_recent_research(conv_id)
+                if _r_entry:
+                    _research_for_fixer = _r_entry.get("report", "") or ""
+                    if _research_for_fixer:
+                        print(f"[run_fixer] injecting research_context "
+                              f"({len(_research_for_fixer)} chars, "
+                              f"topic={(_r_entry.get('topic') or '')[:60]!r})")
+            except Exception as _re:
+                print(f"[run_fixer] research lookup failed (non-fatal): {_re}")
+
             envelope = await fixer.run_fixer(http, events, conv_id,
-                                              reviewer_run_id=reviewer_run_id)
+                                              reviewer_run_id=reviewer_run_id,
+                                              research_context=_research_for_fixer)
 
             f_status = envelope.get("status", "?")
             files = envelope.get("files_touched") or []
@@ -2267,18 +2456,7 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
             # consume directly, instead of the v1 prose plan that every
             # downstream agent has to re-parse from markdown. v1 personas
             # keep the existing prose path below.
-            _is_v2_for_plan = False
-            if conv_id:
-                try:
-                    _conv_row = await db.get_conversation(conv_id)
-                    _mc_id = (_conv_row or {}).get("model_config_id") if _conv_row else None
-                    if _mc_id:
-                        _all_mc = await db.get_model_configs()
-                        _mc = next((m for m in _all_mc if m.get("id") == _mc_id), None)
-                        if _mc and "v2" in (_mc.get("name") or "").lower():
-                            _is_v2_for_plan = True
-                except Exception as _pe:
-                    print(f"[plan_project] persona lookup failed (non-fatal): {_pe}")
+            _is_v2_for_plan = bool(conv_id) and await _is_v2_persona(conv_id)
 
             if _is_v2_for_plan:
                 from agents import architect
@@ -2439,7 +2617,12 @@ Be specific. Name actual files, functions, classes, and routes. This plan will b
                 parts.append("\n\n---\n## Sources\n")
                 for s in sources[:20]:
                     parts.append(f"[{s.get('index','?')}] [{s.get('title','?')}]({s.get('url','')})")
-            return "\n".join(parts)
+            _full_report = "\n".join(parts)
+            # Cache the result so the Fixer dispatcher can inject it into
+            # the next run_fixer call without making the Fixer itself read
+            # the conversation. Keeps fixer.py network-free.
+            _stash_research_result(conv_id, topic, _full_report)
+            return _full_report
 
         elif name == "conspiracy_research":
             topic = args.get("topic", "")

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -13,6 +13,7 @@ from datetime import datetime
 
 import config
 import database as db
+import cancel_registry
 from research import run_deep_research, run_conspiracy_research, _fetch_page, _source_tier
 
 # Strip ANSI escape codes from terminal output before feeding back to the model
@@ -96,10 +97,31 @@ def _issue_signatures(envelope: dict) -> set:
 
 
 async def _deep_research_called_since(conv_id: str, since_iso: str | None) -> bool:
-    """Return True iff at least one assistant message after `since_iso` has a
-    persisted tool_start event for the deep_research tool. Used by the v2
-    gate to verify the model actually researched a recurring error before
-    retrying run_fixer."""
+    """Return True iff deep_research has run on this conversation since the
+    trigger event at `since_iso`. Checks two sources:
+
+      1. In-process `_RECENT_RESEARCH` cache (10-min freshness, populated
+         immediately when deep_research's dispatcher returns). This is what
+         catches mid-stream calls — a model that calls deep_research and
+         then run_fixer in the same turn won't have the deep_research event
+         persisted to the conversation yet (assistant message is only saved
+         at stream end), so the DB walk below misses it. Without this check,
+         the FINAL_CYCLE / STUCK_FIX gates fire a second time, the model
+         dutifully re-runs deep_research, and the user sees duplicate
+         carousels and ~3 minutes of wasted research.
+      2. Persisted assistant messages' saved_events (cross-stream / restart
+         survival). Only consulted when (1) returns nothing.
+    """
+    # In-stream check first — matches what's already populated via
+    # `_stash_research_result` on deep_research completion. The cache is
+    # keyed by conv_id, so the freshness gate (10 min) is enough — we don't
+    # need to re-check the timestamp.
+    try:
+        if conv_id and _get_recent_research(conv_id):
+            return True
+    except Exception as _e:
+        print(f"[v2-gate] in-stream research cache check failed (non-fatal): {_e}")
+
     if not since_iso:
         return False
     try:
@@ -128,6 +150,158 @@ async def _deep_research_called_since(conv_id: str, since_iso: str | None) -> bo
     except Exception as _e:
         print(f"[v2-gate] deep_research history check failed (non-fatal): {_e}")
         return False
+
+
+# Pytest "FAILED tests/foo.py::test_x - reason" line, plus a fallback for
+# generic "FAILED <path>:<line>" / "ERROR tests/foo.py" forms. Captures the
+# file path so the synthesized reviewer envelope can route Fixer to the
+# right `suggested_fix_scope` files.
+_PYTEST_FAIL_RE = re.compile(
+    r"^(?:FAILED|ERROR)\s+([\w./\-]+\.py)(?:::([\w.\[\]<>:_-]+))?(?:\s*-\s*(.{0,200}))?",
+    re.MULTILINE,
+)
+_PYTEST_IMPORT_ERR_RE = re.compile(
+    r"(?:ModuleNotFoundError|ImportError):\s*(.{0,160})", re.MULTILINE,
+)
+
+
+async def _synthesize_reviewer_from_test_failure(
+    conv_id: str, test_output: str, project_dir: str,
+    framework: str, elapsed: float,
+) -> str:
+    """If the most recent reviewer on this conv reported clean but run_tests
+    just failed, persist a NEW reviewer-role run row whose envelope encodes
+    the test failures as a real `issues` list. Returns the new run_id, or ""
+    if no synthesis was warranted (e.g. no prior clean reviewer found).
+
+    The synthesized run is the same shape the real Reviewer would produce, so
+    `run_fixer(reviewer_run_id=...)` works without modification. Distinguished
+    from a real reviewer envelope only by `synthetic: True` in the envelope
+    (kept for diagnostics — Fixer ignores the field).
+    """
+    # Find the most recent run_review for this conversation.
+    try:
+        runs = await db.get_runs_by_conversation(conv_id, limit=20)
+    except Exception:
+        return ""
+    last_review = next(
+        (r for r in runs if r.get("role") == "reviewer"
+         and (r.get("status") or "").lower() == "succeeded"),
+        None,
+    )
+    if not last_review:
+        # No prior reviewer means there's no false negative to compensate for.
+        # Don't synthesize — just let run_tests' default response stand.
+        return ""
+
+    rev_env = last_review.get("result_envelope") or {}
+    rev_test_exit = rev_env.get("test_exit", -1)
+    rev_status = (rev_env.get("status") or "").lower()
+    # Only synthesize if reviewer claimed clean. If reviewer already reported
+    # issues, the model has a real envelope to fix against.
+    if rev_status != "clean" and rev_test_exit != 0:
+        return ""
+
+    # Parse test output into structured issues. Group by file so multiple
+    # failing tests in the same file collapse to a single fixer scope.
+    by_file: dict[str, list[dict]] = {}
+    for m in _PYTEST_FAIL_RE.finditer(test_output or ""):
+        f = m.group(1)
+        test_name = m.group(2) or ""
+        reason = (m.group(3) or "").strip()
+        by_file.setdefault(f, []).append({"test": test_name, "reason": reason})
+
+    issues = []
+    for f, fails in list(by_file.items())[:8]:  # cap
+        # Resolve relative path → absolute under project_dir for fixer scope.
+        abs_path = f if f.startswith("/") else f"{project_dir.rstrip('/')}/{f}"
+        summary_lines = [f"{x['test']}: {x['reason'][:120]}" for x in fails[:3] if x['reason']]
+        summary = (f"{len(fails)} failing test(s) in {f}: "
+                   + ("; ".join(summary_lines) if summary_lines else "see test output"))
+        issues.append({
+            "severity": "test",
+            "file": abs_path,
+            "lines": [],
+            "summary": summary[:300],
+            # Scope to the test file plus a guess at the source-under-test —
+            # if path is `tests/test_foo.py`, also include `src/foo.py` /
+            # `foo.py`. Fixer's scope check only writes files we list, so
+            # be conservative.
+            "suggested_fix_scope": _guess_fix_scope(abs_path, project_dir),
+        })
+
+    # If no FAILED lines parsed but pytest still exited non-zero, fall back to
+    # a single catch-all issue so the model has something to call run_fixer on.
+    if not issues:
+        ie_match = _PYTEST_IMPORT_ERR_RE.search(test_output or "")
+        ie_summary = (f"ImportError during test collection: {ie_match.group(1).strip()}"
+                      if ie_match else
+                      "Tests failed but no FAILED lines parsed — see test output")
+        issues.append({
+            "severity": "test",
+            "file": project_dir,
+            "lines": [],
+            "summary": ie_summary[:300],
+            "suggested_fix_scope": [],
+        })
+
+    # Persist the synthesized envelope as a real run row so Fixer + the
+    # frontend RunCard treat it identically to a normal reviewer run.
+    new_id = f"run-{uuid.uuid4().hex[:12]}"
+    envelope = {
+        "status": "issues",
+        "summary": (f"Synthesized from run_tests failure ({framework}, {elapsed:.1f}s) "
+                    f"after Reviewer reported clean. {len(issues)} issue(s) detected."),
+        "issues": issues,
+        "build_cmd": rev_env.get("build_cmd", ""),
+        "test_cmd": rev_env.get("test_cmd", ""),
+        "lint_cmd": rev_env.get("lint_cmd", ""),
+        "build_exit": rev_env.get("build_exit", 0),  # build wasn't re-run
+        "test_exit": 1,                              # synthesized failure
+        "lint_exit": rev_env.get("lint_exit", 0),
+        "language": rev_env.get("language", "python"),
+        "marker": rev_env.get("marker", ""),
+        "project_dir": project_dir,
+        "review_model": "(synthesized from run_tests)",
+        "synthetic": True,
+        "source_run_id": last_review.get("id", ""),
+        "run_id": new_id,
+    }
+    try:
+        await db.create_run(new_id, conv_id, role="reviewer",
+                            project_id=last_review.get("project_id", ""),
+                            parent_run_id=last_review.get("id", ""),
+                            status="succeeded")
+        await db.update_run(new_id, status="succeeded",
+                            result_envelope=envelope, ended=True)
+    except Exception as e:
+        print(f"[TRIPWIRE] persist synthesized review failed: {e}")
+        return ""
+    return new_id
+
+
+def _guess_fix_scope(test_file_abs: str, project_dir: str) -> list[str]:
+    """Given a failing test file, propose the source files Fixer should be
+    allowed to edit. Conservative — we list the test file itself plus the
+    most plausible source-under-test sibling, never a glob."""
+    pdir = project_dir.rstrip("/")
+    scope = [test_file_abs]
+    base = os.path.basename(test_file_abs)
+    # tests/test_foo.py → foo.py / src/foo.py / app/foo.py
+    if base.startswith("test_") and base.endswith(".py"):
+        stem = base[5:]  # foo.py
+        for cand in (f"{pdir}/src/{stem}", f"{pdir}/{stem}",
+                     f"{pdir}/app/{stem}", f"{pdir}/lib/{stem}"):
+            scope.append(cand)
+    elif base.endswith("_test.py"):
+        stem = base[:-len("_test.py")] + ".py"
+        for cand in (f"{pdir}/src/{stem}", f"{pdir}/{stem}"):
+            scope.append(cand)
+    # Dedup, preserve order.
+    seen = set(); out = []
+    for p in scope:
+        if p not in seen: seen.add(p); out.append(p)
+    return out
 
 
 async def _is_v2_persona(conv_id: str, conv_row: dict | None = None) -> bool:
@@ -1385,7 +1559,25 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                         "download_project", "download_file",
                         "read_file", "list_files",
                     }
-                    if _fixer_succ_gate >= 3 and name in _DELIVERY_OK_AFTER_CAP:
+                    # Deadlock break: the FINAL_CYCLE gate (2 successful fixers,
+                    # no research since the last reviewer) blocks run_fixer with
+                    # the message "call deep_research first". The STUCK_FIX gate
+                    # does the same when issues recur after a fix cycle. But this
+                    # post-review gate then blocks deep_research itself ("call
+                    # run_fixer first") — circular. Whitelist deep_research once
+                    # at least one fixer cycle has run, so the model can satisfy
+                    # the research-first requirement and then retry run_fixer on
+                    # the next round. Below 1 fixer attempt the model should
+                    # actually try fixing before researching.
+                    if (name == "deep_research"
+                            and _fixer_succ_gate >= 1
+                            and not await _deep_research_called_since(
+                                conv_id, _pending_review.get("ended_at"))):
+                        print(f"[v2-gate] research-release: allowing deep_research "
+                              f"despite fix-needed (fixer_succ={_fixer_succ_gate}, "
+                              f"required by FINAL_CYCLE/STUCK_FIX)", flush=True)
+                        # Skip _gate_msg → deep_research runs.
+                    elif _fixer_succ_gate >= 3 and name in _DELIVERY_OK_AFTER_CAP:
                         print(f"[v2-gate] cap-release: allowing {name} despite "
                               f"fix-needed (cap reached, {_fixer_succ_gate} fixers)", flush=True)
                         # Skip _gate_msg entirely → tool runs normally.
@@ -2024,6 +2216,35 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
             parts = [f"**{'TESTS PASSED' if ok else 'TESTS FAILED'}** | {framework} | {elapsed:.1f}s\n"]
             if output:
                 parts.append(f"```\n{output[:8000]}\n```")
+
+            # Post-clean tripwire: if run_tests just failed but the most recent
+            # run_review on this conversation reported test_exit=0 / status=clean,
+            # the reviewer is producing a false negative (e.g. its test_cmd
+            # swallowed pytest's exit code via `|| echo`). Synthesize a real
+            # reviewer envelope from this run_tests output so run_fixer becomes
+            # callable with a non-empty `issues` list. Without this, the model
+            # falls back to v1's manual write_file loop because `run_fixer`
+            # against a clean reviewer envelope returns status='skipped'.
+            if not ok and conv_id and framework == "pytest":
+                try:
+                    synth_id = await _synthesize_reviewer_from_test_failure(
+                        conv_id, output, path, framework, elapsed,
+                    )
+                    if synth_id:
+                        parts.append(
+                            f"\n\n⚠ **Reviewer false-negative detected.** "
+                            f"The latest `run_review` on this conversation reported "
+                            f"`status=clean / test_exit=0`, but `run_tests` just failed. "
+                            f"Synthesized a reviewer envelope from this failure: "
+                            f"`{synth_id}`.\n\n"
+                            f"**Next step — call `run_fixer(reviewer_run_id='{synth_id}')`** "
+                            f"to apply targeted fixes. Do NOT call `write_file` manually for "
+                            f"the failing files — that's the v1 antipattern v2 is meant to "
+                            f"replace, and the v2 gate will block it on the next round."
+                        )
+                except Exception as _twe:
+                    print(f"[TRIPWIRE] synthesize failed (non-fatal): {_twe}")
+
             return "\n".join(parts)
 
         elif name == "lint_code":
@@ -2471,10 +2692,25 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                 if kb_ids:
                     try:
                         import rag
+                        _hints = _kb_filename_hints_for_language(language, task)
                         _kb_chunks = await rag.query(
                             kb_ids, query_text=task[:500], top_k=3,
-                            prefer_filename_hints=_kb_filename_hints_for_language(language, task),
+                            prefer_filename_hints=_hints,
                         )
+                        # Visibility for "is the KB actually being used" question.
+                        # Logs the filenames + scores so you can see at a glance
+                        # whether retrieval found anything relevant.
+                        if _kb_chunks:
+                            _kb_summary = ", ".join(
+                                f"{c.get('filename','?')}({c.get('score',0):.2f})"
+                                for c in _kb_chunks
+                            )
+                            print(f"[plan_project] KB chunks for architect: "
+                                  f"kb_ids={kb_ids} hints={_hints} → {_kb_summary}",
+                                  flush=True)
+                        else:
+                            print(f"[plan_project] No KB chunks returned "
+                                  f"(kb_ids={kb_ids}, hints={_hints})", flush=True)
                     except Exception as _rge:
                         print(f"[plan_project] RAG query failed (non-fatal): {_rge}")
                 plan = await architect.run_architect(
@@ -2761,13 +2997,33 @@ Be specific. Name actual files, functions, classes, and routes. This plan will b
             _run_row_created = False
 
             async def _finalize_run(status: str, envelope: dict):
-                """Mark the run terminal with the given status + envelope. Safe to no-op."""
+                """Mark the run terminal with the given status + envelope. Safe to no-op.
+
+                Also stops the cancel-watcher task and removes the cancel
+                event from the registry — every terminal path goes through
+                here, so this is the right place to release those resources.
+                """
                 if not _run_id:
                     return
                 try:
                     await db.update_run(_run_id, status=status, result_envelope=envelope, ended=True)
                 except Exception as _fre:
                     print(f"[RUN] finalize failed (non-fatal): {_fre}")
+                # Stop the cancel watcher (if it's still waiting) and drop
+                # the registry entry. Defined later in this block but bound
+                # via closure so we reference them by nonlocal lookup.
+                _watcher = _cancel_watcher_ref[0] if _cancel_watcher_ref else None
+                if _watcher and not _watcher.done():
+                    _watcher.cancel()
+                    try:
+                        await _watcher
+                    except (asyncio.CancelledError, BaseException):
+                        pass
+                cancel_registry.cleanup(_run_id)
+
+            # Container so _finalize_run (defined above) can see the watcher
+            # task even though it's created several blocks below.
+            _cancel_watcher_ref: list = [None]
 
             await events.emit(conv_id, "tool_start", {
                 "tool": "generate_code", "icon": "wand",
@@ -3026,6 +3282,21 @@ Be specific. Name actual files, functions, classes, and routes. This plan will b
                     print(f"[CODEGEN:OH] Cancel signal sent to worker for {_run_id} ({reason})", flush=True)
                 except Exception as ce:
                     print(f"[CODEGEN:OH] Cancel signal failed for {_run_id}: {ce}", flush=True)
+
+            # Register the cancel event for this run so POST
+            # /api/runs/{id}/cancel from the frontend Stop button can fire
+            # _signal_oh_cancel without needing the chat stream to disconnect
+            # first. _finalize_run cancels the watcher + drops the registry
+            # entry on every terminal path.
+            _cancel_event = cancel_registry.register(_run_id) if _run_id else None
+            if _cancel_event is not None:
+                async def _on_user_cancel():
+                    try:
+                        await _cancel_event.wait()
+                    except asyncio.CancelledError:
+                        return
+                    await _signal_oh_cancel("user pressed Stop (POST /api/runs/{id}/cancel)")
+                _cancel_watcher_ref[0] = asyncio.create_task(_on_user_cancel())
 
             # Action → emoji mapping for progress pills
             _ACTION_ICONS = {

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -1793,8 +1793,7 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
 
             envelope = await reviewer.run_review(http, events, conv_id,
                                                   project_dir=project_dir,
-                                                  project_id=project_id,
-                                                  conv_model=conv_model)
+                                                  project_id=project_id)
             # Format the envelope as a tool-result string the chat agent can read
             # without needing to know the JSON schema. Keep it compact.
             status = envelope.get("status", "?")
@@ -1885,8 +1884,7 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
             })
 
             envelope = await fixer.run_fixer(http, events, conv_id,
-                                              reviewer_run_id=reviewer_run_id,
-                                              conv_model=conv_model)
+                                              reviewer_run_id=reviewer_run_id)
 
             f_status = envelope.get("status", "?")
             files = envelope.get("files_touched") or []
@@ -2106,7 +2104,6 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                     http, events, conv_id,
                     task=task, language_hint=language,
                     kb_chunks=_kb_chunks,
-                    conv_model=conv_model,
                 )
                 return architect.format_plan_for_chat(plan)
 
@@ -2949,7 +2946,7 @@ Be specific. Name actual files, functions, classes, and routes. This plan will b
                 # Uses a separate model from the coder so it can't rationalize its own mistakes.
                 critique = ""
                 if code_review and config.CRITIC_ENABLED:
-                    critic_model = config.CRITIC_MODEL or conv_model or config.CODER_MODEL or config.DEFAULT_MODEL
+                    critic_model = config.CRITIC_MODEL or config.PLANNING_MODEL or config.DEFAULT_MODEL
                     await events.emit(conv_id, "tool_progress", {
                         "tool": "generate_code", "icon": "wand",
                         "status": f"🔍 Reviewing code with {critic_model}...",

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -1793,7 +1793,8 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
 
             envelope = await reviewer.run_review(http, events, conv_id,
                                                   project_dir=project_dir,
-                                                  project_id=project_id)
+                                                  project_id=project_id,
+                                                  conv_model=conv_model)
             # Format the envelope as a tool-result string the chat agent can read
             # without needing to know the JSON schema. Keep it compact.
             status = envelope.get("status", "?")
@@ -1884,7 +1885,8 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
             })
 
             envelope = await fixer.run_fixer(http, events, conv_id,
-                                              reviewer_run_id=reviewer_run_id)
+                                              reviewer_run_id=reviewer_run_id,
+                                              conv_model=conv_model)
 
             f_status = envelope.get("status", "?")
             files = envelope.get("files_touched") or []
@@ -2947,7 +2949,7 @@ Be specific. Name actual files, functions, classes, and routes. This plan will b
                 # Uses a separate model from the coder so it can't rationalize its own mistakes.
                 critique = ""
                 if code_review and config.CRITIC_ENABLED:
-                    critic_model = config.CRITIC_MODEL or config.PLANNING_MODEL or config.DEFAULT_MODEL
+                    critic_model = config.CRITIC_MODEL or conv_model or config.CODER_MODEL or config.DEFAULT_MODEL
                     await events.emit(conv_id, "tool_progress", {
                         "tool": "generate_code", "icon": "wand",
                         "status": f"🔍 Reviewing code with {critic_model}...",

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -2342,6 +2342,30 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
             project_dir = (args.get("project_dir") or "").strip()
             project_id = (args.get("project_id") or "").strip()
 
+            # Validate the model-passed project_dir actually exists on Codebox.
+            # qwen-style models occasionally fabricate project paths — inheriting
+            # a name from training data or a prior conversation — instead of
+            # using the one generate_code just built. Without this guard the
+            # Reviewer runs against a non-existent path, fails with "no build
+            # markers found", and the Fixer then inherits the bad envelope.
+            # Same fabrication guard ask_project uses below.
+            if project_dir and conv_id:
+                try:
+                    _existsr = await http.post(
+                        f"{config.CODEBOX_URL}/command",
+                        json={"command": f"test -d {shlex.quote(project_dir)} && echo OK || echo NO",
+                              "timeout": 5},
+                        timeout=10,
+                    )
+                    _on_disk = (_existsr.status_code == 200
+                                and "OK" in (_existsr.json().get("stdout") or ""))
+                except Exception:
+                    _on_disk = False
+                if not _on_disk:
+                    print(f"[run_review] passed project_dir={project_dir} does not exist on "
+                          f"Codebox — falling back to auto-resolve from builder run")
+                    project_dir = ""
+
             # Preferred lookup: most recent succeeded builder run for this conv.
             # The builder envelope records the actual workspace path (e.g.
             # /root/projects/pong) — this is the one that matters. coding_projects

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -3,6 +3,7 @@ Tool definitions and execution dispatch for HyprChat's integrated CodeAgent.
 """
 import asyncio
 import base64
+import calendar
 import json
 import os
 import re
@@ -45,17 +46,17 @@ def _parse_ts_loose(s) -> "datetime | None":
 # history for the current turn — saved_events keeps a summary but not the
 # body. Caching it here lets the Fixer dispatcher pick it up across the
 # orchestrator/fixer boundary without persisting research bodies to SQLite
-# or breaking the Fixer's network-free contract. Bounded to the most-recent
-# 32 conversations (LRU-ish via insertion order); freshness window enforced
-# at read time, not write time.
-_RECENT_RESEARCH: "dict[str, dict]" = {}
+# or breaking the Fixer's network-free contract. Bounded to 32 entries with
+# LRU eviction (move-to-end on read); freshness window enforced at read time.
+from collections import OrderedDict
+_RECENT_RESEARCH: OrderedDict[str, dict] = OrderedDict()
 _RECENT_RESEARCH_MAX = 32
 _RESEARCH_FRESH_SECONDS = 600  # 10 min — drop on next read past this
 
 
 def _stash_research_result(conv_id: str, topic: str, report: str) -> None:
-    """Record the most recent deep_research result for this conv. Bounded:
-    when the cache exceeds the cap, the oldest insertion is evicted."""
+    """Record the most recent deep_research result for this conv. LRU-bounded:
+    accessed entries move to the end; eviction drops the least-recently-used."""
     if not conv_id or not report:
         return
     _RECENT_RESEARCH[conv_id] = {
@@ -63,21 +64,22 @@ def _stash_research_result(conv_id: str, topic: str, report: str) -> None:
         "report": report,
         "ts": time.time(),
     }
-    if len(_RECENT_RESEARCH) > _RECENT_RESEARCH_MAX:
-        # Drop oldest by insertion order (dict preserves it in 3.7+).
-        _oldest = next(iter(_RECENT_RESEARCH))
-        _RECENT_RESEARCH.pop(_oldest, None)
+    _RECENT_RESEARCH.move_to_end(conv_id)
+    while len(_RECENT_RESEARCH) > _RECENT_RESEARCH_MAX:
+        _RECENT_RESEARCH.popitem(last=False)
 
 
 def _get_recent_research(conv_id: str) -> "dict | None":
     """Return the cached research entry for conv_id if it's still within the
-    freshness window, else None. Stale entries are dropped on read."""
+    freshness window, else None. Stale entries are dropped on read. Accessed
+    entries are promoted (LRU)."""
     entry = _RECENT_RESEARCH.get(conv_id)
     if not entry:
         return None
     if (time.time() - entry.get("ts", 0)) > _RESEARCH_FRESH_SECONDS:
         _RECENT_RESEARCH.pop(conv_id, None)
         return None
+    _RECENT_RESEARCH.move_to_end(conv_id)
     return entry
 
 
@@ -114,11 +116,21 @@ async def _deep_research_called_since(conv_id: str, since_iso: str | None) -> bo
     """
     # In-stream check first — matches what's already populated via
     # `_stash_research_result` on deep_research completion. The cache is
-    # keyed by conv_id, so the freshness gate (10 min) is enough — we don't
-    # need to re-check the timestamp.
+    # keyed by conv_id. When since_iso is provided, we also verify the
+    # cached entry is newer than the trigger event — pre-build research
+    # done before the latest reviewer run must not satisfy the gate.
     try:
-        if conv_id and _get_recent_research(conv_id):
-            return True
+        _cached = _get_recent_research(conv_id) if conv_id else None
+        if _cached:
+            if since_iso:
+                _since_dt = _parse_ts_loose(since_iso)
+                if _since_dt:
+                    _since_unix = calendar.timegm(_since_dt.timetuple()) + _since_dt.microsecond / 1_000_000
+                    if _cached.get("ts", 0) >= _since_unix:
+                        return True
+                # Cached research is older than since_iso — fall through to DB
+            else:
+                return True
     except Exception as _e:
         print(f"[v2-gate] in-stream research cache check failed (non-fatal): {_e}")
 
@@ -283,13 +295,19 @@ async def _synthesize_reviewer_from_test_failure(
 def _guess_fix_scope(test_file_abs: str, project_dir: str) -> list[str]:
     """Given a failing test file, propose the source files Fixer should be
     allowed to edit. Conservative — we list the test file itself plus the
-    most plausible source-under-test sibling, never a glob."""
+    most plausible source-under-test sibling, never a glob.
+
+    Supports Python (test_foo.py, foo_test.py), Java/Kotlin (FooTest.java),
+    Go (foo_test.go), JavaScript/TypeScript (foo.test.js, foo.spec.ts),
+    and Rust (tests/ convention)."""
     pdir = project_dir.rstrip("/")
     scope = [test_file_abs]
     base = os.path.basename(test_file_abs)
-    # tests/test_foo.py → foo.py / src/foo.py / app/foo.py
+    dname = os.path.dirname(test_file_abs)
+
+    # Python: test_foo.py → foo.py
     if base.startswith("test_") and base.endswith(".py"):
-        stem = base[5:]  # foo.py
+        stem = base[5:]
         for cand in (f"{pdir}/src/{stem}", f"{pdir}/{stem}",
                      f"{pdir}/app/{stem}", f"{pdir}/lib/{stem}"):
             scope.append(cand)
@@ -297,10 +315,49 @@ def _guess_fix_scope(test_file_abs: str, project_dir: str) -> list[str]:
         stem = base[:-len("_test.py")] + ".py"
         for cand in (f"{pdir}/src/{stem}", f"{pdir}/{stem}"):
             scope.append(cand)
+
+    # Java/Kotlin: FooTest.java → Foo.java, FooTests.java → Foo.java
+    elif base.endswith(("Test.java", "Tests.java", "Test.kt", "Tests.kt")):
+        for suffix in ("Tests.java", "Test.java", "Tests.kt", "Test.kt"):
+            if base.endswith(suffix):
+                src_base = base[:-len(suffix)] + base[base.rfind("."):]
+                # Common Maven/Gradle layout: src/test/java/... → src/main/java/...
+                src_dir = dname.replace("/src/test/", "/src/main/")
+                scope.append(f"{src_dir}/{src_base}")
+                scope.append(f"{pdir}/src/main/java/{src_base}")
+                scope.append(f"{pdir}/{src_base}")
+                break
+
+    # Go: foo_test.go → foo.go (same directory)
+    elif base.endswith("_test.go"):
+        src_base = base[:-len("_test.go")] + ".go"
+        scope.append(f"{dname}/{src_base}")
+        scope.append(f"{pdir}/{src_base}")
+
+    # JS/TS: foo.test.js → foo.js, foo.spec.ts → foo.ts
+    elif any(base.endswith(s) for s in (".test.js", ".test.ts", ".test.jsx", ".test.tsx",
+                                        ".spec.js", ".spec.ts", ".spec.jsx", ".spec.tsx")):
+        for mid in (".test.", ".spec."):
+            if mid in base:
+                src_base = base.replace(mid, ".")
+                scope.append(f"{pdir}/src/{src_base}")
+                scope.append(f"{pdir}/{src_base}")
+                scope.append(f"{dname}/{src_base}")
+                break
+
+    # Rust: tests/foo.rs → src/foo.rs or src/lib.rs
+    elif "/tests/" in test_file_abs and base.endswith(".rs"):
+        scope.append(f"{pdir}/src/{base}")
+        scope.append(f"{pdir}/src/lib.rs")
+        scope.append(f"{pdir}/src/main.rs")
+
     # Dedup, preserve order.
-    seen = set(); out = []
+    seen: set[str] = set()
+    out: list[str] = []
     for p in scope:
-        if p not in seen: seen.add(p); out.append(p)
+        if p not in seen:
+            seen.add(p)
+            out.append(p)
     return out
 
 
@@ -309,17 +366,16 @@ async def _is_v2_persona(conv_id: str, conv_row: dict | None = None) -> bool:
 
     Centralised so the workflow gate doesn't repeat the same db lookup +
     string match in five different places. Pass conv_row if the caller has
-    already fetched it to avoid a second db query. Failures are non-fatal
-    and return False (fail-safe — gate stays off rather than mis-firing on
-    a v1 persona)."""
+    already fetched it to avoid a second db query. Uses a direct by-id
+    query instead of loading all configs. Failures are non-fatal and return
+    False (fail-safe — gate stays off rather than mis-firing on a v1 persona)."""
     try:
         if conv_row is None:
             conv_row = await db.get_conversation(conv_id)
         _mc_id = (conv_row or {}).get("model_config_id") if conv_row else None
         if not _mc_id:
             return False
-        _all_mc = await db.get_model_configs()
-        _mc = next((m for m in _all_mc if m.get("id") == _mc_id), None)
+        _mc = await db.get_model_config(_mc_id)
         return bool(_mc and "v2" in (_mc.get("name") or "").lower())
     except Exception as _e:
         print(f"[v2-gate] persona lookup failed (non-fatal): {_e}")
@@ -1183,6 +1239,18 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
         #     the model to summarize for the user. The persona prompt has
         #     said "Hard cap: 3 review/fix cycles" since Phase 2; this
         #     enforces it server-side instead of trusting the model to obey.
+        #
+        # Cache the v2 check result once per exec_tool call so the gate
+        # doesn't hit the DB for each sub-state. Initialized to None =
+        # "not checked yet"; False/True = cached result.
+        _v2_cached: bool | None = None
+        async def _check_v2(cr=None) -> bool:
+            nonlocal _v2_cached
+            if _v2_cached is None:
+                _v2_cached = await _is_v2_persona(conv_id, conv_row=cr)
+            return _v2_cached
+
+        _runs_for_cap = None
         if conv_id and name == "run_fixer":
             try:
                 _runs_for_cap = await db.get_runs_by_conversation(conv_id, limit=20)
@@ -1192,7 +1260,7 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                 )
                 if _fixer_succ >= 3:
                     # v1 doesn't run this loop, so cap only applies to v2.
-                    if await _is_v2_persona(conv_id):
+                    if await _check_v2():
                         # Pull the latest reviewer's summary so the model has
                         # specifics to relay to the user.
                         _last_rev = next(
@@ -1247,10 +1315,11 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
             # tells the model to do this; the gate enforces it server-side.
             #
             # Uses the same _runs_for_cap walk as the cycle cap — cheap because
-            # we already paid for that db hit above, but defensive in case the
-            # cap try-block bailed before populating it.
+            # we already paid for that db hit above. _runs_for_cap is
+            # initialized to None before the first try block so it's always
+            # in scope here.
             try:
-                _runs_sf = locals().get("_runs_for_cap")
+                _runs_sf = _runs_for_cap
                 if _runs_sf is None:
                     _runs_sf = await db.get_runs_by_conversation(conv_id, limit=20)
                 _fsucc_sf = sum(
@@ -1259,7 +1328,7 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                 )
                 # 1 ≤ fixer_succ ≤ 2: between first failure and final cycle.
                 # 0 = first attempt, no gate. ≥3 = cap (handled above).
-                if 1 <= _fsucc_sf <= 2 and await _is_v2_persona(conv_id):
+                if 1 <= _fsucc_sf <= 2 and await _check_v2():
                     _latest_rev_sf = next(
                         (r for r in _runs_sf if r.get("role") == "reviewer"),
                         None,
@@ -1356,7 +1425,7 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
             # legitimate "reviewer just ran with issues → call run_fixer"
             # case; this guard handles every other case.
             try:
-                if await _is_v2_persona(conv_id):
+                if await _check_v2():
                     _runs_pf = await db.get_runs_by_conversation(conv_id, limit=20)
                     _latest_meaningful = None
                     _MEANINGFUL_STATUSES = {"succeeded", "issues", "clean", "partial",
@@ -1419,7 +1488,7 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
         if conv_id and name == "generate_code":
             try:
                 _conv_full = await db.get_conversation(conv_id)
-                if await _is_v2_persona(conv_id, conv_row=_conv_full):
+                if await _check_v2(cr=_conv_full):
                     # Find the most recent user message timestamp.
                     _msgs_rb = (_conv_full or {}).get("messages") or []
                     _latest_user_ts = None
@@ -1543,14 +1612,21 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                 elif _pending_review is not None:
                     _rid = _pending_review.get("id", "?")
                     _rstatus_disp = (_pending_review.get("result_envelope") or {}).get("status", "?")
-                    # Cap-aware release: once the 3-cycle fixer cap has been
-                    # hit, the same review issues will keep blocking the
-                    # conversation forever. Allow the model to deliver what
-                    # was actually built (download_project / download_file)
-                    # and to inspect the tree (read_file / list_files) so the
-                    # user gets the partial result instead of a dead session.
-                    # write_file / run_shell / generate_code stay blocked —
-                    # further code work won't help once we're past 3 cycles.
+                    # Cap-aware release: once the fixer cycle budget is
+                    # exhausted, the same review issues will keep blocking
+                    # the conversation forever. Allow the model to deliver
+                    # what was built (download_project / download_file) and
+                    # inspect the tree (read_file / list_files) so the user
+                    # gets the partial result instead of a dead session.
+                    # Count total fixer attempts (succeeded + failed/no_op)
+                    # for the release — a fixer that declined still represents
+                    # an exhausted attempt. The cycle-cap check (which gates
+                    # run_fixer itself) still counts only successes.
+                    _FIXER_TERMINAL = {"succeeded", "failed", "partial", "no_op"}
+                    _fixer_attempts_gate = sum(
+                        1 for _r in _runs_for_v2_gate
+                        if _r.get("role") == "fixer" and _r.get("status") in _FIXER_TERMINAL
+                    )
                     _fixer_succ_gate = sum(
                         1 for _r in _runs_for_v2_gate
                         if _r.get("role") == "fixer" and _r.get("status") == "succeeded"
@@ -1570,16 +1646,17 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                     # the next round. Below 1 fixer attempt the model should
                     # actually try fixing before researching.
                     if (name == "deep_research"
-                            and _fixer_succ_gate >= 1
+                            and _fixer_attempts_gate >= 1
                             and not await _deep_research_called_since(
                                 conv_id, _pending_review.get("ended_at"))):
                         print(f"[v2-gate] research-release: allowing deep_research "
-                              f"despite fix-needed (fixer_succ={_fixer_succ_gate}, "
+                              f"despite fix-needed (fixer_attempts={_fixer_attempts_gate}, "
                               f"required by FINAL_CYCLE/STUCK_FIX)", flush=True)
                         # Skip _gate_msg → deep_research runs.
-                    elif _fixer_succ_gate >= 3 and name in _DELIVERY_OK_AFTER_CAP:
+                    elif _fixer_attempts_gate >= 3 and name in _DELIVERY_OK_AFTER_CAP:
                         print(f"[v2-gate] cap-release: allowing {name} despite "
-                              f"fix-needed (cap reached, {_fixer_succ_gate} fixers)", flush=True)
+                              f"fix-needed (attempts={_fixer_attempts_gate}, "
+                              f"succ={_fixer_succ_gate})", flush=True)
                         # Skip _gate_msg entirely → tool runs normally.
                     else:
                         _gate_msg = (
@@ -1618,7 +1695,7 @@ async def exec_tool(http, events, name: str, args: dict, conv_id: str, custom_to
                 if _gate_msg is not None:
                     # v1 has no run_review or run_fixer in its workflow, so
                     # the gate only blocks v2 personas.
-                    if await _is_v2_persona(conv_id):
+                    if await _check_v2():
                         _, _state_label, _body, _short_status, _trigger_id = _gate_msg
                         await events.emit(conv_id, "tool_end", {
                             "tool": name, "icon": "code",

--- a/deploy_monitor.py
+++ b/deploy_monitor.py
@@ -48,6 +48,7 @@ WATCHED = {
     "backend/rag.py":               ("RAG Pipeline",     REMOTE_BACKEND,            True),
     "backend/research.py":          ("Research",         REMOTE_BACKEND,            True),
     "backend/quick_search.py":      ("Quick Search",     REMOTE_BACKEND,            True),
+    "backend/search_agent.py":      ("Search Agent",     REMOTE_BACKEND,            True),
     "backend/events.py":            ("Events",           REMOTE_BACKEND,            True),
     "backend/council.py":           ("Council",          REMOTE_BACKEND,            True),
     "backend/hf.py":                ("HuggingFace",      REMOTE_BACKEND,            True),

--- a/deploy_monitor.py
+++ b/deploy_monitor.py
@@ -203,6 +203,16 @@ def ssh_cmd(host, user, password, command, timeout=30):
 
 # ── Deploy logic ──
 
+def _show_journal(target, unit, lines=20):
+    """Print the last N journalctl lines for a unit on the given target."""
+    ok, out, _ = ssh_cmd(target["ip"], target["user"], target["pass"],
+        f"journalctl -u {unit} -n {lines} --no-pager 2>&1")
+    if ok and out:
+        print(f"  {DIM}── journalctl -u {unit} (last {lines} lines) ──{RST}")
+        for line in out.splitlines():
+            print(f"  {DIM}{line}{RST}")
+
+
 def deploy_changes(changed, cfg):
     """Deploy changed files and restart service only if needed."""
     hypr = cfg["hyprchat"]
@@ -263,15 +273,18 @@ def deploy_changes(changed, cfg):
         ok, out, err = ssh_cmd(hypr["ip"], hypr["user"], hypr["pass"],
             "systemctl restart hyprchat 2>&1", timeout=90)
         if ok:
-            time.sleep(1)
+            # Bind to a specific interface (e.g. Tailscale IP) can take a few seconds.
+            time.sleep(3)
             ok2, out2, _ = ssh_cmd(hypr["ip"], hypr["user"], hypr["pass"],
                 "systemctl is-active hyprchat 2>&1")
             if ok2 and "active" in out2:
                 print(f"  {G}\u2713{RST} Service running")
             else:
                 print(f"  {Y}!{RST} Service may not be active: {out2}")
+                _show_journal(hypr, "hyprchat")
         else:
             print(f"  {R}\u2717{RST} Restart failed: {err}")
+            _show_journal(hypr, "hyprchat")
 
     # Restart openhands worker on codebox if it was deployed
     if any(fp == "backend/openhands_worker.py" for fp, *_ in changed):
@@ -280,15 +293,17 @@ def deploy_changes(changed, cfg):
         ok, out, err = ssh_cmd(cb["ip"], cb["user"], cb["pass"],
             "systemctl restart openhands-worker 2>&1", timeout=30)
         if ok:
-            time.sleep(1)
+            time.sleep(3)
             ok2, out2, _ = ssh_cmd(cb["ip"], cb["user"], cb["pass"],
                 "systemctl is-active openhands-worker 2>&1")
             if ok2 and "active" in out2:
                 print(f"  {G}\u2713{RST} OpenHands worker running")
             else:
                 print(f"  {Y}!{RST} Worker may not be active: {out2}")
+                _show_journal(cb, "openhands-worker")
         else:
             print(f"  {R}\u2717{RST} Worker restart failed: {err}")
+            _show_journal(cb, "openhands-worker")
 
     print()
     print(f"  {bar('═', G)}")

--- a/deploy_monitor.py
+++ b/deploy_monitor.py
@@ -45,6 +45,7 @@ WATCHED = {
     "backend/config.py":            ("Config",           REMOTE_BACKEND,            True),
     "backend/database.py":          ("Database",         REMOTE_BACKEND,            True),
     "backend/tools.py":             ("Tools",            REMOTE_BACKEND,            True),
+    "backend/cancel_registry.py":   ("Cancel Registry",  REMOTE_BACKEND,            True),
     "backend/rag.py":               ("RAG Pipeline",     REMOTE_BACKEND,            True),
     "backend/research.py":          ("Research",         REMOTE_BACKEND,            True),
     "backend/quick_search.py":      ("Quick Search",     REMOTE_BACKEND,            True),

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -1728,7 +1728,7 @@ function HyprChat(){
   useEffect(()=>{try{localStorage.setItem("hc-ui-font-size",uiFontSize);}catch{}},[uiFontSize]);
   useEffect(()=>{try{localStorage.setItem("hc-chat-w",chatWidth);}catch{}},[chatWidth]);
   useEffect(()=>{try{localStorage.setItem("hc-custom-quotes",JSON.stringify(customQuotes));}catch{}},[customQuotes]);
-  useEffect(()=>{try{localStorage.setItem("hc-ws-model",wsModel);}catch{}},[wsModel]);
+  useEffect(()=>{try{localStorage.setItem("hc-ws-model",wsModel);fetch(`${API}/api/settings`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({workspace_model:wsModel})}).catch(()=>{});}catch{}},[wsModel]);
   useEffect(()=>{try{localStorage.setItem("hc-planning-model",planningModel);fetch(`${API}/api/settings`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({planning_model:planningModel})}).catch(()=>{});}catch{}},[planningModel]);
   useEffect(()=>{try{localStorage.setItem("hc-coder-model",coderModel);fetch(`${API}/api/settings`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({coder_model:coderModel})}).catch(()=>{});}catch{}},[coderModel]);
   // Coder Bot v2 per-agent overrides — sync each to localStorage + PATCH /api/settings.
@@ -1924,7 +1924,7 @@ function HyprChat(){
     fetch(`${API}/api/tools`).then(r=>r.json()).then(setTools).catch(()=>{});
     fetch(`${API}/api/model-configs`).then(r=>r.json()).then(setMcs).catch(()=>{});
     fetch(`${API}/api/health`).then(r=>r.json()).then(d=>setHealth(d.services||{})).catch(()=>{});
-    fetch(`${API}/api/settings`).then(r=>r.json()).then(d=>{if(d.current_ollama_url)setOllamaUrl(d.current_ollama_url);if(d.rag)setRagSettings(p=>({...p,...d.rag}));if(d.current_planning_model!=null)setPlanningModel(d.current_planning_model);if(d.current_coder_model!=null)setCoderModel(d.current_coder_model);if(d.current_architect_model!=null)setArchitectModel(d.current_architect_model);if(d.current_reviewer_model!=null)setReviewerModel(d.current_reviewer_model);if(d.current_builder_model!=null)setBuilderModel(d.current_builder_model);if(d.current_fixer_model!=null)setFixerModel(d.current_fixer_model);if(d.current_qa_model!=null)setQaModel(d.current_qa_model);if(d.openhands_num_ctx!=null)setCoderNumCtx(d.openhands_num_ctx);if(d.openhands_enabled!=null)setOpenhandsEnabled(d.openhands_enabled);if(d.openhands_max_rounds!=null)setOpenhandsMaxRounds(d.openhands_max_rounds);if(d.openhands_reasoning_effort)setOpenhandsReasoningEffort(d.openhands_reasoning_effort);}).catch(()=>{});
+    fetch(`${API}/api/settings`).then(r=>r.json()).then(d=>{if(d.current_ollama_url)setOllamaUrl(d.current_ollama_url);if(d.rag)setRagSettings(p=>({...p,...d.rag}));if(d.current_planning_model!=null)setPlanningModel(d.current_planning_model);if(d.current_coder_model!=null)setCoderModel(d.current_coder_model);if(d.current_architect_model!=null)setArchitectModel(d.current_architect_model);if(d.current_reviewer_model!=null)setReviewerModel(d.current_reviewer_model);if(d.current_builder_model!=null)setBuilderModel(d.current_builder_model);if(d.current_fixer_model!=null)setFixerModel(d.current_fixer_model);if(d.current_qa_model!=null)setQaModel(d.current_qa_model);if(d.current_workspace_model!=null)setWsModel(d.current_workspace_model);if(d.openhands_num_ctx!=null)setCoderNumCtx(d.openhands_num_ctx);if(d.openhands_enabled!=null)setOpenhandsEnabled(d.openhands_enabled);if(d.openhands_max_rounds!=null)setOpenhandsMaxRounds(d.openhands_max_rounds);if(d.openhands_reasoning_effort)setOpenhandsReasoningEffort(d.openhands_reasoning_effort);}).catch(()=>{});
     fetch(`${API}/api/rag/stats`).then(r=>r.json()).then(setRagStats).catch(()=>{});
     fetch(`${API}/api/workspaces`).then(r=>r.json()).then(setWorkspaces).catch(()=>{});
     fetch(`${API}/api/councils`).then(r=>r.json()).then(setCouncils).catch(()=>{});
@@ -1947,7 +1947,11 @@ function HyprChat(){
     const connect=()=>{
       if(closed)return;
       const es=new EventSource(`${API}/api/events/${actId}`);
-      es.onmessage=e=>{try{const ev=JSON.parse(e.data);if(ev.type!=="heartbeat"&&ev.type!=="keepalive"){setEvts(p=>[...p.slice(-200),ev]);streamSaveEvtsRef.current.push(ev);}retryDelay=1000;}catch{}};
+      es.onmessage=e=>{try{const ev=JSON.parse(e.data);if(ev.type!=="heartbeat"&&ev.type!=="keepalive"){setEvts(p=>[...p.slice(-200),ev]);streamSaveEvtsRef.current.push(ev);
+        // Route search_agent results into the QUICK SEARCH carousel — same data
+        // the chat model saw, instead of the old parallel /api/quick-search call.
+        if(ev.type==="search_results"&&ev.data?.source==="quick_search"){setQuickResults(ev.data.results||[]);setSearchLoading(false);}
+        }retryDelay=1000;}catch{}};
       es.onerror=()=>{es.close();if(!closed){retryTimer=setTimeout(()=>{retryDelay=Math.min(retryDelay*2,30000);connect();},retryDelay);}};
       sseR.current=es;
     };
@@ -2499,10 +2503,12 @@ function HyprChat(){
         displayContent = displayContent ? `${displayContent}\n\n${nonPdfCtx}` : nonPdfCtx;
       }
     }
-    // Quick search fires in parallel — don't block the chat
+    // Quick search results now stream in via SSE (search_results event with
+    // source="quick_search") — same data the chat agent saw, no parallel
+    // fetch. Just clear the carousel and flip to loading; the SSE handler
+    // populates quickResults when the agent finishes its search.
     if(quickSearch&&modelContent.trim()){
       setSearchLoading(true);setQuickResults([]);
-      fetch(`${API}/api/quick-search`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({query:modelContent.trim().slice(0,200),count:6})}).then(r=>r.json()).then(d=>{setQuickResults(d.results||[]);setSearchLoading(false);}).catch(()=>{setQuickResults([]);setSearchLoading(false);});
     }else{setQuickResults([]);}
     const _now=new Date().toISOString();
     const um={role:"user",content:displayContent,_fullContent:modelContent,_images:imageBase64s.length?imageBase64s:undefined,metadata:{pdfs:pdfAttachments.length?pdfAttachments:undefined,images:imageAttachments.length?imageAttachments:undefined},created_at:_now};

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -1592,9 +1592,17 @@ function HyprChat(){
   const [wsModel,setWsModel]=useState(()=>{try{return localStorage.getItem("hc-ws-model")||"qwen2.5:7b";}catch{return "qwen2.5:7b";}});
   const [planningModel,setPlanningModel]=useState(()=>{try{return localStorage.getItem("hc-planning-model")||"";}catch{return "";}});
   const [coderModel,setCoderModel]=useState(()=>{try{return localStorage.getItem("hc-coder-model")||"";}catch{return "";}});
+  // Coder Bot v2 — per-agent model overrides. Empty = inherit from umbrella (Planning/Coder) or chat model.
+  const [architectModel,setArchitectModel]=useState(()=>{try{return localStorage.getItem("hc-architect-model")||"";}catch{return "";}});
+  const [reviewerModel, setReviewerModel] =useState(()=>{try{return localStorage.getItem("hc-reviewer-model") ||"";}catch{return "";}});
+  const [builderModel,  setBuilderModel]  =useState(()=>{try{return localStorage.getItem("hc-builder-model")  ||"";}catch{return "";}});
+  const [fixerModel,    setFixerModel]    =useState(()=>{try{return localStorage.getItem("hc-fixer-model")    ||"";}catch{return "";}});
+  const [qaModel,       setQaModel]       =useState(()=>{try{return localStorage.getItem("hc-qa-model")       ||"";}catch{return "";}});
+  const [coderBotModelsOpen,setCoderBotModelsOpen]=useState(()=>{try{return localStorage.getItem("hc-coderbot-models-open")==="1";}catch{return false;}});
   const [coderNumCtx,setCoderNumCtx]=useState(()=>{try{return parseInt(localStorage.getItem("hc-coder-num-ctx")||"8192");}catch{return 8192;}});
   const [openhandsEnabled,setOpenhandsEnabled]=useState(()=>{try{return localStorage.getItem("hc-openhands-enabled")!=="false";}catch{return true;}});
   const [openhandsMaxRounds,setOpenhandsMaxRounds]=useState(()=>{try{return parseInt(localStorage.getItem("hc-openhands-max-rounds")||"20");}catch{return 20;}});
+  const [openhandsReasoningEffort,setOpenhandsReasoningEffort]=useState(()=>{try{return localStorage.getItem("hc-openhands-reasoning-effort")||"medium";}catch{return "medium";}});
   const [ctxTokens,setCtxTokens]=useState(0);
   const [genTokens,setGenTokens]=useState(0);
   const [previewFile,setPreviewFile]=useState(null);
@@ -1723,9 +1731,17 @@ function HyprChat(){
   useEffect(()=>{try{localStorage.setItem("hc-ws-model",wsModel);}catch{}},[wsModel]);
   useEffect(()=>{try{localStorage.setItem("hc-planning-model",planningModel);fetch(`${API}/api/settings`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({planning_model:planningModel})}).catch(()=>{});}catch{}},[planningModel]);
   useEffect(()=>{try{localStorage.setItem("hc-coder-model",coderModel);fetch(`${API}/api/settings`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({coder_model:coderModel})}).catch(()=>{});}catch{}},[coderModel]);
+  // Coder Bot v2 per-agent overrides — sync each to localStorage + PATCH /api/settings.
+  useEffect(()=>{try{localStorage.setItem("hc-architect-model",architectModel);fetch(`${API}/api/settings`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({architect_model:architectModel})}).catch(()=>{});}catch{}},[architectModel]);
+  useEffect(()=>{try{localStorage.setItem("hc-reviewer-model", reviewerModel); fetch(`${API}/api/settings`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({reviewer_model: reviewerModel})}).catch(()=>{});}catch{}},[reviewerModel]);
+  useEffect(()=>{try{localStorage.setItem("hc-builder-model",  builderModel);  fetch(`${API}/api/settings`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({builder_model:  builderModel})}).catch(()=>{});}catch{}},[builderModel]);
+  useEffect(()=>{try{localStorage.setItem("hc-fixer-model",    fixerModel);    fetch(`${API}/api/settings`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({fixer_model:    fixerModel})}).catch(()=>{});}catch{}},[fixerModel]);
+  useEffect(()=>{try{localStorage.setItem("hc-qa-model",       qaModel);       fetch(`${API}/api/settings`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({qa_model:       qaModel})}).catch(()=>{});}catch{}},[qaModel]);
+  useEffect(()=>{try{localStorage.setItem("hc-coderbot-models-open",coderBotModelsOpen?"1":"0");}catch{}},[coderBotModelsOpen]);
   useEffect(()=>{try{localStorage.setItem("hc-coder-num-ctx",coderNumCtx);fetch(`${API}/api/settings`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({openhands_num_ctx:coderNumCtx})}).catch(()=>{});}catch{}},[coderNumCtx]);
   useEffect(()=>{try{localStorage.setItem("hc-openhands-enabled",openhandsEnabled);fetch(`${API}/api/settings`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({openhands_enabled:openhandsEnabled})}).catch(()=>{});}catch{}},[openhandsEnabled]);
   useEffect(()=>{try{localStorage.setItem("hc-openhands-max-rounds",openhandsMaxRounds);fetch(`${API}/api/settings`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({openhands_max_rounds:openhandsMaxRounds})}).catch(()=>{});}catch{}},[openhandsMaxRounds]);
+  useEffect(()=>{try{localStorage.setItem("hc-openhands-reasoning-effort",openhandsReasoningEffort);fetch(`${API}/api/settings`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({openhands_reasoning_effort:openhandsReasoningEffort})}).catch(()=>{});}catch{}},[openhandsReasoningEffort]);
   useEffect(()=>{try{localStorage.setItem("hc-model-params",JSON.stringify(modelParams));}catch{}},[modelParams]);
   useEffect(()=>{try{localStorage.setItem("hc-prompts",JSON.stringify(prompts));}catch{}},[prompts]);
   useEffect(()=>{try{localStorage.setItem("hc-conv-tags",JSON.stringify(convTags));}catch{}},[convTags]);
@@ -1908,7 +1924,7 @@ function HyprChat(){
     fetch(`${API}/api/tools`).then(r=>r.json()).then(setTools).catch(()=>{});
     fetch(`${API}/api/model-configs`).then(r=>r.json()).then(setMcs).catch(()=>{});
     fetch(`${API}/api/health`).then(r=>r.json()).then(d=>setHealth(d.services||{})).catch(()=>{});
-    fetch(`${API}/api/settings`).then(r=>r.json()).then(d=>{if(d.current_ollama_url)setOllamaUrl(d.current_ollama_url);if(d.rag)setRagSettings(p=>({...p,...d.rag}));if(d.current_planning_model!=null)setPlanningModel(d.current_planning_model);if(d.current_coder_model!=null)setCoderModel(d.current_coder_model);if(d.openhands_num_ctx!=null)setCoderNumCtx(d.openhands_num_ctx);if(d.openhands_enabled!=null)setOpenhandsEnabled(d.openhands_enabled);if(d.openhands_max_rounds!=null)setOpenhandsMaxRounds(d.openhands_max_rounds);}).catch(()=>{});
+    fetch(`${API}/api/settings`).then(r=>r.json()).then(d=>{if(d.current_ollama_url)setOllamaUrl(d.current_ollama_url);if(d.rag)setRagSettings(p=>({...p,...d.rag}));if(d.current_planning_model!=null)setPlanningModel(d.current_planning_model);if(d.current_coder_model!=null)setCoderModel(d.current_coder_model);if(d.current_architect_model!=null)setArchitectModel(d.current_architect_model);if(d.current_reviewer_model!=null)setReviewerModel(d.current_reviewer_model);if(d.current_builder_model!=null)setBuilderModel(d.current_builder_model);if(d.current_fixer_model!=null)setFixerModel(d.current_fixer_model);if(d.current_qa_model!=null)setQaModel(d.current_qa_model);if(d.openhands_num_ctx!=null)setCoderNumCtx(d.openhands_num_ctx);if(d.openhands_enabled!=null)setOpenhandsEnabled(d.openhands_enabled);if(d.openhands_max_rounds!=null)setOpenhandsMaxRounds(d.openhands_max_rounds);if(d.openhands_reasoning_effort)setOpenhandsReasoningEffort(d.openhands_reasoning_effort);}).catch(()=>{});
     fetch(`${API}/api/rag/stats`).then(r=>r.json()).then(setRagStats).catch(()=>{});
     fetch(`${API}/api/workspaces`).then(r=>r.json()).then(setWorkspaces).catch(()=>{});
     fetch(`${API}/api/councils`).then(r=>r.json()).then(setCouncils).catch(()=>{});
@@ -2572,7 +2588,7 @@ function HyprChat(){
         continue;
       }
       if(isPdf(file)){
-        if(file.size>50*1024*1024){console.warn(`Skipped ${file.name} — too large (max 50MB)`);continue;}
+        if(file.size>250*1024*1024){console.warn(`Skipped ${file.name} — too large (max 250MB)`);continue;}
         // Add a loading placeholder immediately
         const placeholderIdx=attachments.length+newAttachments.length;
         setAttachments(p=>[...p,{name:file.name,content:"",type:"pdf",pages:0,loading:true}]);
@@ -2745,6 +2761,12 @@ function HyprChat(){
       // Clear planning/coder model if it was the deleted model
       if(planningModel===m){setPlanningModel("");}
       if(coderModel===m){setCoderModel("");}
+      // Coder Bot v2 per-agent overrides — clear if pinned to the deleted model
+      if(architectModel===m){setArchitectModel("");}
+      if(reviewerModel===m){setReviewerModel("");}
+      if(builderModel===m){setBuilderModel("");}
+      if(fixerModel===m){setFixerModel("");}
+      if(qaModel===m){setQaModel("");}
       // Clear workspace model if it was the deleted model
       if(wsModel===m){setWsModel(fallback);}
       if(modelParamsOpen===m)setModelParamsOpen(null);
@@ -3135,17 +3157,33 @@ function HyprChat(){
             {bodyLines.length>0 && <div style={{color:t.text,fontSize:"0.95em",lineHeight:1.55}}>{bodyLines.map((bl,bi)=><div key={bi} style={{minHeight:bl===""?6:"auto"}}>{inlineParse(bl)}</div>)}</div>}
           </div>;
         }
-        if(ln.match(/^>\s?/)){const qRaw=ln.replace(/^>\s?/,"");
-        /* If this line is just an attribution (— Name...), skip — it was consumed by the previous quote line */
-        if(qRaw.match(/^[—–]\s/))return null;
-        /* Look ahead: if next line is "> — Attribution", grab it */
-        const nextLn=(j+1<_lines.length)?_lines[j+1]:"";
-        const nextAttr=nextLn.match(/^>\s?[—–]\s*(.+)/);
-        const attrLabel=nextAttr?nextAttr[1]:"quoted source";
-        return <div key={j} style={{borderLeft:`3px solid ${t.warm}`,paddingLeft:12,margin:"6px 0",background:`${t.warm}0D`,borderRadius:"0 6px 6px 0",padding:"8px 12px",borderLeftWidth:3,borderLeftStyle:"solid",borderLeftColor:t.warm}}>
-          <div style={{display:"flex",alignItems:"flex-start",gap:6}}><span style={{color:t.warm,fontSize:16,lineHeight:1,flexShrink:0,marginTop:1}}>"</span><span style={{color:t.text,fontStyle:"italic",fontSize:"0.95em",lineHeight:1.6,flex:1}}>{inlineParse(qRaw)}</span><span style={{color:t.warm,fontSize:16,lineHeight:1,flexShrink:0,alignSelf:"flex-end"}}>"</span></div>
-          <div style={{marginTop:4,fontSize:9,color:t.warm,opacity:0.7,textTransform:"uppercase",letterSpacing:1}}>{inlineParse(attrLabel)}</div>
-        </div>;}
+        if(ln.match(/^>\s?/) && !ln.match(/^>\s?[—–]\s/)){
+          const qLines=[ln.replace(/^>\s?/,"")];
+          let attrLabel=null;
+          let qk=j+1;
+          while(qk<_lines.length && _lines[qk].match(/^>\s?/)){
+            const next=_lines[qk].replace(/^>\s?/,"");
+            const am=next.match(/^[—–]\s*(.+)/);
+            if(am){attrLabel=am[1];_consumed.add(qk);qk++;break;}
+            qLines.push(next);
+            _consumed.add(qk);
+            qk++;
+          }
+          while(qLines.length && qLines[qLines.length-1].trim()==="")qLines.pop();
+          while(qLines.length && qLines[0].trim()==="")qLines.shift();
+          if(!qLines.length)return null;
+          return <div key={j} style={{borderLeft:`3px solid ${t.warm}`,margin:"6px 0",background:`${t.warm}0D`,borderRadius:"0 6px 6px 0",padding:"8px 12px"}}>
+            <div style={{display:"flex",alignItems:"flex-start",gap:6}}>
+              <span style={{color:t.warm,fontSize:16,lineHeight:1,flexShrink:0,marginTop:1}}>"</span>
+              <div style={{color:t.text,fontStyle:"italic",fontSize:"0.95em",lineHeight:1.6,flex:1}}>
+                {qLines.map((ql,qi)=><div key={qi} style={{minHeight:ql.trim()===""?6:"auto"}}>{inlineParse(ql)}</div>)}
+              </div>
+              <span style={{color:t.warm,fontSize:16,lineHeight:1,flexShrink:0,alignSelf:"flex-end"}}>"</span>
+            </div>
+            {attrLabel && <div style={{marginTop:4,fontSize:9,color:t.warm,opacity:0.7,textTransform:"uppercase",letterSpacing:1}}>{inlineParse(attrLabel)}</div>}
+          </div>;
+        }
+        if(ln.match(/^>\s?[—–]\s/))return null;
         if(ln.match(/^[-*+]\s+/)){
           const rest=ln.replace(/^[-*+]\s+/,"");
           const taskMatch=rest.match(/^\[([ xX])\]\s+(.*)$/);
@@ -4981,13 +5019,20 @@ function HyprChat(){
           <div style={{fontSize:10,color:t.mut,marginTop:4}}>After the initial answer, the model re-examines and refines it. {EFFORT_LEVELS[globalEffort].name} = {globalEffort===0?"no review":`${globalEffort} review pass${globalEffort>1?"es":""}`}. Each chat can override this.</div>
         </div>
 
-        <div style={{borderTop:`1px solid ${t.brd}22`,paddingTop:14,marginBottom:14}}>
+        <div style={{borderTop:`1px solid ${t.brd}22`,paddingTop:14,marginBottom:6}}>
           <div style={{fontSize:12,color:t.dim,marginBottom:8,fontWeight:600}}>Workspace Analysis Model</div>
           <ModelPicker value={wsModel} onChange={setWsModel} models={models} modelDetails={modelDetails} t={t} font={font}/>
           <div style={{fontSize:10,color:t.mut,marginTop:6}}>Small, fast model for workspace topic auto-detection.</div>
         </div>
+      </div>
 
-        <div style={{borderTop:`1px solid ${t.brd}22`,paddingTop:14,marginBottom:14}}>
+      {/* TILE: Coder Bot — all coder-bot-related settings live here.
+          Includes the umbrella Planning/Coder model pickers, the new collapsible
+          per-agent model overrides card, and OpenHands runtime knobs. */}
+      <div style={{background:`${t.surface}33`,border:`1px solid ${t.brd}22`,borderRadius:12,padding:"16px 18px",marginBottom:14}}>
+        <div style={{fontSize:14,fontWeight:700,color:t.acc,letterSpacing:.5,marginBottom:14,display:"flex",alignItems:"center",gap:8}}>🤖 Coder Bot</div>
+
+        <div style={{marginBottom:14}}>
           <div style={{fontSize:12,color:t.dim,marginBottom:8,fontWeight:600}}>Code Planning Model</div>
           {planningModel?<div style={{display:"flex",gap:6,alignItems:"center"}}>
             <div style={{flex:1}}><ModelPicker value={planningModel} onChange={setPlanningModel} models={models} modelDetails={modelDetails} t={t} font={font}/></div>
@@ -4997,7 +5042,7 @@ function HyprChat(){
             <div style={{flex:1}}><div style={{fontSize:11,fontWeight:600,color:t.mut}}>Same as chat model</div><div style={{fontSize:9,color:t.dim}}>Click to select a dedicated planning model</div></div>
             <span style={{fontSize:9,color:t.mut}}>▾</span>
           </div>}
-          <div style={{fontSize:10,color:t.mut,marginTop:6}}>Model used by plan_project to design architecture before coding. Empty = uses the active chat model.</div>
+          <div style={{fontSize:10,color:t.mut,marginTop:6}}>Used by Architect + Reviewer agents. Empty = uses the active chat model.</div>
         </div>
 
         <div style={{borderTop:`1px solid ${t.brd}22`,paddingTop:14,marginBottom:14}}>
@@ -5010,10 +5055,90 @@ function HyprChat(){
             <div style={{flex:1}}><div style={{fontSize:11,fontWeight:600,color:t.mut}}>Same as chat model</div><div style={{fontSize:9,color:t.dim}}>Click to select a dedicated coder model</div></div>
             <span style={{fontSize:9,color:t.mut}}>▾</span>
           </div>}
-          <div style={{fontSize:10,color:t.mut,marginTop:6}}>Dedicated model for the generate_code sub-agent. Empty = uses the active chat model.</div>
+          <div style={{fontSize:10,color:t.mut,marginTop:6}}>Used by Builder + Fixer agents. Empty = uses the active chat model.</div>
         </div>
 
-        <div style={{marginBottom:14,display:"flex",alignItems:"center",gap:10}}>
+        {/* Per-agent model overrides — collapsible advanced card.
+            Each picker defaults to "Inherits from <umbrella>" until clicked.
+            The reset button clears the override (returns to inheritance). */}
+        <div style={{borderTop:`1px solid ${t.brd}22`,paddingTop:14,marginBottom:14}}>
+          <div onClick={()=>setCoderBotModelsOpen(p=>!p)} style={{display:"flex",alignItems:"center",gap:8,cursor:"pointer",userSelect:"none"}}>
+            <span style={{fontSize:14}}>🎛</span>
+            <span style={{fontSize:12,fontWeight:700,color:t.fg,letterSpacing:.3}}>Per-Agent Model Overrides</span>
+            <span style={{flex:1}}/>
+            <span style={{fontSize:10,color:t.mut}}>{coderBotModelsOpen ? "▴ collapse" : "▾ expand"}</span>
+          </div>
+          <div style={{fontSize:10,color:t.mut,marginTop:4}}>Optional. Pin a specific model per agent; empty rows inherit from the umbrella above.</div>
+
+          {coderBotModelsOpen && <div style={{marginTop:14,paddingLeft:10,borderLeft:`2px solid ${t.acc}33`}}>
+            {/* Architect — inherits from Planning Model */}
+            <div style={{marginBottom:14}}>
+              <div style={{fontSize:12,color:t.dim,marginBottom:6,fontWeight:600}}>📐 Architect Model</div>
+              {architectModel?<div style={{display:"flex",gap:6,alignItems:"center"}}>
+                <div style={{flex:1}}><ModelPicker value={architectModel} onChange={setArchitectModel} models={models} modelDetails={modelDetails} t={t} font={font}/></div>
+                <button onClick={()=>setArchitectModel("")} style={{padding:"6px 10px",background:`${t.err}18`,border:`1px solid ${t.err}33`,borderRadius:7,color:t.err,fontSize:10,cursor:"pointer",fontWeight:600,whiteSpace:"nowrap"}}>Reset</button>
+              </div>:<div onClick={()=>setArchitectModel(models[0]||"")} style={{display:"flex",alignItems:"center",gap:6,padding:"5px 10px",background:t.bgDeep,border:`1px dashed ${t.brd}55`,borderRadius:8,cursor:"pointer",transition:"all .15s"}}>
+                <span style={{fontSize:14}}>📐</span>
+                <div style={{flex:1}}><div style={{fontSize:11,fontWeight:600,color:t.mut}}>Inherits from Planning Model</div><div style={{fontSize:9,color:t.dim}}>Click to override for the Architect agent only</div></div>
+                <span style={{fontSize:9,color:t.mut}}>▾</span>
+              </div>}
+            </div>
+
+            {/* Reviewer — inherits from Planning Model */}
+            <div style={{marginBottom:14}}>
+              <div style={{fontSize:12,color:t.dim,marginBottom:6,fontWeight:600}}>🔍 Reviewer Model</div>
+              {reviewerModel?<div style={{display:"flex",gap:6,alignItems:"center"}}>
+                <div style={{flex:1}}><ModelPicker value={reviewerModel} onChange={setReviewerModel} models={models} modelDetails={modelDetails} t={t} font={font}/></div>
+                <button onClick={()=>setReviewerModel("")} style={{padding:"6px 10px",background:`${t.err}18`,border:`1px solid ${t.err}33`,borderRadius:7,color:t.err,fontSize:10,cursor:"pointer",fontWeight:600,whiteSpace:"nowrap"}}>Reset</button>
+              </div>:<div onClick={()=>setReviewerModel(models[0]||"")} style={{display:"flex",alignItems:"center",gap:6,padding:"5px 10px",background:t.bgDeep,border:`1px dashed ${t.brd}55`,borderRadius:8,cursor:"pointer",transition:"all .15s"}}>
+                <span style={{fontSize:14}}>🔍</span>
+                <div style={{flex:1}}><div style={{fontSize:11,fontWeight:600,color:t.mut}}>Inherits from Planning Model</div><div style={{fontSize:9,color:t.dim}}>Click to override for the Reviewer agent only</div></div>
+                <span style={{fontSize:9,color:t.mut}}>▾</span>
+              </div>}
+            </div>
+
+            {/* Builder — inherits from Coder Model */}
+            <div style={{marginBottom:14}}>
+              <div style={{fontSize:12,color:t.dim,marginBottom:6,fontWeight:600}}>🏗 Builder Model</div>
+              {builderModel?<div style={{display:"flex",gap:6,alignItems:"center"}}>
+                <div style={{flex:1}}><ModelPicker value={builderModel} onChange={setBuilderModel} models={models} modelDetails={modelDetails} t={t} font={font}/></div>
+                <button onClick={()=>setBuilderModel("")} style={{padding:"6px 10px",background:`${t.err}18`,border:`1px solid ${t.err}33`,borderRadius:7,color:t.err,fontSize:10,cursor:"pointer",fontWeight:600,whiteSpace:"nowrap"}}>Reset</button>
+              </div>:<div onClick={()=>setBuilderModel(models[0]||"")} style={{display:"flex",alignItems:"center",gap:6,padding:"5px 10px",background:t.bgDeep,border:`1px dashed ${t.brd}55`,borderRadius:8,cursor:"pointer",transition:"all .15s"}}>
+                <span style={{fontSize:14}}>🏗</span>
+                <div style={{flex:1}}><div style={{fontSize:11,fontWeight:600,color:t.mut}}>Inherits from Coder Model</div><div style={{fontSize:9,color:t.dim}}>Click to override the Builder (OpenHands) agent only</div></div>
+                <span style={{fontSize:9,color:t.mut}}>▾</span>
+              </div>}
+            </div>
+
+            {/* Fixer — inherits from Coder Model */}
+            <div style={{marginBottom:14}}>
+              <div style={{fontSize:12,color:t.dim,marginBottom:6,fontWeight:600}}>🛠 Fixer Model</div>
+              {fixerModel?<div style={{display:"flex",gap:6,alignItems:"center"}}>
+                <div style={{flex:1}}><ModelPicker value={fixerModel} onChange={setFixerModel} models={models} modelDetails={modelDetails} t={t} font={font}/></div>
+                <button onClick={()=>setFixerModel("")} style={{padding:"6px 10px",background:`${t.err}18`,border:`1px solid ${t.err}33`,borderRadius:7,color:t.err,fontSize:10,cursor:"pointer",fontWeight:600,whiteSpace:"nowrap"}}>Reset</button>
+              </div>:<div onClick={()=>setFixerModel(models[0]||"")} style={{display:"flex",alignItems:"center",gap:6,padding:"5px 10px",background:t.bgDeep,border:`1px dashed ${t.brd}55`,borderRadius:8,cursor:"pointer",transition:"all .15s"}}>
+                <span style={{fontSize:14}}>🛠</span>
+                <div style={{flex:1}}><div style={{fontSize:11,fontWeight:600,color:t.mut}}>Inherits from Coder Model</div><div style={{fontSize:9,color:t.dim}}>Click to override the Fixer agent only</div></div>
+                <span style={{fontSize:9,color:t.mut}}>▾</span>
+              </div>}
+            </div>
+
+            {/* ProjectQA — inherits from chat/persona model */}
+            <div style={{marginBottom:6}}>
+              <div style={{fontSize:12,color:t.dim,marginBottom:6,fontWeight:600}}>❓ ProjectQA Model</div>
+              {qaModel?<div style={{display:"flex",gap:6,alignItems:"center"}}>
+                <div style={{flex:1}}><ModelPicker value={qaModel} onChange={setQaModel} models={models} modelDetails={modelDetails} t={t} font={font}/></div>
+                <button onClick={()=>setQaModel("")} style={{padding:"6px 10px",background:`${t.err}18`,border:`1px solid ${t.err}33`,borderRadius:7,color:t.err,fontSize:10,cursor:"pointer",fontWeight:600,whiteSpace:"nowrap"}}>Reset</button>
+              </div>:<div onClick={()=>setQaModel(models[0]||"")} style={{display:"flex",alignItems:"center",gap:6,padding:"5px 10px",background:t.bgDeep,border:`1px dashed ${t.brd}55`,borderRadius:8,cursor:"pointer",transition:"all .15s"}}>
+                <span style={{fontSize:14}}>❓</span>
+                <div style={{flex:1}}><div style={{fontSize:11,fontWeight:600,color:t.mut}}>Inherits from chat model</div><div style={{fontSize:9,color:t.dim}}>Click to override the ProjectQA agent only</div></div>
+                <span style={{fontSize:9,color:t.mut}}>▾</span>
+              </div>}
+            </div>
+          </div>}
+        </div>
+
+        <div style={{borderTop:`1px solid ${t.brd}22`,paddingTop:14,marginBottom:14,display:"flex",alignItems:"center",gap:10}}>
           <label style={{fontSize:12,color:t.dim,fontWeight:600,whiteSpace:"nowrap"}}>OpenHands Enabled</label>
           <div onClick={()=>setOpenhandsEnabled(!openhandsEnabled)} style={{width:36,height:20,borderRadius:10,background:openhandsEnabled?t.acc:`${t.mut}44`,cursor:"pointer",position:"relative",transition:"all .2s"}}>
             <div style={{width:16,height:16,borderRadius:8,background:t.fg,position:"absolute",top:2,left:openhandsEnabled?18:2,transition:"all .2s"}}/>
@@ -5027,10 +5152,20 @@ function HyprChat(){
           <div style={{display:"flex",justifyContent:"space-between",fontSize:9,color:t.mut}}><span>2048</span><span>32768</span></div>
         </div>
 
-        <div style={{marginBottom:6}}>
+        <div style={{marginBottom:14}}>
           <label style={{fontSize:12,color:t.dim,fontWeight:600,display:"block",marginBottom:6}}>Max Agent Rounds: <span style={{color:t.acc}}>{openhandsMaxRounds}</span></label>
           <input type="range" min="5" max="40" step="1" value={openhandsMaxRounds} onChange={e=>setOpenhandsMaxRounds(parseInt(e.target.value))} style={{width:"100%",accentColor:t.acc}}/>
           <div style={{display:"flex",justifyContent:"space-between",fontSize:9,color:t.mut}}><span>5</span><span>40</span></div>
+        </div>
+
+        <div style={{marginBottom:6}}>
+          <label style={{fontSize:12,color:t.dim,fontWeight:600,display:"block",marginBottom:6}}>Reasoning Effort: <span style={{color:t.acc}}>{openhandsReasoningEffort}</span></label>
+          <select value={openhandsReasoningEffort} onChange={e=>setOpenhandsReasoningEffort(e.target.value)} style={{width:"100%",background:t.bgDeep,border:`1px solid ${t.brd}44`,color:t.text,padding:"8px 12px",borderRadius:8,fontFamily:font,fontSize:12,outline:"none",cursor:"pointer"}}>
+            <option value="low">Low — fastest, minimal think tokens</option>
+            <option value="medium">Medium — balanced (recommended for local Ollama)</option>
+            <option value="high">High — most thorough, slow on local models</option>
+          </select>
+          <div style={{fontSize:9,color:t.mut,marginTop:4}}>Controls how much the Builder LLM thinks before each tool call. Drop to <b>low</b> if generate_code is taking minutes per file.</div>
         </div>
       </div>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -787,7 +787,10 @@ const ToolStatus = ({evts,t,expandedPill,setExpandedPill,onPreview,historical,md
 
   const codeOutputEvts = evts.filter(e=>e.type==="code_output");
   const fileReadyEvts = evts.filter(e=>e.type==="file_ready");
-  const searchResultEvts = evts.filter(e=>e.type==="search_results");
+  // Skip search_agent's events here — those render in the QUICK SEARCH RESULTS
+  // carousel above the message via quickResults state. SearchResultCards is
+  // for the `research` tool's mid-message results, which don't carry source.
+  const searchResultEvts = evts.filter(e=>e.type==="search_results"&&e.data?.source!=="quick_search");
   const sourceLinkEvts = evts.filter(e=>e.type==="source_links");
 
   // Surface reasoning + architecture plan above the pill row.

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -2624,7 +2624,22 @@ function HyprChat(){
     if(newAttachments.length)setAttachments(p=>[...p,...newAttachments]);
   };
 
-  const stop=()=>{abortR.current?.abort();setStreaming(false);streamingCidRef.current=null;};
+  const stop=()=>{
+    // Tell the backend to abort any in-flight runs (architect, builder,
+    // reviewer, fixer) before we drop the SSE connection. Without this the
+    // run's ollama call keeps burning until its 600s timeout and the runs
+    // row stays status='running' forever.
+    try{
+      const rids=_runIdsFromEvents(evtsRef.current||evts);
+      for(const rid of rids){
+        // Fire-and-forget — we don't await, the backend route is idempotent.
+        fetch(`${API}/api/runs/${rid}/cancel`,{method:"POST"}).catch(()=>{});
+      }
+    }catch{}
+    abortR.current?.abort();
+    setStreaming(false);
+    streamingCidRef.current=null;
+  };
 
   const openPreview=async(filename,url)=>{
     const isExternal=url.startsWith("http://") || url.startsWith("https://");
@@ -5157,8 +5172,14 @@ function HyprChat(){
 
         <div style={{marginBottom:14}}>
           <label style={{fontSize:12,color:t.dim,fontWeight:600,display:"block",marginBottom:6}}>Coder Context Window: <span style={{color:t.acc}}>{coderNumCtx.toLocaleString()}</span></label>
-          <input type="range" min="2048" max="32768" step="1024" value={coderNumCtx} onChange={e=>setCoderNumCtx(parseInt(e.target.value))} style={{width:"100%",accentColor:t.acc}}/>
-          <div style={{display:"flex",justifyContent:"space-between",fontSize:9,color:t.mut}}><span>2048</span><span>32768</span></div>
+          <input type="range" min="2048" max="262144" step="2048" value={coderNumCtx} onChange={e=>setCoderNumCtx(parseInt(e.target.value))} style={{width:"100%",accentColor:t.acc}}/>
+          <div style={{display:"flex",justifyContent:"space-between",fontSize:9,color:t.mut}}><span>2048</span><span>262144</span></div>
+          <div style={{fontSize:9,color:t.mut,marginTop:4,lineHeight:1.5}}>
+            {coderNumCtx<=16384?<><b style={{color:t.acc}}>Compact (≤16K)</b> — small tasks, single-function edits. Fits comfortably with 3 models warm.</>
+            :coderNumCtx<=65536?<><b style={{color:t.acc}}>Recommended (32–64K)</b> — sweet spot for most Coder Bot work. Multi-file refactors fit, VRAM stays comfortable.</>
+            :coderNumCtx<=131072?<><b style={{color:t.acc}}>Large (64–128K)</b> — whole-file analysis, big refactors. Keep only 1–2 models warm or you may hit VRAM limits.</>
+            :<><b style={{color:t.err}}>Maximum (128–256K)</b> — whole-codebase context. Drop <code>OLLAMA_MAX_LOADED_MODELS</code> to 1 or expect OOM. First run after slider change reloads the model.</>}
+          </div>
         </div>
 
         <div style={{marginBottom:14}}>


### PR DESCRIPTION
## Alpha v17.0.1 — May 26, 2026

### Coder Bot v2 — workflow gate hardening

Ten edge cases in the v2 gate, profile detection, and persona prompt that together swung the same prompt between a clean 16-round bug fix and a 24-round rebuild loop. All fixed.

#### Gate / Reviewer / Fixer
- **Phantom `run_fixer` blocked** — `tools.py` gate refuses `run_fixer` unless the latest run is a reviewer with `status="issues"`/`"error"`. Stops cycle-cap burn from hallucinated `reviewer_run_id`s.
- **"Nothing to fix" is `skipped`, not `succeeded`** — `agents/fixer.py:249`. The 3-cycle cap counts only real attempts now.
- **`pytest` exit 5 ("no tests collected") treated as benign** — `agents/reviewer.py:43,47` append `|| echo '(no tests)'`. Greenfield scaffolds stop infinite-looping on a missing `pytest.ini`.
- **Cycle cap delivers gracefully** — PENDING_FIX gate releases `download_project`, `download_file`, `read_file`, `list_files` once the cap fires, with the cap message suggesting `download_project` as the ship path.
- **Anti-rebuild guard** — `tools.py` blocks a second `generate_code` against the same project in the same turn (detected via `runs.started_at >= latest_user_message.created_at`). Pushes the model toward `read_file` + `write_file` for refinement.
- **Profile auto-detect for edited uploads** — `tools.py` fallback sets `_builder_profile = "feature"` when an active project has no prior builder run, so `write_file`-edited uploads aren't clobbered by a scaffold rebuild.
- **`_parse_ts_loose()`** — new helper unifies SQLite `CURRENT_TIMESTAMP` (space, no µs) and Python `isoformat()` (T, with µs) for cross-table "is this run from the current turn?" comparisons.

#### ACTIVE PROJECT block
- **Path-explicit injection** — `agents/chat.py` emits `**ON-DISK PATH (use this for ALL tool calls): /root/projects/{project_id}**` and relabels the human name `display name (NOT a directory)`. Stops `mkdir -p /root/projects/{display-name}` mistakes.
- **`write_file` is the default** — small edits, refactors, 1–5 line pastes all route to `read_file` → `write_file`. `generate_code` reserved for genuinely new 3+ files or major refactors.
- **Runtime-bug branch** — runtime crashes that compile fine (font errors, bad preview state) skip `run_review` and go straight to `read_file` → `write_file`, since the reviewer can't see them. Persona prompt updated to match.

#### Persona + seeding
- **Coder Bot v2 prompt** — runtime-bug branch added; new top-level **ANTI-REBUILD RULE** explaining the gate.
- **`seed_coder_bot_v2()` updates in-place** — `agents/personas.py` no longer deletes-and-recreates on re-seed, preserving `mc_id` so existing conversations keep their persona link.

#### Settings & uploads
- **Empty-string settings respected on restart** — `main.py:183` switched to `"key" in _settings` membership checks. Planning Model = "(use chat model)" now survives restarts instead of reverting to the env default. Same fix for `coder_model`.
- **Upload limit 50 MB → 250 MB** — `config.MAX_UPLOAD_SIZE_MB` (env-overridable). Fits a typical PyQt5 + venv. `main.py:1641` PDF route and `frontend/dist/index.html:2589` attach guard now route through the constant.

### OpenHands — Reasoning Effort
- **New "Reasoning Effort" dropdown** in the OpenHands settings tile: **Low** / **Medium** (new default for local Ollama) / **High** (SDK default).
- **Why it matters** — the SDK defaults `reasoning_effort=high` + `extended_thinking_budget=200000`. On a 30B model with `num_ctx=16384` that's 30+ s per tool round; with chat ↔ builder VRAM thrashing, a 3-file scaffold ran 5 min wall-clock. Medium/Low cuts that with no quality regression on CRUD/UI tasks.
- **Plumbing** — `OPENHANDS_REASONING_EFFORT` in `config.py` → settings handlers in `main.py` → `oh_payload` in `tools.py` → `RunRequest.reasoning_effort` in `openhands_worker.py` → `_LLM(reasoning_effort=…)` with a `TypeError` fallback for older SDKs (logs a warning, no-op).

### Quick Search — best-of synthesis

Pulled the highest-ROI patterns from Perplexica (24k★), Khoj (18k★), and Open WebUI (70k★) into `backend/search_agent.py` + `backend/quick_search.py`.

- **`standalone_query` in triage** (Perplexica) — triage now returns a context-independent rephrasing of the latest message alongside `queries[]`. Used as the canonical query for ranking, embedding, and the carousel — kills pronoun/anaphora bugs at the source.
- **Embedding rerank + dedup** (Perplexica) — batched `nomic-embed-text` call scores snippets vs `standalone_query`; drops sim < 0.45, dedups pairs > 0.85. Catches synonym/paraphrase mismatches and the SearXNG-mirror dup case. Falls back to heuristic order on any embed failure.
- **Trafilatura page extraction** — replaces the regex strip with `trafilatura.extract()` on top-N pages. JS-heavy and paywall-prelude pages now produce usable content. Falls back inline (same fetched HTML, no double round-trip) if trafilatura is unavailable.
- **Per-conversation subquery dedup** (Khoj) — drops queries already searched earlier in the same conversation; preserves at least one query if all are dupes.
- **Follow-up relevance fix** — `relevance_score` now folds prior-turn tokens into the user-token set when the message is a follow-up. Refine actually fires for "any updates?" instead of returning 1.0 every time.
- **News freshness** — when triage's category is `news` and the user message has a recency cue (`today`/`latest`/`current year`), SearXNG gets `time_range=month`. Cache key becomes `(query, time_range)`.
- **Triage category used for ranking** — was being computed and discarded; now drives `_apply_domain_bias` directly. Regex `_classify_query` becomes the triage-failure fallback only.
- **SSRF guard** (Open WebUI) — `_url_safe()` resolves hostnames before fetch; rejects private/loopback/link-local IPs. Defends against malicious search results redirecting to internal services.
- **Bounded LRU cache** — `_CACHE` capped at 512 entries with LRU eviction. Prevents long-running-process leak.
- **Concurrency semaphore** — `_FETCH_SEMA(6)` around page-fetch + OG-image-fetch. Smooths bursts on the SearXNG LXC and ProtonVPN exit.
- **Search-failure note** — when quick search throws, a system note ("web search was unavailable, don't guess") is appended to the user turn so the model doesn't hallucinate current events.
- **Pre-existing `_search_searxng` bug** — any SearXNG result with a thumbnail was being marked `type="image"` and filtered out by the chat ranker. News results almost always carry an `og:image`; this was silently dropping ~60% of news results before they reached embedding rerank. Narrowed to URL-extension-only.
- **Removed** — `_fetch_page` import in `quick_search.py` (replaced by `_fetch_clean_page`); stale `_rewrite_query` references in docstrings.
- **New dep** — `trafilatura>=1.10.0` in `requirements.txt`.