### PR TITLE
Memory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ N8N_URL=http://127.0.0.1:5678
 N8N_WEBHOOK_PATH=/webhook/execute-code
 N8N_RESEARCH_PATH=/webhook/deep-research
 
+# Optional proxy for public page/image fetches. Leave empty unless the
+# SearXNG privacy setup activates the host-local proxy on :8899.
+HYPRCHAT_OUTBOUND_PROXY=
+
 # Storage
 DATABASE_PATH=/opt/hyprchat/data/hyprchat.db
 UPLOAD_DIR=/opt/hyprchat/data/uploads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## Alpha v17.1.2 — June 8, 2026
+
+### Quick Search
+- Improved same-day event queries so prompts like "WWDC that just took place today" search cleaner event/year/date variants instead of dragging filler words into SearXNG.
+- Added a general-web fallback for strict same-day searches so fresh official pages, live blogs, and tech coverage can surface when the news/day filter misses them.
+- Made same-day evidence handling smarter by accepting exact dates, "today", recent-hour snippets, and current-year live-update text before warning that sources are stale.
+
+### Chat Streaming & Context Meter
+- Tool-enabled chat rounds now stream assistant text live while it is generated instead of waiting for the full model output to finish.
+- If streamed draft text turns into a native or text-parsed tool call, the chat clears that draft before showing the tool execution cards/results.
+- Replaced the misleading live "Generating ... chars" status with token-based wording that matches the top-right context meter.
+- Clarified the header context meter tooltip as prompt plus generated tokens against the active `num_ctx`.
+
+### Workspace Memory & Ghost Mode
+- Added workspace-scoped memory with reviewed suggestions, accepted memories, and manual memory blocks that can be injected into workspace chats.
+- Added memory review controls for accepting, rejecting, editing, deleting, and manually creating semantic, episodic, and procedural memories.
+- Added Ghost Mode for local-only chats that are not saved, indexed, added to history, or used for workspace memory suggestions.
+
 ## Alpha v17.1.1 — June 8, 2026
 
 >Deep Research overhaul update. This update focued on making sure deep research got the love it deserved. Daedalus will still use deep research but for the user front end it has been renamed to Agent Research (the togglable tool above the composer). A backend code rename could break a lot of things and that is something ill do at a later date.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
-## Alpha v17.1.2 — June 8, 2026
+## Alpha v17.1.2 — June 10, 2026
+
+### HyprChat Memory & Navigation
+- Added global HyprChat memory that can persist across chats when memory is enabled for a conversation.
+- Added a user profile and memory management panel for profile details, interests, links, manual memories, and reviewed memory suggestions.
+- Added a per-chat memory toggle, including support for enabling memory on an empty chat before the first message creates the saved conversation.
+- Reorganized the left rail so Search, Chat, Research, Council, Memory, Agents, and Prompt Library are always visible.
+- Moved Knowledge Bases, Tools, Model Manager, and Analytics behind an inline expandable More section that opens inside the rail instead of a separate popout.
+
+### Workspace Memory & Ghost Mode
+- Added workspace-scoped memory with reviewed suggestions, accepted memories, and manual memory blocks that can be injected into workspace chats.
+- Added memory review controls for accepting, rejecting, editing, deleting, and manually creating semantic, episodic, and procedural memories.
+- Added Ghost Mode for local-only chats that are not saved, indexed, added to history, or used for workspace memory suggestions.
 
 ### Quick Search
 - Improved same-day event queries so prompts like "WWDC that just took place today" search cleaner event/year/date variants instead of dragging filler words into SearXNG.
@@ -11,10 +23,6 @@
 - Replaced the misleading live "Generating ... chars" status with token-based wording that matches the top-right context meter.
 - Clarified the header context meter tooltip as prompt plus generated tokens against the active `num_ctx`.
 
-### Workspace Memory & Ghost Mode
-- Added workspace-scoped memory with reviewed suggestions, accepted memories, and manual memory blocks that can be injected into workspace chats.
-- Added memory review controls for accepting, rejecting, editing, deleting, and manually creating semantic, episodic, and procedural memories.
-- Added Ghost Mode for local-only chats that are not saved, indexed, added to history, or used for workspace memory suggestions.
 
 ## Alpha v17.1.1 — June 8, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@
 - Replaced the misleading live "Generating ... chars" status with token-based wording that matches the top-right context meter.
 - Clarified the header context meter tooltip as prompt plus generated tokens against the active `num_ctx`.
 
+### Multi-User support (Not for concurrent usage, only for splitting up your chats)
+- Now you have the option to have different users for different things. Keep all your chats, workspaces and configurations separate from each other by signing into the appropriate user.
+- Each user has the option to have a password or not.
+- Manage users in the settings panel. You can set passwords, reset passwords, add users and remove users.
+
+
+### Bug Fixes
+- Fixed a fresh empty-chat race where selecting a model in the top-left picker and immediately sending could create the chat with the selected model but stream the first response through a stale/default model before React state caught up.
+
 
 ## Alpha v17.1.1 — June 8, 2026
 

--- a/README.md
+++ b/README.md
@@ -204,11 +204,16 @@ OLLAMA_URL=http://127.0.0.1:11434
 CODEBOX_URL=http://127.0.0.1:8585
 OPENHANDS_URL=http://127.0.0.1:8586
 SEARXNG_URL=http://127.0.0.1:8888
+HYPRCHAT_OUTBOUND_PROXY=
 
 DEFAULT_MODEL=qwen3.5:27b
 PLANNING_MODEL=qwen3.5:27b
 CODER_MODEL=qwen2.5-coder:14b
 ```
+
+`HYPRCHAT_OUTBOUND_PROXY` is optional. The first-time deploy monitor can set it
+to `http://<searxng-host>:8899` after the SearXNG privacy setup verifies that a
+Proton OpenVPN tunnel and host-local proxy are active.
 
 Runtime settings live in the Settings overlay. Source defaults live in `backend/config.py`.
 
@@ -221,6 +226,30 @@ python3 deploy_monitor.py
 ```
 
 It reads `.deploy_config.json`, pushes changed backend/frontend files, restarts HyprChat after backend changes, and deploys `backend/openhands_worker.py` to Codebox when needed.
+
+Optional `.deploy_config.json` SearXNG entry:
+
+```json
+{
+  "hyprchat": {"host": "192.168.1.120", "user": "root", "password": "<local-only-password>"},
+  "codebox": {"host": "192.168.1.201", "user": "root", "password": "<local-only-password>"},
+  "searxng": {
+    "host": "192.168.1.141",
+    "user": "root",
+    "password": "<local-only-password>",
+    "dev_ip": "<optional-dev-ip>"
+  }
+}
+```
+
+On first-time full deploy, a configured `searxng` host runs
+`scripts/setup-searxng-privacy.sh`. The script hardens an existing SearXNG
+install; it does not install SearXNG or create Proton credentials. To activate
+the VPN-backed proxy, place Proton OpenVPN files at
+`/etc/openvpn/proton-ovpn/*.ovpn` and credentials at
+`/etc/openvpn/proton-ovpn/auth.txt` on the SearXNG host before running setup. If
+those files are absent, deploy continues with a warning and does not set
+`HYPRCHAT_OUTBOUND_PROXY`.
 
 Manual deploy:
 

--- a/backend/agents/chat.py
+++ b/backend/agents/chat.py
@@ -1111,6 +1111,8 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
         gen_tokens = 0
         prompt_tokens = 0
         _gen_pill_started = False  # First "generating" pill uses tool_start; subsequent ones use tool_progress so the frontend collapses them into one updating pill
+        _streamed_content = False
+        _has_tools = bool(available_tool_names)
 
         # ── Context window management: prune old tool results to stay under budget ──
         _ctx_size = sum(len(m.get("content", "")) for m in messages)
@@ -1213,9 +1215,9 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                     _chunk_buf = ""
                     _repeat_window = ""  # Rolling window for repetition detection
                     _live_gen_tokens = 0  # Live token counter for streaming updates
-                    # Buffer mode: when tools are active, don't stream content immediately
-                    # so code blocks don't flash in chat before tool calls are detected
-                    _has_tools = bool(available_tool_names)
+                    # Tool-enabled rounds stream draft content live. If the
+                    # completed round resolves to a tool call, the existing
+                    # clear event removes that draft before tool execution.
 
                     # Pipe aiter_lines into a queue so we can read with timeout
                     # without corrupting the httpx stream (asyncio.wait_for cancels)
@@ -1358,29 +1360,33 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                                         break
 
                                 if _has_tools:
-                                    # Buffer mode: emit a progress pill instead of streaming tokens
-                                    # Show what the model is working on via SSE event
+                                    # Keep the activity pill in token units so
+                                    # it matches the header context meter.
                                     if len(content) % 200 < len(token):
                                         _evt_type = "tool_start" if not _gen_pill_started else "tool_progress"
                                         _gen_pill_started = True
+                                        _shown_tokens = max(_live_gen_tokens, (len(content) + 3) // 4)
                                         await events.emit(conv_id, _evt_type, {
                                             "tool": "generating",
-                                            "status": f"✍️ Generating... ({len(content)} chars)",
+                                            "status": f"✍️ Generating... (~{_shown_tokens} tokens)",
                                             "icon": "edit",
                                         })
+
+                                # Stream assistant text live even when tools
+                                # are enabled. Tool-call rounds clear this
+                                # provisional text after parsing completes.
+                                _chunk_buf += token
+                                if len(_chunk_buf) >= 8 or chunk.get("done"):
+                                    yield f"data: {json.dumps({'type': 'token', 'content': _chunk_buf})}\n\n"
+                                    _streamed_content = True
+                                    _chunk_buf = ""
                                     await asyncio.sleep(0)
-                                else:
-                                    # No tools — stream content directly to chat
-                                    _chunk_buf += token
-                                    if len(_chunk_buf) >= 8 or chunk.get("done"):
-                                        yield f"data: {json.dumps({'type': 'token', 'content': _chunk_buf})}\n\n"
-                                        _chunk_buf = ""
-                                        await asyncio.sleep(0)
 
                         # Track token counts from Ollama
                         if chunk.get("done"):
                             if _chunk_buf:
                                 yield f"data: {json.dumps({'type': 'token', 'content': _chunk_buf})}\n\n"
+                                _streamed_content = True
                                 _chunk_buf = ""
                             # Finalize thinking if we were in native thinking mode
                             if _in_thinking and _thinking_buf:
@@ -1632,16 +1638,11 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                 if len(_tool_history) > 5:
                     _tool_history.pop(0)
 
+            if _streamed_content:
+                yield f"data: {json.dumps({'type': 'clear'})}\n\n"
             if content:
-                if _has_tools:
-                    # Content was buffered (not streamed) — strip code, keep prose for history
-                    cleaned = re.sub(r'```\w*\n.*?```', '', content, flags=re.DOTALL).strip()
-                    msg["content"] = cleaned
-                else:
-                    # Content was streamed — tell frontend to discard it
-                    yield f"data: {json.dumps({'type': 'clear'})}\n\n"
-                    cleaned = re.sub(r'```\w*\n.*?```', '', content, flags=re.DOTALL).strip()
-                    msg["content"] = cleaned
+                cleaned = re.sub(r'```\w*\n.*?```', '', content, flags=re.DOTALL).strip()
+                msg["content"] = cleaned
 
             messages.append(msg)
             yield f"data: {json.dumps({'type': 'keepalive'})}\n\n"
@@ -1941,7 +1942,7 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
         # No tool calls — we have a final response
         if content:
             # If content was buffered (tool mode), flush it now as the final answer
-            if _has_tools:
+            if _has_tools and not _streamed_content:
                 for i in range(0, len(content), 8):
                     yield f"data: {json.dumps({'type': 'token', 'content': content[i:i+8]})}\n\n"
                     await asyncio.sleep(0)

--- a/backend/agents/chat.py
+++ b/backend/agents/chat.py
@@ -1617,9 +1617,11 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
             msg["tool_calls"] = tool_calls
 
         # ── Text-based tool call fallback ──
+        _text_tool_call_round = False
         if not tool_calls and content and available_tool_names:
             tool_calls = parse_text_tool_calls(content, available_tool_names)
             if tool_calls:
+                _text_tool_call_round = True
                 content = strip_tool_calls(content)
                 # Clean up residual garbage (backticks, braces, etc.) left after stripping
                 cleaned_residue = re.sub(r'[`{}\[\]\s"\']', '', content).strip()
@@ -1816,7 +1818,7 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                 if len(_tool_history) > 5:
                     _tool_history.pop(0)
 
-            if _streamed_content:
+            if _streamed_content and _text_tool_call_round:
                 yield f"data: {json.dumps({'type': 'clear'})}\n\n"
             if content:
                 cleaned = re.sub(r'```\w*\n.*?```', '', content, flags=re.DOTALL).strip()

--- a/backend/agents/chat.py
+++ b/backend/agents/chat.py
@@ -27,6 +27,26 @@ _PERSONA_RATING_GUIDANCE = {
     "Unrated": "Unrated (max XXX): Broadest adult setting. Explicit consenting-adult NSFW is allowed within safety boundaries. Avoid minors, coercion, illegal content, and non-consensual sexual content.",
 }
 
+_PERSONA_PLACEHOLDER_RE = re.compile(
+    r"\{\{\s*(user|char)\s*\}\}|\{\s*(user|char)\s*\}",
+    re.IGNORECASE,
+)
+
+
+def _replace_persona_placeholders(text: str, *, user_name: str, char_name: str) -> str:
+    if not text:
+        return text or ""
+    names = {
+        "user": (user_name or "User").strip() or "User",
+        "char": (char_name or "the character").strip() or "the character",
+    }
+
+    def repl(match: re.Match) -> str:
+        key = (match.group(1) or match.group(2) or "").lower()
+        return names.get(key, match.group(0))
+
+    return _PERSONA_PLACEHOLDER_RE.sub(repl, str(text))
+
 
 def _normalize_persona_rating(value) -> str:
     s = re.sub(r"[\s_]+", "", str(value or "PG-13").strip().lower())
@@ -649,6 +669,7 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
     persona_system_prompt = None
     persona_kb_ids = []
     persona_think_budget = None
+    persona_placeholder_ctx = None
     _is_v2_persona = False
     if req.persona_id:
         all_configs = await db.get_model_configs()
@@ -659,7 +680,17 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
             if "v2" in _persona_name_l or "daedalus" in _persona_name_l:
                 _is_v2_persona = True
             params = mc.get("parameters", {})
-            if _model_config_profile_type(mc, params) == "persona":
+            profile_type = _model_config_profile_type(mc, params)
+            if profile_type == "persona":
+                try:
+                    current_user = await db.get_user()
+                    user_name = (current_user or {}).get("name") or "User"
+                except Exception:
+                    user_name = "User"
+                persona_placeholder_ctx = {
+                    "user_name": user_name,
+                    "char_name": mc.get("name") or "the character",
+                }
                 persona_fields = params.get("persona") if isinstance(params.get("persona"), dict) else {}
                 thinking_mode = _normalize_persona_thinking_mode(persona_fields.get("thinking_mode", params.get("thinking_mode")))
                 if thinking_mode != "auto":
@@ -671,6 +702,10 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                         persona_system_prompt += rating_block
                 else:
                     persona_system_prompt = rating_block.strip()
+                persona_system_prompt = _replace_persona_placeholders(
+                    persona_system_prompt or "",
+                    **persona_placeholder_ctx,
+                )
             for key in ("temperature", "num_ctx", "top_p", "top_k"):
                 if params.get(key) is not None:
                     if key == "num_ctx":
@@ -1011,7 +1046,10 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
         print(f"[CHAT] Injected active project context: {_active_project.get('name', '?')} ({len(_ap_files)} files)")
 
     for m in req.messages:
-        _msg = {"role": m["role"], "content": m["content"]}
+        _content = m["content"]
+        if persona_placeholder_ctx and m.get("role") in {"assistant", "system"}:
+            _content = _replace_persona_placeholders(_content, **persona_placeholder_ctx)
+        _msg = {"role": m["role"], "content": _content}
         # Pass image attachments through to vision-capable Ollama models.
         # Non-vision models silently ignore the field.
         if m.get("images"):

--- a/backend/agents/chat.py
+++ b/backend/agents/chat.py
@@ -77,6 +77,122 @@ def _persona_rating_guidance(params: dict) -> str:
     return _PERSONA_RATING_GUIDANCE.get(rating, _PERSONA_RATING_GUIDANCE["PG-13"])
 
 
+def _extract_json_array(text: str) -> list:
+    raw = re.sub(r"<think>.*?</think>", "", text or "", flags=re.DOTALL).strip()
+    start, end = raw.find("["), raw.rfind("]")
+    if start == -1 or end <= start:
+        return []
+    try:
+        data = json.loads(raw[start:end + 1])
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+
+async def _suggest_workspace_memories(
+    req,
+    http,
+    events,
+    conv_id: str,
+    workspace: dict | None,
+    user_text: str,
+    assistant_text: str,
+    assistant_msg_id: int | None,
+):
+    if not workspace or not int(workspace.get("memory_enabled") or 0):
+        return
+    ws_id = workspace.get("id")
+    if not ws_id or len((user_text or "") + (assistant_text or "")) < 120:
+        return
+    model = getattr(config, "WORKSPACE_MODEL", "") or getattr(req, "model", "") or config.DEFAULT_MODEL
+    prompt = (
+        "You extract useful long-term workspace memories from one chat turn.\n"
+        "Return ONLY a JSON array with 0-5 objects. Do not include markdown.\n"
+        "Each object shape:\n"
+        "{\"type\":\"semantic|episodic|procedural\",\"content\":\"one durable memory\","
+        "\"importance\":1-5,\"confidence\":0-1,\"entities\":[\"short names\"],"
+        "\"reason\":\"why it should be remembered\"}\n\n"
+        "Rules:\n"
+        "- Suggest only durable, reusable information for this workspace.\n"
+        "- semantic = stable facts/preferences/constraints.\n"
+        "- episodic = dated decisions, outcomes, blockers, or events.\n"
+        "- procedural = repeatable workflows, commands, deployment steps, lessons learned.\n"
+        "- Do not save secrets, credentials, private keys, passwords, or raw tokens.\n"
+        "- Do not save generic facts that are obvious from the chat app.\n"
+        "- Prefer fewer high-value memories over many weak ones.\n\n"
+        f"Workspace: {workspace.get('name') or ws_id}\n"
+        f"User turn:\n{(user_text or '')[:5000]}\n\n"
+        f"Assistant answer:\n{(assistant_text or '')[:7000]}"
+    )
+    try:
+        await events.emit(conv_id, "tool_start", {
+            "tool": "memory", "icon": "brain",
+            "status": "Reviewing turn for workspace memory suggestions...",
+        })
+        r = await http.post(
+            f"{config.OLLAMA_URL}/api/generate",
+            json={
+                "model": model,
+                "prompt": prompt,
+                "stream": False,
+                "think": False,
+                "options": {"temperature": 0.1, "num_ctx": 4096, "num_predict": 700},
+            },
+            timeout=45,
+        )
+        if r.status_code != 200:
+            await events.emit(conv_id, "tool_done", {
+                "tool": "memory", "icon": "brain",
+                "status": "Workspace memory suggestion skipped (helper model unavailable).",
+            })
+            return
+        suggestions = _extract_json_array(r.json().get("response", ""))
+        if not suggestions:
+            await events.emit(conv_id, "tool_done", {
+                "tool": "memory", "icon": "brain",
+                "status": "No new workspace memories suggested.",
+            })
+            return
+        existing = await db.list_workspace_memories(ws_id, status="all")
+        existing_norm = {re.sub(r"\s+", " ", (m.get("content") or "").strip().lower()) for m in existing}
+        created = 0
+        for item in suggestions[:5]:
+            if not isinstance(item, dict):
+                continue
+            content = re.sub(r"\s+", " ", str(item.get("content") or "").strip())
+            if len(content) < 12 or len(content) > 800:
+                continue
+            norm = content.lower()
+            if norm in existing_norm:
+                continue
+            if re.search(r"(password|api[_ -]?key|secret|private key|token)\s*[:=]", content, re.I):
+                continue
+            try:
+                await db.create_workspace_memory(
+                    ws_id,
+                    content=content,
+                    memory_type=item.get("type", "semantic"),
+                    status="suggested",
+                    importance=item.get("importance", 3),
+                    source_conv_id=conv_id,
+                    source_conversation_id=conv_id,
+                    source_message_id=assistant_msg_id,
+                    confidence=item.get("confidence", 0),
+                    entities=item.get("entities") if isinstance(item.get("entities"), list) else [],
+                    metadata={"reason": item.get("reason", ""), "suggested_by": "workspace_helper"},
+                )
+                existing_norm.add(norm)
+                created += 1
+            except Exception as _ce:
+                print(f"[CHAT] memory suggestion insert failed: {_ce}")
+        await events.emit(conv_id, "tool_done", {
+            "tool": "memory", "icon": "brain",
+            "status": f"Queued {created} workspace memory suggestion{'s' if created != 1 else ''} for review." if created else "No new workspace memories suggested.",
+        })
+    except Exception as e:
+        print(f"[CHAT] workspace memory suggestion failed (non-fatal): {e}")
+
+
 # ── Tool-calling templates keyed by model family ──
 TOOL_TEMPLATES = {
     "chatml": {
@@ -376,6 +492,7 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
         custom_tool_id_map: dict of custom tools keyed by id
     """
     conv_id = req.conversation_id
+    ephemeral = bool(getattr(req, "ephemeral", False))
 
     last_user_msg = ""
     for m in reversed(req.messages):
@@ -388,7 +505,7 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
     # (flaky network, etc.) the message would be lost while the assistant
     # reply still saves below. Upsert if the most recent user message in
     # the DB doesn't match the incoming one.
-    if conv_id and last_user_msg:
+    if conv_id and last_user_msg and not ephemeral:
         # Prefer the explicit display_content sent by the frontend (user's typed text,
         # without the `[Attached N image: ...]` hint that goes to the model). Fall back
         # to last_user_msg for older clients.
@@ -410,7 +527,7 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
 
     await events.emit(conv_id, "tool_start", {"tool": "processing", "status": "🔮 Connecting to neural oracle...", "icon": "activity"})
 
-    print(f"[CHAT] conv={conv_id} model={req.model} tool_ids={req.tool_ids} msgs={len(req.messages)} persona={req.persona_id}")
+    print(f"[CHAT] conv={conv_id} model={req.model} tool_ids={req.tool_ids} msgs={len(req.messages)} persona={req.persona_id} ephemeral={ephemeral}")
 
     # ── Validate model exists in Ollama before streaming ──
     try:
@@ -472,14 +589,14 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                     break
 
             kb_ids = mc.get("kb_ids", [])
-            persona_kb_ids = kb_ids
+            persona_kb_ids = [] if ephemeral else kb_ids
 
             # ── RAG config defaults (used by both KB and research memory queries) ──
             _rag_research_top_k = 4
             _rag_research_max_chars = 3000
 
             # ── RAG: Query attached knowledge bases ──
-            if kb_ids and user_query:
+            if kb_ids and user_query and not ephemeral:
                 await events.emit(conv_id, "tool_start", {
                     "tool": "kb", "icon": "database",
                     "status": f"Searching {len(kb_ids)} knowledge base(s)...",
@@ -530,7 +647,7 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                         kb_context = "\n\n".join(parts)
 
             # ── RAG: Query persona's past research memory ──
-            if user_query:
+            if user_query and not ephemeral:
                 try:
                     research_chunks = await rag.query_research(req.persona_id, user_query, top_k=_rag_research_top_k)
                     if research_chunks:
@@ -573,6 +690,27 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
     if "num_ctx" not in model_options:
         model_options["num_ctx"] = config.coerce_num_ctx(config.DEFAULT_NUM_CTX)
 
+    workspace_memory_info = {"workspace": None, "context": "", "memory_ids": [], "block_ids": []}
+    if not ephemeral:
+        try:
+            workspace_memory_info = await db.build_workspace_memory_context(
+                workspace_id=getattr(req, "workspace_id", None),
+                conversation_id=conv_id,
+                query=last_user_msg,
+                max_chars=5200,
+            )
+            if workspace_memory_info.get("context"):
+                await events.emit(conv_id, "tool_done", {
+                    "tool": "memory", "icon": "brain",
+                    "status": (
+                        f"Recalled {len(workspace_memory_info.get('memory_ids') or [])} workspace "
+                        f"memories from {workspace_memory_info.get('workspace', {}).get('name', 'workspace')}"
+                    ),
+                })
+        except Exception as _wme:
+            print(f"[CHAT] Workspace memory context failed (non-fatal): {_wme}")
+            workspace_memory_info = {"workspace": None, "context": "", "memory_ids": [], "block_ids": []}
+
     messages = []
     effective_system = persona_system_prompt if persona_system_prompt is not None else req.system_prompt
     if kb_context:
@@ -582,6 +720,14 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
             "the user's query. Use them to accurately answer questions. "
             "Each excerpt shows its source file and relevance score.\n\n"
             + kb_context
+        )
+    if workspace_memory_info.get("context"):
+        effective_system += (
+            "\n\n=== WORKSPACE MEMORY ===\n"
+            "The following workspace memory was explicitly accepted or configured by the user. "
+            "Use it as persistent context for this workspace. If it conflicts with the latest "
+            "user message, ask or follow the latest explicit user instruction.\n\n"
+            + workspace_memory_info["context"]
         )
     if effective_system:
         messages.append({"role": "system", "content": effective_system})
@@ -735,8 +881,9 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
     # ── Build Ollama-native tool definitions ──
     available_tool_names = set()
     ollama_tools = []
+    requested_tool_ids = list(req.tool_ids or [])
 
-    for tid in req.tool_ids:
+    for tid in requested_tool_ids:
         if tid == "codeagent":
             for tname, tdef in CODEAGENT_TOOLS.items():
                 if tname not in ("deep_research", "conspiracy_research"):
@@ -764,13 +911,13 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                     available_tool_names.add(tname)
 
     # Include deep_research for all codeagent sessions; conspiracy_research only when explicitly listed
-    if "codeagent" in req.tool_ids:
+    if "codeagent" in requested_tool_ids:
         if "deep_research" in CODEAGENT_TOOLS and "deep_research" not in available_tool_names:
             ollama_tools.append(CODEAGENT_TOOLS["deep_research"])
             available_tool_names.add("deep_research")
     # Also include special tools if explicitly listed by name
     for tname in ("deep_research", "conspiracy_research"):
-        if tname in req.tool_ids:
+        if tname in requested_tool_ids:
             if tname in CODEAGENT_TOOLS and tname not in available_tool_names:
                 ollama_tools.append(CODEAGENT_TOOLS[tname])
                 available_tool_names.add(tname)
@@ -785,7 +932,7 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
     print(f"[CHAT]   Tools: {sorted(available_tool_names)}")
 
     # ── Quick Search: gate → rewrite → search → rank → fetch → inject ──
-    if "quick_search" in req.tool_ids:
+    if "quick_search" in requested_tool_ids:
         try:
             qs = await run_quick_search_for_chat(
                 http,
@@ -930,16 +1077,17 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
     # the frontend sees on reload.
     _assistant_msg_id = None
     _stream_started_at = datetime.utcnow().isoformat()
-    try:
-        _assistant_msg_id = await db.add_message(conv_id, "assistant", "", metadata={
-            "stream_started_at": _stream_started_at,
-            "in_progress": True,
-        })
-        # Tell the frontend the message_id so it can PATCH the final state on
-        # stream-complete instead of POSTing a duplicate.
-        yield f"data: {json.dumps({'type': 'init', 'message_id': _assistant_msg_id})}\n\n"
-    except Exception as _ase:
-        print(f"[CHAT] Failed to create assistant message stub: {_ase}")
+    if not ephemeral:
+        try:
+            _assistant_msg_id = await db.add_message(conv_id, "assistant", "", metadata={
+                "stream_started_at": _stream_started_at,
+                "in_progress": True,
+            })
+            # Tell the frontend the message_id so it can PATCH the final state on
+            # stream-complete instead of POSTing a duplicate.
+            yield f"data: {json.dumps({'type': 'init', 'message_id': _assistant_msg_id})}\n\n"
+        except Exception as _ase:
+            print(f"[CHAT] Failed to create assistant message stub: {_ase}")
     _text_fallback_done = False
     _prev_tool_key = None  # Track previous tool call to detect loops
     _tool_history = []     # Last N tool keys for near-duplicate detection
@@ -1365,11 +1513,11 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                     msg["content"] = ""
 
         print(f"[CHAT] Round {round_num}: content={len(content)} thinking={len(thinking)} tool_calls={len(tool_calls)} gen_tokens={gen_tokens} prompt_tokens={prompt_tokens}")
-        if thinking:
+        if thinking and not ephemeral:
             print(f"[CHAT]   thinking: {thinking[:200]!r}")
-        if content:
+        if content and not ephemeral:
             print(f"[CHAT]   content: {content[:200]!r}")
-        if tool_calls:
+        if tool_calls and not ephemeral:
             print(f"[CHAT]   tool_calls: {json.dumps(tool_calls)[:300]}")
 
         # Phase 0.6: snapshot the assistant message at every round boundary.
@@ -1508,7 +1656,8 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                     try:
                         tool_args = json.loads(tool_args)
                     except (json.JSONDecodeError, ValueError):
-                        print(f"[CHAT] Warning: failed to parse tool args JSON for {tool_name}: {tool_args[:200]!r}")
+                        if not ephemeral:
+                            print(f"[CHAT] Warning: failed to parse tool args JSON for {tool_name}: {tool_args[:200]!r}")
                         tool_args = {}
                 _parsed_calls.append((tool_name, tool_args))
 
@@ -1541,7 +1690,10 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                         messages.append({"role": "tool", "content": f"Error: tool '{tool_name}' is not available in this session."})
                         continue
 
-                    print(f"[CHAT]   Executing tool: {tool_name}({json.dumps(tool_args)[:200]})")
+                    if ephemeral:
+                        print(f"[CHAT]   Executing tool: {tool_name}(args redacted for ghost mode)")
+                    else:
+                        print(f"[CHAT]   Executing tool: {tool_name}({json.dumps(tool_args)[:200]})")
 
                     _tool_icon, _tool_label = _TOOL_ICONS.get(tool_name, ("tool", f"🔧 Running {tool_name}"))
                     _tool_detail = ""
@@ -1717,7 +1869,10 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                 yield f"data: {json.dumps({'type': 'ctx_update', 'gen_tokens': 0, 'prompt_tokens': _est_prompt, 'live': True})}\n\n"
 
                 # Auto-index research results into persona's RAG memory
-                if req.persona_id and tool_name in rag.RESEARCH_TOOLS and len(tool_result) > 100:
+                if (not ephemeral
+                        and req.persona_id
+                        and tool_name in rag.RESEARCH_TOOLS
+                        and len(tool_result) > 100):
                     try:
                         _query_for_index = ""
                         if isinstance(tool_args, dict):
@@ -1850,11 +2005,22 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
 
             messages.append(msg)
             # Record token usage for analytics
-            if gen_tokens or prompt_tokens:
+            if (gen_tokens or prompt_tokens) and not ephemeral:
                 try:
                     await db.record_token_usage(conv_id, req.model, getattr(req, 'persona_id', '') or '', prompt_tokens, gen_tokens)
                 except Exception as _te:
                     print(f"[CHAT] Token recording error: {_te}")
+            if not ephemeral:
+                await _suggest_workspace_memories(
+                    req,
+                    http,
+                    events,
+                    conv_id,
+                    workspace_memory_info.get("workspace"),
+                    last_user_msg,
+                    content,
+                    _assistant_msg_id,
+                )
             await events.emit(conv_id, "complete", {"status": "Complete"})
             _done_payload = {"type": "done", "model": req.model, "message_id": _assistant_msg_id}
             if _review_round > 0:

--- a/backend/agents/chat.py
+++ b/backend/agents/chat.py
@@ -193,6 +193,105 @@ async def _suggest_workspace_memories(
         print(f"[CHAT] workspace memory suggestion failed (non-fatal): {e}")
 
 
+async def _suggest_global_memories(
+    req,
+    http,
+    events,
+    conv_id: str,
+    user_text: str,
+    assistant_text: str,
+    assistant_msg_id: int | None,
+):
+    if len((user_text or "") + (assistant_text or "")) < 120:
+        return
+    model = getattr(config, "WORKSPACE_MODEL", "") or getattr(req, "model", "") or config.DEFAULT_MODEL
+    prompt = (
+        "You extract useful long-term personal memories for a cross-chat AI assistant.\n"
+        "Return ONLY a JSON array with 0-5 objects. Do not include markdown.\n"
+        "Each object shape:\n"
+        "{\"type\":\"semantic|episodic|procedural\",\"content\":\"one durable memory\","
+        "\"importance\":1-5,\"confidence\":0-1,\"entities\":[\"short names\"],"
+        "\"reason\":\"why it should be remembered\"}\n\n"
+        "Rules:\n"
+        "- Suggest only durable information useful across many future chats.\n"
+        "- Good semantic memories include user preferences, personal background, important people, birthdays, interests, names, and stable constraints.\n"
+        "- Good episodic memories include dated user-confirmed events, decisions, or outcomes.\n"
+        "- Good procedural memories include reusable workflows or recurring user instructions.\n"
+        "- Do not save secrets, credentials, private keys, passwords, raw tokens, or credential-bearing URLs.\n"
+        "- Do not infer sensitive facts; only save what the user clearly states or confirms.\n"
+        "- Do not save generic assistant claims or one-off trivia.\n"
+        "- Prefer fewer high-value memories over many weak ones.\n\n"
+        f"User turn:\n{(user_text or '')[:5000]}\n\n"
+        f"Assistant answer:\n{(assistant_text or '')[:7000]}"
+    )
+    try:
+        await events.emit(conv_id, "tool_start", {
+            "tool": "memory", "icon": "brain",
+            "status": "Reviewing turn for HyprChat memory suggestions...",
+        })
+        r = await http.post(
+            f"{config.OLLAMA_URL}/api/generate",
+            json={
+                "model": model,
+                "prompt": prompt,
+                "stream": False,
+                "think": False,
+                "options": {"temperature": 0.1, "num_ctx": 4096, "num_predict": 700},
+            },
+            timeout=45,
+        )
+        if r.status_code != 200:
+            await events.emit(conv_id, "tool_done", {
+                "tool": "memory", "icon": "brain",
+                "status": "HyprChat memory suggestion skipped (helper model unavailable).",
+            })
+            return
+        suggestions = _extract_json_array(r.json().get("response", ""))
+        if not suggestions:
+            await events.emit(conv_id, "tool_done", {
+                "tool": "memory", "icon": "brain",
+                "status": "No new HyprChat memories suggested.",
+            })
+            return
+        existing = await db.list_global_memories(status="all")
+        existing_norm = {re.sub(r"\s+", " ", (m.get("content") or "").strip().lower()) for m in existing}
+        created = 0
+        for item in suggestions[:5]:
+            if not isinstance(item, dict):
+                continue
+            content = re.sub(r"\s+", " ", str(item.get("content") or "").strip())
+            if len(content) < 12 or len(content) > 800:
+                continue
+            norm = content.lower()
+            if norm in existing_norm:
+                continue
+            if re.search(r"(password|api[_ -]?key|secret|private key|token)\s*[:=]", content, re.I):
+                continue
+            try:
+                await db.create_global_memory(
+                    content=content,
+                    memory_type=item.get("type", "semantic"),
+                    status="suggested",
+                    importance=item.get("importance", 3),
+                    source_conv_id=conv_id,
+                    source_conversation_id=conv_id,
+                    source_message_id=assistant_msg_id,
+                    confidence=item.get("confidence", 0),
+                    entities=item.get("entities") if isinstance(item.get("entities"), list) else [],
+                    metadata={"reason": item.get("reason", ""), "suggested_by": "global_helper"},
+                )
+                existing_norm.add(norm)
+                created += 1
+            except Exception as _ce:
+                print(f"[CHAT] global memory suggestion insert failed: {_ce}")
+        await events.emit(conv_id, "tool_done", {
+            "tool": "memory", "icon": "brain",
+            "status": f"Queued {created} HyprChat memory suggestion{'s' if created != 1 else ''} for review." if created else "No new HyprChat memories suggested.",
+        })
+    except Exception as e:
+        print(f"[CHAT] global memory suggestion failed (non-fatal): {e}")
+
+
 # ── Tool-calling templates keyed by model family ──
 TOOL_TEMPLATES = {
     "chatml": {
@@ -690,6 +789,38 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
     if "num_ctx" not in model_options:
         model_options["num_ctx"] = config.coerce_num_ctx(config.DEFAULT_NUM_CTX)
 
+    global_memory_enabled = False
+    if not ephemeral:
+        raw_use_memories = getattr(req, "use_memories", None)
+        if raw_use_memories is None:
+            try:
+                global_memory_enabled = await db.get_conversation_use_memories(conv_id)
+            except Exception as _gme:
+                print(f"[CHAT] Conversation memory flag lookup failed (non-fatal): {_gme}")
+                global_memory_enabled = False
+        else:
+            global_memory_enabled = str(raw_use_memories).lower() in {"1", "true", "yes", "on"}
+
+    global_memory_info = {"profile": None, "context": "", "memory_ids": []}
+    if global_memory_enabled and not ephemeral:
+        try:
+            global_memory_info = await db.build_global_memory_context(
+                query=last_user_msg,
+                max_chars=4200,
+            )
+            if global_memory_info.get("context"):
+                mem_count = len(global_memory_info.get("memory_ids") or [])
+                await events.emit(conv_id, "tool_done", {
+                    "tool": "memory", "icon": "brain",
+                    "status": (
+                        f"Recalled {mem_count} HyprChat memor{'y' if mem_count == 1 else 'ies'}"
+                        if mem_count else "Recalled HyprChat profile"
+                    ),
+                })
+        except Exception as _gme:
+            print(f"[CHAT] HyprChat memory context failed (non-fatal): {_gme}")
+            global_memory_info = {"profile": None, "context": "", "memory_ids": []}
+
     workspace_memory_info = {"workspace": None, "context": "", "memory_ids": [], "block_ids": []}
     if not ephemeral:
         try:
@@ -720,6 +851,15 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
             "the user's query. Use them to accurately answer questions. "
             "Each excerpt shows its source file and relevance score.\n\n"
             + kb_context
+        )
+    if global_memory_info.get("context"):
+        effective_system += (
+            "\n\n=== HYPRCHAT MEMORY ===\n"
+            "The following user profile and cross-chat memories were explicitly entered "
+            "or accepted by the user. Use them as persistent context when relevant. "
+            "If this context conflicts with the latest user message, ask or follow the "
+            "latest explicit user instruction.\n\n"
+            + global_memory_info["context"]
         )
     if workspace_memory_info.get("context"):
         effective_system += (
@@ -2012,6 +2152,16 @@ async def chat_stream_generate(req, http, events, custom_tool_map, custom_tool_i
                 except Exception as _te:
                     print(f"[CHAT] Token recording error: {_te}")
             if not ephemeral:
+                if global_memory_enabled:
+                    await _suggest_global_memories(
+                        req,
+                        http,
+                        events,
+                        conv_id,
+                        last_user_msg,
+                        content,
+                        _assistant_msg_id,
+                    )
                 await _suggest_workspace_memories(
                     req,
                     http,

--- a/backend/config.py
+++ b/backend/config.py
@@ -14,6 +14,13 @@ SEARXNG_URL = os.getenv("SEARXNG_URL", "http://127.0.0.1:8888")
 N8N_URL = os.getenv("N8N_URL", "http://127.0.0.1:5678")
 N8N_WEBHOOK_PATH = os.getenv("N8N_WEBHOOK_PATH", "/webhook/execute-code")
 N8N_RESEARCH_PATH = os.getenv("N8N_RESEARCH_PATH", "/webhook/deep-research")
+HTTP_VERIFY_SSL = os.getenv("HTTP_VERIFY_SSL", "true").lower() == "true"
+OUTBOUND_PROXY_URL = (
+    os.getenv("HYPRCHAT_OUTBOUND_PROXY")
+    or os.getenv("OUTBOUND_PROXY_URL")
+    or os.getenv("WEB_FETCH_PROXY_URL")
+    or ""
+).strip()
 
 # ============================================================
 # SERVER

--- a/backend/database.py
+++ b/backend/database.py
@@ -3,16 +3,85 @@ Database layer — SQLite with aiosqlite for async access.
 Stores conversations, messages, knowledge bases, tools, model configs.
 """
 import aiosqlite
+import base64
+import contextvars
+import hashlib
+import hmac
 import os
 import json
+import secrets
 import uuid
 import re
 from datetime import datetime
 from config import DATABASE_PATH
 
+DEFAULT_USER_ID = "default"
+_CURRENT_USER_ID = contextvars.ContextVar("hyprchat_user_id", default=DEFAULT_USER_ID)
+_PASSWORD_ITERATIONS = 260_000
+
+
+def current_user_id() -> str:
+    user_id = (_CURRENT_USER_ID.get() or DEFAULT_USER_ID).strip()
+    return user_id or DEFAULT_USER_ID
+
+
+def set_current_user_id(user_id: str):
+    return _CURRENT_USER_ID.set((user_id or DEFAULT_USER_ID).strip() or DEFAULT_USER_ID)
+
+
+def reset_current_user_id(token) -> None:
+    _CURRENT_USER_ID.reset(token)
+
+
+def _scope_user(user_id: str | None = None) -> str:
+    return (user_id or current_user_id() or DEFAULT_USER_ID).strip() or DEFAULT_USER_ID
+
+
+def _hash_password(password: str) -> str:
+    salt = os.urandom(16)
+    digest = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, _PASSWORD_ITERATIONS)
+    return "pbkdf2_sha256${}${}${}".format(
+        _PASSWORD_ITERATIONS,
+        base64.b64encode(salt).decode("ascii"),
+        base64.b64encode(digest).decode("ascii"),
+    )
+
+
+def _verify_password(password: str, stored: str) -> bool:
+    if not stored:
+        return not password
+    try:
+        scheme, iterations, salt_b64, digest_b64 = stored.split("$", 3)
+        if scheme != "pbkdf2_sha256":
+            return False
+        salt = base64.b64decode(salt_b64.encode("ascii"))
+        expected = base64.b64decode(digest_b64.encode("ascii"))
+        actual = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, int(iterations))
+        return hmac.compare_digest(actual, expected)
+    except Exception:
+        return False
+
 DB_SCHEMA = """
+CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    password_hash TEXT DEFAULT '',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_login_at TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS user_sessions (
+    token_hash TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_user_sessions_user ON user_sessions(user_id);
+
 CREATE TABLE IF NOT EXISTS conversations (
     id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL DEFAULT 'default',
     title TEXT NOT NULL DEFAULT 'New Chat',
     model TEXT DEFAULT '',
     system_prompt TEXT DEFAULT '',
@@ -37,6 +106,7 @@ CREATE TABLE IF NOT EXISTS messages (
 
 CREATE TABLE IF NOT EXISTS knowledge_bases (
     id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL DEFAULT 'default',
     name TEXT NOT NULL,
     description TEXT DEFAULT '',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -56,6 +126,7 @@ CREATE TABLE IF NOT EXISTS kb_files (
 
 CREATE TABLE IF NOT EXISTS tools (
     id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL DEFAULT 'default',
     name TEXT NOT NULL,
     description TEXT DEFAULT '',
     filename TEXT NOT NULL,
@@ -66,6 +137,7 @@ CREATE TABLE IF NOT EXISTS tools (
 
 CREATE TABLE IF NOT EXISTS model_configs (
     id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL DEFAULT 'default',
     name TEXT NOT NULL,
     base_model TEXT NOT NULL,
     system_prompt TEXT DEFAULT '',
@@ -81,6 +153,7 @@ CREATE INDEX IF NOT EXISTS idx_kb_files_kb ON kb_files(kb_id);
 
 CREATE TABLE IF NOT EXISTS workspaces (
     id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL DEFAULT 'default',
     name TEXT NOT NULL,
     description TEXT DEFAULT '',
     topics TEXT DEFAULT '[]',
@@ -107,6 +180,7 @@ CREATE TABLE IF NOT EXISTS conversation_files (
 
 CREATE TABLE IF NOT EXISTS council_configs (
     id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL DEFAULT 'default',
     name TEXT NOT NULL DEFAULT 'My Council',
     host_model TEXT NOT NULL DEFAULT '',
     host_system_prompt TEXT DEFAULT '',
@@ -126,6 +200,7 @@ CREATE TABLE IF NOT EXISTS council_members (
 
 CREATE TABLE IF NOT EXISTS memories (
     id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL DEFAULT 'default',
     workspace_id TEXT,
     content TEXT NOT NULL,
     type TEXT DEFAULT 'semantic',
@@ -187,6 +262,7 @@ CREATE INDEX IF NOT EXISTS idx_health_service_time ON service_health_log(service
 
 CREATE TABLE IF NOT EXISTS token_usage (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL DEFAULT 'default',
     conversation_id TEXT,
     model TEXT NOT NULL,
     persona_name TEXT DEFAULT '',
@@ -201,6 +277,7 @@ CREATE INDEX IF NOT EXISTS idx_token_usage_date ON token_usage(created_at);
 
 CREATE TABLE IF NOT EXISTS coding_projects (
     id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL DEFAULT 'default',
     name TEXT NOT NULL,
     description TEXT DEFAULT '',
     language TEXT DEFAULT '',
@@ -237,6 +314,7 @@ CREATE INDEX IF NOT EXISTS idx_runs_parent  ON runs(parent_run_id);
 -- compatibility-focused; these rows back the dedicated report workspace.
 CREATE TABLE IF NOT EXISTS research_reports (
     id              TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL DEFAULT 'default',
     title           TEXT NOT NULL DEFAULT '',
     query           TEXT NOT NULL,
     focus           TEXT DEFAULT '',
@@ -318,10 +396,292 @@ async def get_db() -> aiosqlite.Connection:
     return db
 
 
+def _session_token_hash(token: str) -> str:
+    return hashlib.sha256((token or "").encode("utf-8")).hexdigest()
+
+
+def _clean_user_name(name: str) -> str:
+    return re.sub(r"\s+", " ", str(name or "").strip())[:80] or "User"
+
+
+def _public_user(row, counts: dict | None = None) -> dict:
+    d = dict(row)
+    return {
+        "id": d["id"],
+        "name": d.get("name") or "User",
+        "password_enabled": bool(d.get("password_hash")),
+        "created_at": d.get("created_at"),
+        "updated_at": d.get("updated_at"),
+        "last_login_at": d.get("last_login_at"),
+        **(counts or {}),
+    }
+
+
+async def _ensure_default_user_conn(conn: aiosqlite.Connection) -> None:
+    now = datetime.utcnow().isoformat()
+    await conn.execute(
+        """INSERT OR IGNORE INTO users(id,name,password_hash,created_at,updated_at)
+           VALUES(?,?,?,?,?)""",
+        (DEFAULT_USER_ID, "Main", "", now, now),
+    )
+
+
+async def _ensure_user_column(conn: aiosqlite.Connection, table: str) -> None:
+    try:
+        await conn.execute(f"ALTER TABLE {table} ADD COLUMN user_id TEXT DEFAULT '{DEFAULT_USER_ID}'")
+    except Exception as e:
+        if "duplicate column" not in str(e).lower():
+            print(f"[DB MIGRATION] Warning adding {table}.user_id: {e}")
+    try:
+        await conn.execute(
+            f"UPDATE {table} SET user_id=? WHERE user_id IS NULL OR user_id=''",
+            (DEFAULT_USER_ID,),
+        )
+    except Exception as e:
+        print(f"[DB MIGRATION] Warning backfilling {table}.user_id: {e}")
+
+
+async def list_users() -> list[dict]:
+    db = await get_db()
+    try:
+        await _ensure_default_user_conn(db)
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM users ORDER BY CASE id WHEN 'default' THEN 0 ELSE 1 END, name COLLATE NOCASE")
+        users = []
+        for row in rows:
+            uid = row["id"]
+            counts = {
+                "conversation_count": (await db.execute_fetchall("SELECT COUNT(*) AS n FROM conversations WHERE user_id=?", (uid,)))[0]["n"],
+                "workspace_count": (await db.execute_fetchall("SELECT COUNT(*) AS n FROM workspaces WHERE user_id=?", (uid,)))[0]["n"],
+                "knowledge_base_count": (await db.execute_fetchall("SELECT COUNT(*) AS n FROM knowledge_bases WHERE user_id=?", (uid,)))[0]["n"],
+            }
+            users.append(_public_user(row, counts))
+        return users
+    finally:
+        await db.close()
+
+
+async def get_user(user_id: str | None = None) -> dict | None:
+    uid = _scope_user(user_id)
+    db = await get_db()
+    try:
+        await _ensure_default_user_conn(db)
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM users WHERE id=?", (uid,))
+        return _public_user(rows[0]) if rows else None
+    finally:
+        await db.close()
+
+
+async def get_user_private(user_id: str | None = None) -> dict | None:
+    uid = _scope_user(user_id)
+    db = await get_db()
+    try:
+        await _ensure_default_user_conn(db)
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM users WHERE id=?", (uid,))
+        return dict(rows[0]) if rows else None
+    finally:
+        await db.close()
+
+
+async def create_user(name: str, password: str = "") -> dict:
+    user_id = f"user-{uuid.uuid4().hex[:12]}"
+    clean_name = _clean_user_name(name)
+    now = datetime.utcnow().isoformat()
+    password_hash = _hash_password(password) if password else ""
+    db = await get_db()
+    try:
+        await db.execute(
+            "INSERT INTO users(id,name,password_hash,created_at,updated_at) VALUES(?,?,?,?,?)",
+            (user_id, clean_name, password_hash, now, now),
+        )
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM users WHERE id=?", (user_id,))
+        return _public_user(rows[0])
+    finally:
+        await db.close()
+
+
+async def create_user_session(user_id: str) -> str:
+    token = secrets.token_urlsafe(32)
+    token_hash = _session_token_hash(token)
+    now = datetime.utcnow().isoformat()
+    db = await get_db()
+    try:
+        await db.execute(
+            "INSERT INTO user_sessions(token_hash,user_id,created_at,last_seen_at) VALUES(?,?,?,?)",
+            (token_hash, user_id, now, now),
+        )
+        await db.execute("UPDATE users SET last_login_at=?, updated_at=? WHERE id=?", (now, now, user_id))
+        await db.commit()
+        return token
+    finally:
+        await db.close()
+
+
+async def login_user(user_id: str, password: str = "") -> tuple[dict | None, str | None]:
+    uid = _scope_user(user_id)
+    db = await get_db()
+    try:
+        await _ensure_default_user_conn(db)
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM users WHERE id=?", (uid,))
+        if not rows:
+            return None, None
+        row = dict(rows[0])
+        if row.get("password_hash") and not _verify_password(password or "", row["password_hash"]):
+            return None, None
+        now = datetime.utcnow().isoformat()
+        token = None
+        if row.get("password_hash"):
+            token = secrets.token_urlsafe(32)
+            await db.execute(
+                "INSERT INTO user_sessions(token_hash,user_id,created_at,last_seen_at) VALUES(?,?,?,?)",
+                (_session_token_hash(token), uid, now, now),
+            )
+        await db.execute("UPDATE users SET last_login_at=?, updated_at=? WHERE id=?", (now, now, uid))
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM users WHERE id=?", (uid,))
+        return _public_user(rows[0]), token
+    finally:
+        await db.close()
+
+
+async def validate_user_session(user_id: str, token: str | None) -> bool:
+    uid = _scope_user(user_id)
+    user = await get_user_private(uid)
+    if not user:
+        return False
+    if not user.get("password_hash"):
+        return True
+    if not token:
+        return False
+    token_hash = _session_token_hash(token)
+    db = await get_db()
+    try:
+        rows = await db.execute_fetchall(
+            "SELECT token_hash FROM user_sessions WHERE token_hash=? AND user_id=?",
+            (token_hash, uid),
+        )
+        if not rows:
+            return False
+        await db.execute(
+            "UPDATE user_sessions SET last_seen_at=? WHERE token_hash=?",
+            (datetime.utcnow().isoformat(), token_hash),
+        )
+        await db.commit()
+        return True
+    finally:
+        await db.close()
+
+
+async def logout_user_session(user_id: str, token: str | None = None) -> None:
+    uid = _scope_user(user_id)
+    db = await get_db()
+    try:
+        if token:
+            await db.execute(
+                "DELETE FROM user_sessions WHERE user_id=? AND token_hash=?",
+                (uid, _session_token_hash(token)),
+            )
+        else:
+            await db.execute("DELETE FROM user_sessions WHERE user_id=?", (uid,))
+        await db.commit()
+    finally:
+        await db.close()
+
+
+async def update_user(user_id: str, *, name: str | None = None,
+                      password: str | None = None, clear_password: bool = False) -> tuple[dict | None, str | None]:
+    uid = _scope_user(user_id)
+    fields = {}
+    if name is not None:
+        fields["name"] = _clean_user_name(name)
+    if clear_password:
+        fields["password_hash"] = ""
+    elif password is not None:
+        fields["password_hash"] = _hash_password(password) if password else ""
+    if not fields:
+        return await get_user(uid), None
+    fields["updated_at"] = datetime.utcnow().isoformat()
+    sets = ",".join(f"{k}=?" for k in fields)
+    db = await get_db()
+    try:
+        await db.execute(f"UPDATE users SET {sets} WHERE id=?", (*fields.values(), uid))
+        if "password_hash" in fields:
+            await db.execute("DELETE FROM user_sessions WHERE user_id=?", (uid,))
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM users WHERE id=?", (uid,))
+        if not rows:
+            return None, None
+    finally:
+        await db.close()
+    return await get_user(uid), None
+
+
+async def delete_user(user_id: str) -> bool:
+    uid = _scope_user(user_id)
+    if uid == DEFAULT_USER_ID:
+        return False
+    db = await get_db()
+    try:
+        rows = await db.execute_fetchall("SELECT id FROM users WHERE id=?", (uid,))
+        if not rows:
+            return False
+        await db.execute("DELETE FROM conversation_files WHERE conversation_id IN (SELECT id FROM conversations WHERE user_id=?)", (uid,))
+        await db.execute("DELETE FROM workspace_conversations WHERE conversation_id IN (SELECT id FROM conversations WHERE user_id=?)", (uid,))
+        await db.execute("DELETE FROM workspace_conversations WHERE workspace_id IN (SELECT id FROM workspaces WHERE user_id=?)", (uid,))
+        await db.execute("DELETE FROM workspace_research_reports WHERE workspace_id IN (SELECT id FROM workspaces WHERE user_id=?)", (uid,))
+        await db.execute("DELETE FROM workspace_research_reports WHERE report_id IN (SELECT id FROM research_reports WHERE user_id=?)", (uid,))
+        await db.execute("DELETE FROM research_sources WHERE report_id IN (SELECT id FROM research_reports WHERE user_id=?)", (uid,))
+        for table in (
+            "messages",
+            "runs",
+            "coder_workflows",
+        ):
+            await db.execute(
+                f"DELETE FROM {table} WHERE conversation_id IN (SELECT id FROM conversations WHERE user_id=?)",
+                (uid,),
+            )
+        for table in (
+            "conversations", "knowledge_bases", "tools", "model_configs",
+            "workspaces", "council_configs", "memories", "research_reports",
+            "token_usage", "coding_projects",
+        ):
+            await db.execute(f"DELETE FROM {table} WHERE user_id=?", (uid,))
+        await db.execute("DELETE FROM user_profile WHERE id=?", (uid,))
+        await db.execute("DELETE FROM user_sessions WHERE user_id=?", (uid,))
+        await db.execute("DELETE FROM users WHERE id=?", (uid,))
+        await db.commit()
+        return True
+    finally:
+        await db.close()
+
+
 async def init_db():
     db = await get_db()
     try:
         await db.executescript(DB_SCHEMA)
+        await _ensure_default_user_conn(db)
+        for table in (
+            "conversations", "knowledge_bases", "tools", "model_configs",
+            "workspaces", "council_configs", "memories", "token_usage",
+            "coding_projects", "research_reports",
+        ):
+            await _ensure_user_column(db, table)
+        await db.executescript("""
+            CREATE INDEX IF NOT EXISTS idx_conversations_user ON conversations(user_id, updated_at);
+            CREATE INDEX IF NOT EXISTS idx_knowledge_bases_user ON knowledge_bases(user_id, updated_at);
+            CREATE INDEX IF NOT EXISTS idx_tools_user ON tools(user_id, updated_at);
+            CREATE INDEX IF NOT EXISTS idx_model_configs_user ON model_configs(user_id, updated_at);
+            CREATE INDEX IF NOT EXISTS idx_workspaces_user ON workspaces(user_id, updated_at);
+            CREATE INDEX IF NOT EXISTS idx_council_configs_user ON council_configs(user_id, updated_at);
+            CREATE INDEX IF NOT EXISTS idx_memories_user ON memories(user_id, updated_at);
+            CREATE INDEX IF NOT EXISTS idx_token_usage_user ON token_usage(user_id, created_at);
+            CREATE INDEX IF NOT EXISTS idx_coding_projects_user ON coding_projects(user_id, updated_at);
+            CREATE INDEX IF NOT EXISTS idx_research_reports_user ON research_reports(user_id, updated_at);
+        """)
         # HyprChat automation now lives in external n8n; remove legacy internal
         # tables on startup so old installs do not keep stale definitions/runs.
         for table in ("workflow_schedules", "workflow_runs", "workflows"):
@@ -441,8 +801,8 @@ async def init_db():
         # Research workspace and the Agent Research tool. Remove only the fixed
         # preset row; user-created research agents use their own IDs.
         try:
-            await db.execute("DELETE FROM model_configs WHERE id='mc-preset-deepresearch'")
-            await db.execute("DELETE FROM model_configs WHERE name='💻 Coder Bot'")
+            await db.execute("DELETE FROM model_configs WHERE id='mc-preset-deepresearch' AND user_id=?", (DEFAULT_USER_ID,))
+            await db.execute("DELETE FROM model_configs WHERE name='💻 Coder Bot' AND user_id=?", (DEFAULT_USER_ID,))
         except Exception as e:
             print(f"[DB SEED] Legacy agent cleanup failed: {e}")
         await db.commit()
@@ -461,12 +821,14 @@ async def create_conversation(
     model_config_id: str = None,
     use_memories: str = "0",
 ):
+    user_id = _scope_user()
     db = await get_db()
     try:
         await db.execute(
-            "INSERT INTO conversations (id, title, model, system_prompt, model_config_id, use_memories) VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO conversations (id, user_id, title, model, system_prompt, model_config_id, use_memories) VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
                 id,
+                user_id,
                 title,
                 model,
                 system_prompt,
@@ -480,11 +842,12 @@ async def create_conversation(
 
 
 async def get_conversations(limit: int = 50, offset: int = 0):
+    user_id = _scope_user()
     db = await get_db()
     try:
         cursor = await db.execute(
-            "SELECT * FROM conversations ORDER BY CAST(COALESCE(pinned,'0') AS INTEGER) DESC, updated_at DESC LIMIT ? OFFSET ?",
-            (limit, offset)
+            "SELECT * FROM conversations WHERE user_id=? ORDER BY CAST(COALESCE(pinned,'0') AS INTEGER) DESC, updated_at DESC LIMIT ? OFFSET ?",
+            (user_id, limit, offset)
         )
         rows = await cursor.fetchall()
         convs = []
@@ -501,9 +864,10 @@ async def get_conversations(limit: int = 50, offset: int = 0):
 
 
 async def get_conversation(id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
-        cursor = await db.execute("SELECT * FROM conversations WHERE id = ?", (id,))
+        cursor = await db.execute("SELECT * FROM conversations WHERE id = ? AND user_id = ?", (id, user_id))
         row = await cursor.fetchone()
         if not row:
             return None
@@ -536,9 +900,10 @@ async def get_conversation(id: str):
 async def get_conversation_use_memories(id: str) -> bool:
     if not id:
         return False
+    user_id = _scope_user()
     db = await get_db()
     try:
-        rows = await db.execute_fetchall("SELECT use_memories FROM conversations WHERE id=?", (id,))
+        rows = await db.execute_fetchall("SELECT use_memories FROM conversations WHERE id=? AND user_id=?", (id, user_id))
         if not rows:
             return False
         return str(rows[0]["use_memories"] or "0").lower() in {"1", "true", "yes", "on"}
@@ -579,6 +944,7 @@ def _scrub_surrogates(v):
 async def update_conversation(id: str, **kwargs):
     if not kwargs:
         return
+    user_id = _scope_user()
     db = await get_db()
     try:
         # Serialize list/dict fields
@@ -587,16 +953,20 @@ async def update_conversation(id: str, **kwargs):
         if "use_memories" in kwargs:
             kwargs["use_memories"] = "1" if str(kwargs["use_memories"]).lower() in {"1", "true", "yes", "on"} else "0"
         sets = ", ".join(f"{k} = ?" for k in kwargs)
-        vals = [_scrub_surrogates(v) for v in kwargs.values()] + [id]
-        await db.execute(f"UPDATE conversations SET {sets}, updated_at = CURRENT_TIMESTAMP WHERE id = ?", vals)
+        vals = [_scrub_surrogates(v) for v in kwargs.values()] + [id, user_id]
+        await db.execute(f"UPDATE conversations SET {sets}, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND user_id = ?", vals)
         await db.commit()
     finally:
         await db.close()
 
 
 async def delete_conversation(id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
+        rows = await db.execute_fetchall("SELECT id FROM conversations WHERE id=? AND user_id=?", (id, user_id))
+        if not rows:
+            return
         # Explicitly delete related rows (don't rely solely on CASCADE)
         await db.execute("DELETE FROM messages WHERE conversation_id = ?", (id,))
         await db.execute("DELETE FROM conversation_files WHERE conversation_id = ?", (id,))
@@ -610,8 +980,12 @@ async def delete_conversation(id: str):
 async def add_message(conversation_id: str, role: str, content: str, metadata: dict = None) -> int:
     """Insert a new message; return its auto-generated id so callers can update it later
     (e.g. chat agent persisting the assistant message progressively as rounds complete)."""
+    user_id = _scope_user()
     db = await get_db()
     try:
+        rows = await db.execute_fetchall("SELECT id FROM conversations WHERE id=? AND user_id=?", (conversation_id, user_id))
+        if not rows:
+            return 0
         cur = await db.execute(
             "INSERT INTO messages (conversation_id, role, content, metadata) VALUES (?, ?, ?, ?)",
             (conversation_id, role, content, json.dumps(metadata or {}))
@@ -641,19 +1015,28 @@ async def update_message(message_id: int, *, content: str = None, metadata: dict
         vals.append(json.dumps(metadata))
     if not sets:
         return
-    vals.append(message_id)
+    user_id = _scope_user()
+    vals.extend([message_id, user_id])
     db = await get_db()
     try:
-        await db.execute(f"UPDATE messages SET {', '.join(sets)} WHERE id=?", tuple(vals))
+        await db.execute(
+            f"""UPDATE messages SET {', '.join(sets)}
+                WHERE id=? AND conversation_id IN (SELECT id FROM conversations WHERE user_id=?)""",
+            tuple(vals),
+        )
         await db.commit()
     finally:
         await db.close()
 
 
 async def delete_message(message_id: int) -> bool:
+    user_id = _scope_user()
     db = await get_db()
     try:
-        cur = await db.execute("DELETE FROM messages WHERE id = ?", (message_id,))
+        cur = await db.execute(
+            "DELETE FROM messages WHERE id = ? AND conversation_id IN (SELECT id FROM conversations WHERE user_id=?)",
+            (message_id, user_id),
+        )
         await db.commit()
         return cur.rowcount > 0
     finally:
@@ -664,11 +1047,12 @@ async def delete_message(message_id: int) -> bool:
 # KNOWLEDGE BASE CRUD
 # ============================================================
 async def create_kb(id: str, name: str, description: str = ""):
+    user_id = _scope_user()
     db = await get_db()
     try:
         await db.execute(
-            "INSERT INTO knowledge_bases (id, name, description) VALUES (?, ?, ?)",
-            (id, name, description)
+            "INSERT INTO knowledge_bases (id, user_id, name, description) VALUES (?, ?, ?, ?)",
+            (id, user_id, name, description)
         )
         await db.commit()
     finally:
@@ -676,9 +1060,10 @@ async def create_kb(id: str, name: str, description: str = ""):
 
 
 async def get_kbs():
+    user_id = _scope_user()
     db = await get_db()
     try:
-        cursor = await db.execute("SELECT * FROM knowledge_bases ORDER BY updated_at DESC")
+        cursor = await db.execute("SELECT * FROM knowledge_bases WHERE user_id=? ORDER BY updated_at DESC", (user_id,))
         kbs = [dict(r) for r in await cursor.fetchall()]
         for kb in kbs:
             cursor = await db.execute("SELECT * FROM kb_files WHERE kb_id = ?", (kb["id"],))
@@ -689,8 +1074,12 @@ async def get_kbs():
 
 
 async def add_kb_file(kb_id: str, filename: str, filepath: str, file_size: int, file_type: str) -> int:
+    user_id = _scope_user()
     db = await get_db()
     try:
+        rows = await db.execute_fetchall("SELECT id FROM knowledge_bases WHERE id=? AND user_id=?", (kb_id, user_id))
+        if not rows:
+            return 0
         cursor = await db.execute(
             "INSERT INTO kb_files (kb_id, filename, filepath, file_size, file_type) VALUES (?, ?, ?, ?, ?)",
             (kb_id, filename, filepath, file_size, file_type)
@@ -704,32 +1093,43 @@ async def add_kb_file(kb_id: str, filename: str, filepath: str, file_size: int, 
 
 
 async def update_kb(id: str, **kwargs):
+    user_id = _scope_user()
     db = await get_db()
     try:
         sets = ", ".join(f"{k} = ?" for k in kwargs)
-        vals = list(kwargs.values()) + [id]
-        await db.execute(f"UPDATE knowledge_bases SET {sets}, updated_at = CURRENT_TIMESTAMP WHERE id = ?", vals)
+        vals = list(kwargs.values()) + [id, user_id]
+        await db.execute(f"UPDATE knowledge_bases SET {sets}, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND user_id = ?", vals)
         await db.commit()
     finally:
         await db.close()
 
 
 async def delete_kb(id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
-        await db.execute("DELETE FROM knowledge_bases WHERE id = ?", (id,))
+        await db.execute("DELETE FROM knowledge_bases WHERE id = ? AND user_id = ?", (id, user_id))
         await db.commit()
     finally:
         await db.close()
 
 
 async def delete_kb_file(file_id: int):
+    user_id = _scope_user()
     db = await get_db()
     try:
-        cursor = await db.execute("SELECT filepath FROM kb_files WHERE id = ?", (file_id,))
+        cursor = await db.execute(
+            """SELECT f.filepath FROM kb_files f
+               JOIN knowledge_bases kb ON kb.id=f.kb_id
+               WHERE f.id=? AND kb.user_id=?""",
+            (file_id, user_id),
+        )
         row = await cursor.fetchone()
         # Delete from DB first — if disk removal fails, at least DB is consistent
-        await db.execute("DELETE FROM kb_files WHERE id = ?", (file_id,))
+        await db.execute(
+            "DELETE FROM kb_files WHERE id = ? AND kb_id IN (SELECT id FROM knowledge_bases WHERE user_id=?)",
+            (file_id, user_id),
+        )
         await db.commit()
         if row and os.path.exists(row["filepath"]):
             try:
@@ -744,11 +1144,12 @@ async def delete_kb_file(file_id: int):
 # TOOL CRUD
 # ============================================================
 async def create_tool(id: str, name: str, description: str, filename: str, code: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
         await db.execute(
-            "INSERT INTO tools (id, name, description, filename, code) VALUES (?, ?, ?, ?, ?)",
-            (id, name, description, filename, code)
+            "INSERT INTO tools (id, user_id, name, description, filename, code) VALUES (?, ?, ?, ?, ?, ?)",
+            (id, user_id, name, description, filename, code)
         )
         await db.commit()
     finally:
@@ -756,29 +1157,32 @@ async def create_tool(id: str, name: str, description: str, filename: str, code:
 
 
 async def get_tools():
+    user_id = _scope_user()
     db = await get_db()
     try:
-        cursor = await db.execute("SELECT * FROM tools ORDER BY updated_at DESC")
+        cursor = await db.execute("SELECT * FROM tools WHERE user_id=? ORDER BY updated_at DESC", (user_id,))
         return [dict(r) for r in await cursor.fetchall()]
     finally:
         await db.close()
 
 
 async def update_tool(id: str, **kwargs):
+    user_id = _scope_user()
     db = await get_db()
     try:
         sets = ", ".join(f"{k} = ?" for k in kwargs)
-        vals = list(kwargs.values()) + [id]
-        await db.execute(f"UPDATE tools SET {sets}, updated_at = CURRENT_TIMESTAMP WHERE id = ?", vals)
+        vals = list(kwargs.values()) + [id, user_id]
+        await db.execute(f"UPDATE tools SET {sets}, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND user_id = ?", vals)
         await db.commit()
     finally:
         await db.close()
 
 
 async def delete_tool(id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
-        await db.execute("DELETE FROM tools WHERE id = ?", (id,))
+        await db.execute("DELETE FROM tools WHERE id = ? AND user_id = ?", (id, user_id))
         await db.commit()
     finally:
         await db.close()
@@ -789,11 +1193,12 @@ async def delete_tool(id: str):
 # ============================================================
 async def create_model_config(id: str, name: str, base_model: str, system_prompt: str = "",
                                tool_ids: list = None, kb_ids: list = None, parameters: dict = None):
+    user_id = _scope_user()
     db = await get_db()
     try:
         await db.execute(
-            "INSERT INTO model_configs (id, name, base_model, system_prompt, tool_ids, kb_ids, parameters) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (id, name, base_model, system_prompt, json.dumps(tool_ids or []), json.dumps(kb_ids or []), json.dumps(parameters or {}))
+            "INSERT INTO model_configs (id, user_id, name, base_model, system_prompt, tool_ids, kb_ids, parameters) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (id, user_id, name, base_model, system_prompt, json.dumps(tool_ids or []), json.dumps(kb_ids or []), json.dumps(parameters or {}))
         )
         await db.commit()
     finally:
@@ -801,9 +1206,10 @@ async def create_model_config(id: str, name: str, base_model: str, system_prompt
 
 
 async def get_model_configs():
+    user_id = _scope_user()
     db = await get_db()
     try:
-        cursor = await db.execute("SELECT * FROM model_configs ORDER BY updated_at DESC")
+        cursor = await db.execute("SELECT * FROM model_configs WHERE user_id=? ORDER BY updated_at DESC", (user_id,))
         configs = [dict(r) for r in await cursor.fetchall()]
         for c in configs:
             c["tool_ids"] = json.loads(c["tool_ids"])
@@ -816,9 +1222,10 @@ async def get_model_configs():
 
 async def get_model_config(mc_id: str) -> dict | None:
     """Return a single model config by id, or None if not found."""
+    user_id = _scope_user()
     db = await get_db()
     try:
-        cursor = await db.execute("SELECT * FROM model_configs WHERE id = ?", (mc_id,))
+        cursor = await db.execute("SELECT * FROM model_configs WHERE id = ? AND user_id = ?", (mc_id, user_id))
         row = await cursor.fetchone()
         if not row:
             return None
@@ -832,23 +1239,25 @@ async def get_model_config(mc_id: str) -> dict | None:
 
 
 async def update_model_config(id: str, **kwargs):
+    user_id = _scope_user()
     db = await get_db()
     try:
         for k in ("tool_ids", "kb_ids", "parameters"):
             if k in kwargs:
                 kwargs[k] = json.dumps(kwargs[k])
         sets = ", ".join(f"{k} = ?" for k in kwargs)
-        vals = list(kwargs.values()) + [id]
-        await db.execute(f"UPDATE model_configs SET {sets}, updated_at = CURRENT_TIMESTAMP WHERE id = ?", vals)
+        vals = list(kwargs.values()) + [id, user_id]
+        await db.execute(f"UPDATE model_configs SET {sets}, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND user_id = ?", vals)
         await db.commit()
     finally:
         await db.close()
 
 
 async def delete_model_config(id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
-        await db.execute("DELETE FROM model_configs WHERE id = ?", (id,))
+        await db.execute("DELETE FROM model_configs WHERE id = ? AND user_id = ?", (id, user_id))
         await db.commit()
     finally:
         await db.close()
@@ -858,12 +1267,13 @@ async def delete_model_config(id: str):
 # WORKSPACE CRUD
 # ============================================================
 async def create_workspace(id: str, name: str, description: str = ""):
+    user_id = _scope_user()
     db = await get_db()
     try:
         now = datetime.utcnow().isoformat()
         await db.execute(
-            "INSERT INTO workspaces(id,name,description,topics,memory_enabled,instructions,created_at,updated_at) VALUES(?,?,?,'[]',0,'',?,?)",
-            (id, name, description, now, now)
+            "INSERT INTO workspaces(id,user_id,name,description,topics,memory_enabled,instructions,created_at,updated_at) VALUES(?,?,?,?, '[]',0,'',?,?)",
+            (id, user_id, name, description, now, now)
         )
         await db.commit()
     finally:
@@ -876,6 +1286,7 @@ async def create_workspace(id: str, name: str, description: str = ""):
 
 
 async def get_workspaces():
+    user_id = _scope_user()
     db = await get_db()
     try:
         rows = await db.execute_fetchall("""
@@ -883,7 +1294,7 @@ async def get_workspaces():
                 (SELECT COUNT(*) FROM workspace_conversations wc WHERE wc.workspace_id=w.id) as conv_count,
                 (SELECT COUNT(*) FROM conversation_files cf JOIN workspace_conversations wc2 ON cf.conversation_id=wc2.conversation_id WHERE wc2.workspace_id=w.id) as file_count,
                 (SELECT COUNT(*) FROM workspace_research_reports wrr WHERE wrr.workspace_id=w.id) as report_count
-            FROM workspaces w ORDER BY w.updated_at DESC""")
+            FROM workspaces w WHERE w.user_id=? ORDER BY w.updated_at DESC""", (user_id,))
         result = []
         for r in rows:
             d = dict(r)
@@ -898,9 +1309,10 @@ async def get_workspaces():
 
 
 async def get_workspace(ws_id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
-        row = await db.execute_fetchall("SELECT * FROM workspaces WHERE id=?", (ws_id,))
+        row = await db.execute_fetchall("SELECT * FROM workspaces WHERE id=? AND user_id=?", (ws_id, user_id))
         if not row:
             return None
         ws = dict(row[0])
@@ -911,16 +1323,16 @@ async def get_workspace(ws_id: str):
         conv_rows = await db.execute_fetchall(
             """SELECT c.id,c.title,c.model,c.updated_at FROM conversations c
                JOIN workspace_conversations wc ON c.id=wc.conversation_id
-               WHERE wc.workspace_id=? ORDER BY wc.added_at DESC""",
-            (ws_id,)
+               WHERE wc.workspace_id=? AND c.user_id=? ORDER BY wc.added_at DESC""",
+            (ws_id, user_id)
         )
         ws["conversations"] = [dict(r) for r in conv_rows]
         file_rows = await db.execute_fetchall(
             """SELECT cf.*,c.title as conversation_title FROM conversation_files cf
                JOIN workspace_conversations wc ON cf.conversation_id=wc.conversation_id
                LEFT JOIN conversations c ON c.id=cf.conversation_id
-               WHERE wc.workspace_id=? ORDER BY cf.created_at DESC""",
-            (ws_id,)
+               WHERE wc.workspace_id=? AND c.user_id=? ORDER BY cf.created_at DESC""",
+            (ws_id, user_id)
         )
         ws["files"] = [dict(r) for r in file_rows]
         report_rows = await db.execute_fetchall(
@@ -929,8 +1341,8 @@ async def get_workspace(ws_id: str):
                       rr.created_at,rr.updated_at,rr.completed_at,wrr.added_at
                FROM research_reports rr
                JOIN workspace_research_reports wrr ON rr.id=wrr.report_id
-               WHERE wrr.workspace_id=? ORDER BY wrr.added_at DESC""",
-            (ws_id,)
+               WHERE wrr.workspace_id=? AND rr.user_id=? ORDER BY wrr.added_at DESC""",
+            (ws_id, user_id)
         )
         reports = []
         for row in report_rows:
@@ -965,26 +1377,37 @@ async def update_workspace(ws_id: str, **kwargs):
         fields["memory_enabled"] = 1 if str(fields["memory_enabled"]).lower() in {"1", "true", "yes", "on"} else 0
     fields["updated_at"] = datetime.utcnow().isoformat()
     set_clause = ",".join(f"{k}=?" for k in fields)
+    user_id = _scope_user()
     db = await get_db()
     try:
-        await db.execute(f"UPDATE workspaces SET {set_clause} WHERE id=?", (*fields.values(), ws_id))
+        await db.execute(f"UPDATE workspaces SET {set_clause} WHERE id=? AND user_id=?", (*fields.values(), ws_id, user_id))
         await db.commit()
     finally:
         await db.close()
 
 
 async def delete_workspace(ws_id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
-        await db.execute("DELETE FROM workspaces WHERE id=?", (ws_id,))
+        await db.execute("DELETE FROM workspaces WHERE id=? AND user_id=?", (ws_id, user_id))
         await db.commit()
     finally:
         await db.close()
 
 
 async def add_conv_to_workspace(ws_id: str, conv_id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
+        rows = await db.execute_fetchall(
+            """SELECT w.id FROM workspaces w
+               JOIN conversations c ON c.id=?
+               WHERE w.id=? AND w.user_id=? AND c.user_id=?""",
+            (conv_id, ws_id, user_id, user_id),
+        )
+        if not rows:
+            return
         now = datetime.utcnow().isoformat()
         await db.execute(
             "INSERT OR IGNORE INTO workspace_conversations VALUES(?,?,?)",
@@ -997,11 +1420,14 @@ async def add_conv_to_workspace(ws_id: str, conv_id: str):
 
 
 async def remove_conv_from_workspace(ws_id: str, conv_id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
         await db.execute(
-            "DELETE FROM workspace_conversations WHERE workspace_id=? AND conversation_id=?",
-            (ws_id, conv_id)
+            """DELETE FROM workspace_conversations
+               WHERE workspace_id IN (SELECT id FROM workspaces WHERE id=? AND user_id=?)
+                 AND conversation_id IN (SELECT id FROM conversations WHERE id=? AND user_id=?)""",
+            (ws_id, user_id, conv_id, user_id)
         )
         await db.commit()
     finally:
@@ -1009,8 +1435,17 @@ async def remove_conv_from_workspace(ws_id: str, conv_id: str):
 
 
 async def add_research_report_to_workspace(ws_id: str, report_id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
+        rows = await db.execute_fetchall(
+            """SELECT w.id FROM workspaces w
+               JOIN research_reports rr ON rr.id=?
+               WHERE w.id=? AND w.user_id=? AND rr.user_id=?""",
+            (report_id, ws_id, user_id, user_id),
+        )
+        if not rows:
+            return
         now = datetime.utcnow().isoformat()
         await db.execute(
             "INSERT OR IGNORE INTO workspace_research_reports(workspace_id,report_id,added_at) VALUES(?,?,?)",
@@ -1023,21 +1458,28 @@ async def add_research_report_to_workspace(ws_id: str, report_id: str):
 
 
 async def remove_research_report_from_workspace(ws_id: str, report_id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
         await db.execute(
-            "DELETE FROM workspace_research_reports WHERE workspace_id=? AND report_id=?",
-            (ws_id, report_id)
+            """DELETE FROM workspace_research_reports
+               WHERE workspace_id IN (SELECT id FROM workspaces WHERE id=? AND user_id=?)
+                 AND report_id IN (SELECT id FROM research_reports WHERE id=? AND user_id=?)""",
+            (ws_id, user_id, report_id, user_id)
         )
-        await db.execute("UPDATE workspaces SET updated_at=? WHERE id=?", (datetime.utcnow().isoformat(), ws_id))
+        await db.execute("UPDATE workspaces SET updated_at=? WHERE id=? AND user_id=?", (datetime.utcnow().isoformat(), ws_id, user_id))
         await db.commit()
     finally:
         await db.close()
 
 
 async def add_conversation_file(id: str, conv_id: str, filename: str, url: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
+        rows = await db.execute_fetchall("SELECT id FROM conversations WHERE id=? AND user_id=?", (conv_id, user_id))
+        if not rows:
+            return
         now = datetime.utcnow().isoformat()
         await db.execute(
             "INSERT OR IGNORE INTO conversation_files(id,conversation_id,filename,url,created_at) VALUES(?,?,?,?,?)",
@@ -1149,12 +1591,13 @@ def _normalize_profile_row(row) -> dict:
 
 
 async def _ensure_user_profile(conn: aiosqlite.Connection) -> None:
+    user_id = _scope_user()
     now = datetime.utcnow().isoformat()
     await conn.execute(
         """INSERT OR IGNORE INTO user_profile
            (id,display_name,legal_name,birthday,age,bio,interests_json,links_json,extra_json,created_at,updated_at)
-           VALUES('default','','','','','','[]','[]','{}',?,?)""",
-        (now, now),
+           VALUES(?,?,?,?,?,?,?,?,?,?,?)""",
+        (user_id, "", "", "", "", "", "[]", "[]", "{}", now, now),
     )
 
 
@@ -1163,7 +1606,7 @@ async def get_user_profile() -> dict:
     try:
         await _ensure_user_profile(db)
         await db.commit()
-        rows = await db.execute_fetchall("SELECT * FROM user_profile WHERE id='default'")
+        rows = await db.execute_fetchall("SELECT * FROM user_profile WHERE id=?", (_scope_user(),))
         return _normalize_profile_row(rows[0])
     finally:
         await db.close()
@@ -1191,18 +1634,19 @@ async def update_user_profile(**kwargs) -> dict:
                     fields[key] = _scrub_surrogates(str(fields[key] or "").strip())
             fields["updated_at"] = datetime.utcnow().isoformat()
             sets = ",".join(f"{k}=?" for k in fields)
-            await db.execute(f"UPDATE user_profile SET {sets} WHERE id='default'", tuple(fields.values()))
+            await db.execute(f"UPDATE user_profile SET {sets} WHERE id=?", (*fields.values(), _scope_user()))
         await db.commit()
-        rows = await db.execute_fetchall("SELECT * FROM user_profile WHERE id='default'")
+        rows = await db.execute_fetchall("SELECT * FROM user_profile WHERE id=?", (_scope_user(),))
         return _normalize_profile_row(rows[0])
     finally:
         await db.close()
 
 
 async def get_workspace_basic(ws_id: str) -> dict | None:
+    user_id = _scope_user()
     db = await get_db()
     try:
-        rows = await db.execute_fetchall("SELECT * FROM workspaces WHERE id=?", (ws_id,))
+        rows = await db.execute_fetchall("SELECT * FROM workspaces WHERE id=? AND user_id=?", (ws_id, user_id))
         return dict(rows[0]) if rows else None
     finally:
         await db.close()
@@ -1216,14 +1660,16 @@ async def get_workspace_for_conversation(conv_id: str) -> dict | None:
     """
     if not conv_id:
         return None
+    user_id = _scope_user()
     db = await get_db()
     try:
         rows = await db.execute_fetchall(
             """SELECT w.* FROM workspaces w
                JOIN workspace_conversations wc ON wc.workspace_id=w.id
-               WHERE wc.conversation_id=?
+               JOIN conversations c ON c.id=wc.conversation_id
+               WHERE wc.conversation_id=? AND w.user_id=? AND c.user_id=?
                ORDER BY wc.added_at DESC""",
-            (conv_id,),
+            (conv_id, user_id, user_id),
         )
         return dict(rows[0]) if len(rows) == 1 else None
     finally:
@@ -1254,6 +1700,8 @@ def _normalize_block_row(row) -> dict:
 
 
 async def get_workspace_memory_blocks(ws_id: str) -> list[dict]:
+    if not await get_workspace_basic(ws_id):
+        return []
     db = await get_db()
     try:
         await _ensure_workspace_memory_blocks(db, ws_id)
@@ -1268,6 +1716,8 @@ async def get_workspace_memory_blocks(ws_id: str) -> list[dict]:
 
 
 async def update_workspace_memory_blocks(ws_id: str, blocks: list[dict]) -> list[dict]:
+    if not await get_workspace_basic(ws_id):
+        return []
     db = await get_db()
     try:
         await _ensure_workspace_memory_blocks(db, ws_id)
@@ -1325,8 +1775,9 @@ async def list_workspace_memories(
     memory_type: str | None = None,
     include_archived: bool = True,
 ) -> list[dict]:
-    clauses = ["workspace_id=?"]
-    vals = [ws_id]
+    user_id = _scope_user()
+    clauses = ["workspace_id=?", "user_id=?"]
+    vals = [ws_id, user_id]
     if status and status != "all":
         clauses.append("status=?")
         vals.append(_normalize_memory_status(status))
@@ -1370,6 +1821,9 @@ async def create_workspace_memory(
     entities: list | None = None,
     metadata: dict | None = None,
 ) -> dict:
+    user_id = _scope_user()
+    if not await get_workspace_basic(ws_id):
+        raise ValueError("workspace not found")
     mem_id = f"mem-{uuid.uuid4().hex[:12]}"
     now = datetime.utcnow().isoformat()
     clean_content = _scrub_surrogates((content or "").strip())
@@ -1382,21 +1836,21 @@ async def create_workspace_memory(
     try:
         await db.execute(
             """INSERT INTO memories
-               (id,workspace_id,content,type,status,category,importance,pinned,
+               (id,user_id,workspace_id,content,type,status,category,importance,pinned,
                 source_conv_id,source_conversation_id,source_message_id,confidence,
                 valid_from,valid_until,supersedes_id,entities_json,metadata_json,updated_at,created_at)
-               VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+               VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
             (
-                mem_id, ws_id, clean_content, mtype, mstatus, category or "General",
+                mem_id, user_id, ws_id, clean_content, mtype, mstatus, category or "General",
                 importance, 1 if pinned else 0, source_conv_id or source_conversation_id,
                 source_conversation_id or source_conv_id, source_message_id,
                 float(confidence or 0), valid_from, valid_until, supersedes_id,
                 json.dumps(entities or []), json.dumps(metadata or {}), now, now,
             ),
         )
-        await db.execute("UPDATE workspaces SET updated_at=? WHERE id=?", (now, ws_id))
+        await db.execute("UPDATE workspaces SET updated_at=? WHERE id=? AND user_id=?", (now, ws_id, user_id))
         await db.commit()
-        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=?", (mem_id,))
+        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=? AND user_id=?", (mem_id, user_id))
         return _normalize_memory_row(rows[0])
     finally:
         await db.close()
@@ -1428,13 +1882,14 @@ async def update_workspace_memory(memory_id: str, ws_id: str, **kwargs) -> dict 
         fields["metadata_json"] = json.dumps(fields.pop("metadata") or {})
     fields["updated_at"] = datetime.utcnow().isoformat()
     sets = ",".join(f"{k}=?" for k in fields)
-    vals = list(fields.values()) + [memory_id, ws_id]
+    user_id = _scope_user()
+    vals = list(fields.values()) + [memory_id, ws_id, user_id]
     db = await get_db()
     try:
-        await db.execute(f"UPDATE memories SET {sets} WHERE id=? AND workspace_id=?", vals)
-        await db.execute("UPDATE workspaces SET updated_at=? WHERE id=?", (fields["updated_at"], ws_id))
+        await db.execute(f"UPDATE memories SET {sets} WHERE id=? AND workspace_id=? AND user_id=?", vals)
+        await db.execute("UPDATE workspaces SET updated_at=? WHERE id=? AND user_id=?", (fields["updated_at"], ws_id, user_id))
         await db.commit()
-        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=? AND workspace_id=?", (memory_id, ws_id))
+        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=? AND workspace_id=? AND user_id=?", (memory_id, ws_id, user_id))
         return _normalize_memory_row(rows[0]) if rows else None
     finally:
         await db.close()
@@ -1442,12 +1897,13 @@ async def update_workspace_memory(memory_id: str, ws_id: str, **kwargs) -> dict 
 
 async def accept_workspace_memory(memory_id: str, ws_id: str, supersedes_id: str | None = None) -> dict | None:
     now = datetime.utcnow().isoformat()
+    user_id = _scope_user()
     db = await get_db()
     try:
         if supersedes_id:
             await db.execute(
-                "UPDATE memories SET valid_until=?, updated_at=? WHERE id=? AND workspace_id=?",
-                (now, now, supersedes_id, ws_id),
+                "UPDATE memories SET valid_until=?, updated_at=? WHERE id=? AND workspace_id=? AND user_id=?",
+                (now, now, supersedes_id, ws_id, user_id),
             )
         await db.execute(
             """UPDATE memories
@@ -1455,12 +1911,12 @@ async def accept_workspace_memory(memory_id: str, ws_id: str, supersedes_id: str
                    supersedes_id=COALESCE(?, supersedes_id),
                    valid_from=COALESCE(valid_from, ?),
                    updated_at=?
-               WHERE id=? AND workspace_id=?""",
-            (supersedes_id, now, now, memory_id, ws_id),
+               WHERE id=? AND workspace_id=? AND user_id=?""",
+            (supersedes_id, now, now, memory_id, ws_id, user_id),
         )
-        await db.execute("UPDATE workspaces SET updated_at=? WHERE id=?", (now, ws_id))
+        await db.execute("UPDATE workspaces SET updated_at=? WHERE id=? AND user_id=?", (now, ws_id, user_id))
         await db.commit()
-        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=? AND workspace_id=?", (memory_id, ws_id))
+        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=? AND workspace_id=? AND user_id=?", (memory_id, ws_id, user_id))
         return _normalize_memory_row(rows[0]) if rows else None
     finally:
         await db.close()
@@ -1471,9 +1927,10 @@ async def reject_workspace_memory(memory_id: str, ws_id: str) -> dict | None:
 
 
 async def delete_workspace_memory(memory_id: str, ws_id: str) -> bool:
+    user_id = _scope_user()
     db = await get_db()
     try:
-        cur = await db.execute("DELETE FROM memories WHERE id=? AND workspace_id=?", (memory_id, ws_id))
+        cur = await db.execute("DELETE FROM memories WHERE id=? AND workspace_id=? AND user_id=?", (memory_id, ws_id, user_id))
         await db.commit()
         return cur.rowcount > 0
     finally:
@@ -1499,8 +1956,9 @@ async def list_global_memories(
     memory_type: str | None = None,
     include_archived: bool = True,
 ) -> list[dict]:
-    clauses = ["workspace_id IS NULL"]
-    vals = []
+    user_id = _scope_user()
+    clauses = ["workspace_id IS NULL", "user_id=?"]
+    vals = [user_id]
     if status and status != "all":
         clauses.append("status=?")
         vals.append(_normalize_memory_status(status))
@@ -1543,6 +2001,7 @@ async def create_global_memory(
     entities: list | None = None,
     metadata: dict | None = None,
 ) -> dict:
+    user_id = _scope_user()
     mem_id = f"mem-{uuid.uuid4().hex[:12]}"
     now = datetime.utcnow().isoformat()
     clean_content = _scrub_surrogates((content or "").strip())
@@ -1555,12 +2014,12 @@ async def create_global_memory(
     try:
         await db.execute(
             """INSERT INTO memories
-               (id,workspace_id,content,type,status,category,importance,pinned,
+               (id,user_id,workspace_id,content,type,status,category,importance,pinned,
                 source_conv_id,source_conversation_id,source_message_id,confidence,
                 valid_from,valid_until,supersedes_id,entities_json,metadata_json,updated_at,created_at)
-               VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+               VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
             (
-                mem_id, None, clean_content, mtype, mstatus, category or "General",
+                mem_id, user_id, None, clean_content, mtype, mstatus, category or "General",
                 importance, 1 if pinned else 0, source_conv_id or source_conversation_id,
                 source_conversation_id or source_conv_id, source_message_id,
                 float(confidence or 0), valid_from, valid_until, supersedes_id,
@@ -1568,7 +2027,7 @@ async def create_global_memory(
             ),
         )
         await db.commit()
-        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=?", (mem_id,))
+        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=? AND user_id=?", (mem_id, user_id))
         return _normalize_memory_row(rows[0])
     finally:
         await db.close()
@@ -1600,12 +2059,13 @@ async def update_global_memory(memory_id: str, **kwargs) -> dict | None:
         fields["metadata_json"] = json.dumps(fields.pop("metadata") or {})
     fields["updated_at"] = datetime.utcnow().isoformat()
     sets = ",".join(f"{k}=?" for k in fields)
-    vals = list(fields.values()) + [memory_id]
+    user_id = _scope_user()
+    vals = list(fields.values()) + [memory_id, user_id]
     db = await get_db()
     try:
-        await db.execute(f"UPDATE memories SET {sets} WHERE id=? AND workspace_id IS NULL", vals)
+        await db.execute(f"UPDATE memories SET {sets} WHERE id=? AND workspace_id IS NULL AND user_id=?", vals)
         await db.commit()
-        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=? AND workspace_id IS NULL", (memory_id,))
+        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=? AND workspace_id IS NULL AND user_id=?", (memory_id, user_id))
         return _normalize_memory_row(rows[0]) if rows else None
     finally:
         await db.close()
@@ -1613,12 +2073,13 @@ async def update_global_memory(memory_id: str, **kwargs) -> dict | None:
 
 async def accept_global_memory(memory_id: str, supersedes_id: str | None = None) -> dict | None:
     now = datetime.utcnow().isoformat()
+    user_id = _scope_user()
     db = await get_db()
     try:
         if supersedes_id:
             await db.execute(
-                "UPDATE memories SET valid_until=?, updated_at=? WHERE id=? AND workspace_id IS NULL",
-                (now, now, supersedes_id),
+                "UPDATE memories SET valid_until=?, updated_at=? WHERE id=? AND workspace_id IS NULL AND user_id=?",
+                (now, now, supersedes_id, user_id),
             )
         await db.execute(
             """UPDATE memories
@@ -1626,11 +2087,11 @@ async def accept_global_memory(memory_id: str, supersedes_id: str | None = None)
                    supersedes_id=COALESCE(?, supersedes_id),
                    valid_from=COALESCE(valid_from, ?),
                    updated_at=?
-               WHERE id=? AND workspace_id IS NULL""",
-            (supersedes_id, now, now, memory_id),
+               WHERE id=? AND workspace_id IS NULL AND user_id=?""",
+            (supersedes_id, now, now, memory_id, user_id),
         )
         await db.commit()
-        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=? AND workspace_id IS NULL", (memory_id,))
+        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=? AND workspace_id IS NULL AND user_id=?", (memory_id, user_id))
         return _normalize_memory_row(rows[0]) if rows else None
     finally:
         await db.close()
@@ -1641,9 +2102,10 @@ async def reject_global_memory(memory_id: str) -> dict | None:
 
 
 async def delete_global_memory(memory_id: str) -> bool:
+    user_id = _scope_user()
     db = await get_db()
     try:
-        cur = await db.execute("DELETE FROM memories WHERE id=? AND workspace_id IS NULL", (memory_id,))
+        cur = await db.execute("DELETE FROM memories WHERE id=? AND workspace_id IS NULL AND user_id=?", (memory_id, user_id))
         await db.commit()
         return cur.rowcount > 0
     finally:
@@ -1700,6 +2162,7 @@ def _format_profile_context(profile: dict, remaining: int) -> tuple[list[str], i
 
 async def build_global_memory_context(*, query: str = "", max_chars: int = 4200) -> dict:
     profile = await get_user_profile()
+    user_id = _scope_user()
     remaining = max(1000, int(max_chars or 4200))
     lines, remaining, has_memory_content = _format_profile_context(profile, remaining)
 
@@ -1709,11 +2172,12 @@ async def build_global_memory_context(*, query: str = "", max_chars: int = 4200)
         rows = await db.execute_fetchall(
             f"""SELECT * FROM memories
                 WHERE workspace_id IS NULL
+                  AND user_id=?
                   AND status='accepted'
                   AND {_memory_current_clause(now)}
                 ORDER BY pinned DESC, importance DESC, COALESCE(updated_at, created_at) DESC
                 LIMIT 80""",
-            (now,),
+            (user_id, now),
         )
     finally:
         await db.close()
@@ -1770,6 +2234,7 @@ async def build_workspace_memory_context(
     if not ws or not int(ws.get("memory_enabled") or 0):
         return {"workspace": ws, "context": "", "memory_ids": [], "block_ids": []}
 
+    user_id = _scope_user()
     ws_id = ws["id"]
     remaining = max(1000, int(max_chars or 5200))
     lines = [f"Workspace: {ws.get('name') or ws_id}"]
@@ -1802,11 +2267,12 @@ async def build_workspace_memory_context(
         rows = await db.execute_fetchall(
             f"""SELECT * FROM memories
                 WHERE workspace_id=?
+                  AND user_id=?
                   AND status='accepted'
                   AND {_memory_current_clause(now)}
                 ORDER BY pinned DESC, importance DESC, COALESCE(updated_at, created_at) DESC
                 LIMIT 80""",
-            (ws_id, now),
+            (ws_id, user_id, now),
         )
     finally:
         await db.close()
@@ -1854,12 +2320,13 @@ async def build_workspace_memory_context(
 # COUNCIL CRUD
 # ============================================================
 async def create_council(id: str, name: str, host_model: str, host_system_prompt: str = "", kb_ids: list = None):
+    user_id = _scope_user()
     db = await get_db()
     try:
         now = datetime.utcnow().isoformat()
         await db.execute(
-            "INSERT INTO council_configs(id,name,host_model,host_system_prompt,kb_ids,created_at,updated_at) VALUES(?,?,?,?,?,?,?)",
-            (id, name, host_model, host_system_prompt, json.dumps(kb_ids or []), now, now)
+            "INSERT INTO council_configs(id,user_id,name,host_model,host_system_prompt,kb_ids,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?)",
+            (id, user_id, name, host_model, host_system_prompt, json.dumps(kb_ids or []), now, now)
         )
         await db.commit()
     finally:
@@ -1867,9 +2334,10 @@ async def create_council(id: str, name: str, host_model: str, host_system_prompt
 
 
 async def get_councils():
+    user_id = _scope_user()
     db = await get_db()
     try:
-        rows = await db.execute_fetchall("SELECT * FROM council_configs ORDER BY updated_at DESC")
+        rows = await db.execute_fetchall("SELECT * FROM council_configs WHERE user_id=? ORDER BY updated_at DESC", (user_id,))
         result = []
         for r in rows:
             c = dict(r)
@@ -1888,9 +2356,10 @@ async def get_councils():
 
 
 async def get_council(council_id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
-        rows = await db.execute_fetchall("SELECT * FROM council_configs WHERE id=?", (council_id,))
+        rows = await db.execute_fetchall("SELECT * FROM council_configs WHERE id=? AND user_id=?", (council_id, user_id))
         if not rows:
             return None
         c = dict(rows[0])
@@ -1916,26 +2385,32 @@ async def update_council(council_id: str, **kwargs):
         return
     fields["updated_at"] = datetime.utcnow().isoformat()
     set_clause = ",".join(f"{k}=?" for k in fields)
+    user_id = _scope_user()
     db = await get_db()
     try:
-        await db.execute(f"UPDATE council_configs SET {set_clause} WHERE id=?", (*fields.values(), council_id))
+        await db.execute(f"UPDATE council_configs SET {set_clause} WHERE id=? AND user_id=?", (*fields.values(), council_id, user_id))
         await db.commit()
     finally:
         await db.close()
 
 
 async def delete_council(council_id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
-        await db.execute("DELETE FROM council_configs WHERE id=?", (council_id,))
+        await db.execute("DELETE FROM council_configs WHERE id=? AND user_id=?", (council_id, user_id))
         await db.commit()
     finally:
         await db.close()
 
 
 async def add_council_member(id: str, council_id: str, model: str, system_prompt: str = "", persona_name: str = ""):
+    user_id = _scope_user()
     db = await get_db()
     try:
+        rows = await db.execute_fetchall("SELECT id FROM council_configs WHERE id=? AND user_id=?", (council_id, user_id))
+        if not rows:
+            return
         await db.execute(
             "INSERT INTO council_members(id,council_id,model,system_prompt,persona_name,points) VALUES(?,?,?,?,?,0)",
             (id, council_id, model, system_prompt, persona_name)
@@ -1952,18 +2427,27 @@ async def update_council_member(member_id: str, **kwargs):
     if not fields:
         return
     set_clause = ",".join(f"{k}=?" for k in fields)
+    user_id = _scope_user()
     db = await get_db()
     try:
-        await db.execute(f"UPDATE council_members SET {set_clause} WHERE id=?", (*fields.values(), member_id))
+        await db.execute(
+            f"""UPDATE council_members SET {set_clause}
+                WHERE id=? AND council_id IN (SELECT id FROM council_configs WHERE user_id=?)""",
+            (*fields.values(), member_id, user_id),
+        )
         await db.commit()
     finally:
         await db.close()
 
 
 async def delete_council_member(member_id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
-        await db.execute("DELETE FROM council_members WHERE id=?", (member_id,))
+        await db.execute(
+            "DELETE FROM council_members WHERE id=? AND council_id IN (SELECT id FROM council_configs WHERE user_id=?)",
+            (member_id, user_id),
+        )
         await db.commit()
     finally:
         await db.close()
@@ -1973,14 +2457,15 @@ async def get_kb_files_for_kbs(kb_ids: list) -> list:
     """Load all file records (with KB name) for a list of KB IDs."""
     if not kb_ids:
         return []
+    user_id = _scope_user()
     db = await get_db()
     try:
         placeholders = ",".join("?" * len(kb_ids))
         cursor = await db.execute(
             f"SELECT kb_files.*, knowledge_bases.name AS kb_name FROM kb_files "
             f"JOIN knowledge_bases ON kb_files.kb_id = knowledge_bases.id "
-            f"WHERE kb_files.kb_id IN ({placeholders})",
-            kb_ids
+            f"WHERE knowledge_bases.user_id=? AND kb_files.kb_id IN ({placeholders})",
+            [user_id, *kb_ids]
         )
         return [dict(r) for r in await cursor.fetchall()]
     finally:
@@ -1992,6 +2477,7 @@ async def get_kb_files_for_kbs(kb_ids: list) -> list:
 # ============================================================
 async def search_messages(query: str, limit: int = 20):
     """Full-text search across all messages, returning conversation context."""
+    user_id = _scope_user()
     db = await get_db()
     try:
         cursor = await db.execute("""
@@ -2001,10 +2487,10 @@ async def search_messages(query: str, limit: int = 20):
             FROM messages_fts
             JOIN messages m ON m.id = messages_fts.rowid
             JOIN conversations c ON c.id = m.conversation_id
-            WHERE messages_fts MATCH ?
+            WHERE messages_fts MATCH ? AND c.user_id = ?
             ORDER BY rank
             LIMIT ?
-        """, (query, limit))
+        """, (query, user_id, limit))
         return [dict(r) for r in await cursor.fetchall()]
     except Exception as e:
         print(f"[SEARCH] Error: {e}")
@@ -2018,9 +2504,10 @@ async def search_messages(query: str, limit: int = 20):
 # ============================================================
 async def fork_conversation(original_conv_id: str, fork_msg_id: int, new_conv_id: str):
     """Fork a conversation at a specific message, copying messages up to that point."""
+    user_id = _scope_user()
     db = await get_db()
     try:
-        cursor = await db.execute("SELECT * FROM conversations WHERE id = ?", (original_conv_id,))
+        cursor = await db.execute("SELECT * FROM conversations WHERE id = ? AND user_id = ?", (original_conv_id, user_id))
         original = await cursor.fetchone()
         if not original:
             return None
@@ -2028,10 +2515,10 @@ async def fork_conversation(original_conv_id: str, fork_msg_id: int, new_conv_id
         now = datetime.utcnow().isoformat()
         await db.execute(
             """INSERT INTO conversations
-               (id, title, model, system_prompt, model_config_id, tool_ids,
+               (id, user_id, title, model, system_prompt, model_config_id, tool_ids,
                 persona_name, persona_avatar, forked_from, fork_point_msg_id, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (new_conv_id, f"Fork of {original.get('title', 'Chat')}", original.get("model", ""),
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (new_conv_id, user_id, f"Fork of {original.get('title', 'Chat')}", original.get("model", ""),
              original.get("system_prompt", ""), original.get("model_config_id"),
              original.get("tool_ids", "[]"), original.get("persona_name", ""),
              original.get("persona_avatar", ""), original_conv_id, str(fork_msg_id), now, now)
@@ -2050,11 +2537,12 @@ async def fork_conversation(original_conv_id: str, fork_msg_id: int, new_conv_id
 
 async def get_forks(conv_id: str):
     """Get all conversations forked from this one."""
+    user_id = _scope_user()
     db = await get_db()
     try:
         cursor = await db.execute(
-            "SELECT id, title, fork_point_msg_id, created_at FROM conversations WHERE forked_from = ?",
-            (conv_id,))
+            "SELECT id, title, fork_point_msg_id, created_at FROM conversations WHERE forked_from = ? AND user_id = ?",
+            (conv_id, user_id))
         return [dict(r) for r in await cursor.fetchall()]
     finally:
         await db.close()
@@ -2065,13 +2553,14 @@ async def get_forks(conv_id: str):
 # ============================================================
 async def record_token_usage(conversation_id: str, model: str, persona_name: str,
                               prompt_tokens: int, completion_tokens: int):
+    user_id = _scope_user()
     db = await get_db()
     try:
         await db.execute(
-            """INSERT INTO token_usage (conversation_id, model, persona_name,
+            """INSERT INTO token_usage (user_id, conversation_id, model, persona_name,
                prompt_tokens, completion_tokens, total_tokens)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (conversation_id, model, persona_name or "", prompt_tokens, completion_tokens,
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (user_id, conversation_id, model, persona_name or "", prompt_tokens, completion_tokens,
              prompt_tokens + completion_tokens)
         )
         await db.commit()
@@ -2083,28 +2572,29 @@ async def record_token_usage(conversation_id: str, model: str, persona_name: str
 
 async def get_token_usage(days: int = 30, group_by: str = "day"):
     """Aggregate token usage. group_by: day, model, persona."""
+    user_id = _scope_user()
     db = await get_db()
     try:
         if group_by == "model":
             q = """SELECT model, SUM(prompt_tokens) as prompt_tokens,
                    SUM(completion_tokens) as completion_tokens,
                    SUM(total_tokens) as total_tokens, COUNT(*) as request_count
-                   FROM token_usage WHERE created_at >= datetime('now', ?)
+                   FROM token_usage WHERE user_id=? AND created_at >= datetime('now', ?)
                    GROUP BY model ORDER BY total_tokens DESC"""
         elif group_by == "persona":
             q = """SELECT persona_name, SUM(prompt_tokens) as prompt_tokens,
                    SUM(completion_tokens) as completion_tokens,
                    SUM(total_tokens) as total_tokens, COUNT(*) as request_count
-                   FROM token_usage WHERE created_at >= datetime('now', ?)
+                   FROM token_usage WHERE user_id=? AND created_at >= datetime('now', ?)
                    GROUP BY persona_name ORDER BY total_tokens DESC"""
         else:
             q = """SELECT date(created_at) as date,
                    SUM(prompt_tokens) as prompt_tokens,
                    SUM(completion_tokens) as completion_tokens,
                    SUM(total_tokens) as total_tokens, COUNT(*) as request_count
-                   FROM token_usage WHERE created_at >= datetime('now', ?)
+                   FROM token_usage WHERE user_id=? AND created_at >= datetime('now', ?)
                    GROUP BY date(created_at) ORDER BY date ASC"""
-        cursor = await db.execute(q, (f"-{days} days",))
+        cursor = await db.execute(q, (user_id, f"-{days} days"))
         return [dict(r) for r in await cursor.fetchall()]
     finally:
         await db.close()
@@ -2142,15 +2632,16 @@ async def create_research_report(report_id: str, *, query: str, title: str = "",
                                  planner_model: str = "", auditor_model: str = "",
                                  kb_ids: list = None, inputs: list = None,
                                  status: str = "queued") -> None:
+    user_id = _scope_user()
     db = await get_db()
     try:
         now = datetime.utcnow().isoformat()
         await db.execute(
-            "INSERT INTO research_reports(id,title,query,focus,report_type,status,depth,"
+            "INSERT INTO research_reports(id,user_id,title,query,focus,report_type,status,depth,"
             "model,planner_model,auditor_model,kb_ids,inputs_json,created_at,updated_at) "
-            "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
             (
-                report_id, title or query[:80], query, focus or "", report_type or "analyst",
+                report_id, user_id, title or query[:80], query, focus or "", report_type or "analyst",
                 status, int(depth or 3), model or "", planner_model or "",
                 auditor_model or "", json.dumps(kb_ids or []), json.dumps(inputs or []),
                 now, now,
@@ -2191,19 +2682,20 @@ async def update_research_report(report_id: str, **kwargs) -> None:
         return
     sets.append("updated_at=?")
     vals.append(datetime.utcnow().isoformat())
-    vals.append(report_id)
+    vals.extend([report_id, _scope_user()])
     db = await get_db()
     try:
-        await db.execute(f"UPDATE research_reports SET {', '.join(sets)} WHERE id=?", tuple(vals))
+        await db.execute(f"UPDATE research_reports SET {', '.join(sets)} WHERE id=? AND user_id=?", tuple(vals))
         await db.commit()
     finally:
         await db.close()
 
 
 async def append_research_event(report_id: str, event: dict) -> None:
+    user_id = _scope_user()
     db = await get_db()
     try:
-        rows = await db.execute_fetchall("SELECT events_log FROM research_reports WHERE id=?", (report_id,))
+        rows = await db.execute_fetchall("SELECT events_log FROM research_reports WHERE id=? AND user_id=?", (report_id, user_id))
         if not rows:
             return
         try:
@@ -2223,8 +2715,12 @@ async def append_research_event(report_id: str, event: dict) -> None:
 
 
 async def replace_research_sources(report_id: str, sources: list[dict]) -> None:
+    user_id = _scope_user()
     db = await get_db()
     try:
+        rows = await db.execute_fetchall("SELECT id FROM research_reports WHERE id=? AND user_id=?", (report_id, user_id))
+        if not rows:
+            return
         await db.execute("DELETE FROM research_sources WHERE report_id=?", (report_id,))
         for i, src in enumerate(sources or [], start=1):
             metadata = dict(src.get("metadata") or {})
@@ -2247,9 +2743,10 @@ async def replace_research_sources(report_id: str, sources: list[dict]) -> None:
 
 
 async def get_research_report(report_id: str) -> dict | None:
+    user_id = _scope_user()
     db = await get_db()
     try:
-        rows = await db.execute_fetchall("SELECT * FROM research_reports WHERE id=?", (report_id,))
+        rows = await db.execute_fetchall("SELECT * FROM research_reports WHERE id=? AND user_id=?", (report_id, user_id))
         if not rows:
             return None
         report = _parse_research_report(rows[0])
@@ -2280,6 +2777,7 @@ async def get_research_report(report_id: str) -> dict | None:
 
 
 async def list_research_reports(limit: int = 50, offset: int = 0, query: str = "") -> list[dict]:
+    user_id = _scope_user()
     db = await get_db()
     try:
         if query:
@@ -2287,16 +2785,16 @@ async def list_research_reports(limit: int = 50, offset: int = 0, query: str = "
             rows = await db.execute_fetchall(
                 "SELECT id,title,query,focus,report_type,status,depth,model,summary,error,"
                 "sources_json,metrics_json,created_at,updated_at,completed_at "
-                "FROM research_reports WHERE title LIKE ? OR query LIKE ? OR summary LIKE ? "
+                "FROM research_reports WHERE user_id=? AND (title LIKE ? OR query LIKE ? OR summary LIKE ?) "
                 "ORDER BY updated_at DESC LIMIT ? OFFSET ?",
-                (like, like, like, limit, offset),
+                (user_id, like, like, like, limit, offset),
             )
         else:
             rows = await db.execute_fetchall(
                 "SELECT id,title,query,focus,report_type,status,depth,model,summary,error,"
                 "sources_json,metrics_json,created_at,updated_at,completed_at "
-                "FROM research_reports ORDER BY updated_at DESC LIMIT ? OFFSET ?",
-                (limit, offset),
+                "FROM research_reports WHERE user_id=? ORDER BY updated_at DESC LIMIT ? OFFSET ?",
+                (user_id, limit, offset),
             )
         reports = []
         for row in rows:
@@ -2320,11 +2818,15 @@ async def list_research_reports(limit: int = 50, offset: int = 0, query: str = "
 
 
 async def delete_research_report(report_id: str) -> None:
+    user_id = _scope_user()
     db = await get_db()
     try:
+        rows = await db.execute_fetchall("SELECT id FROM research_reports WHERE id=? AND user_id=?", (report_id, user_id))
+        if not rows:
+            return
         await db.execute("DELETE FROM workspace_research_reports WHERE report_id=?", (report_id,))
         await db.execute("DELETE FROM research_sources WHERE report_id=?", (report_id,))
-        await db.execute("DELETE FROM research_reports WHERE id=?", (report_id,))
+        await db.execute("DELETE FROM research_reports WHERE id=? AND user_id=?", (report_id, user_id))
         await db.commit()
     finally:
         await db.close()
@@ -2337,23 +2839,24 @@ async def upsert_coding_project(project_id: str, name: str, conversation_id: str
                                  description: str = "", language: str = "",
                                  file_manifest: list = None, last_plan: str = "",
                                  openhands_project_id: str = ""):
+    user_id = _scope_user()
     db = await get_db()
     try:
         now = datetime.utcnow().isoformat()
         manifest_json = json.dumps(file_manifest or [])
-        existing = await db.execute_fetchall("SELECT id FROM coding_projects WHERE id = ?", (project_id,))
+        existing = await db.execute_fetchall("SELECT id FROM coding_projects WHERE id = ? AND user_id = ?", (project_id, user_id))
         if existing:
             await db.execute(
                 "UPDATE coding_projects SET name=?, description=?, language=?, file_manifest=?, "
-                "last_plan=?, conversation_id=?, openhands_project_id=?, updated_at=? WHERE id=?",
+                "last_plan=?, conversation_id=?, openhands_project_id=?, updated_at=? WHERE id=? AND user_id=?",
                 (name, description, language, manifest_json, last_plan,
-                 conversation_id, openhands_project_id, now, project_id)
+                 conversation_id, openhands_project_id, now, project_id, user_id)
             )
         else:
             await db.execute(
-                "INSERT INTO coding_projects(id,name,description,language,file_manifest,last_plan,"
-                "conversation_id,openhands_project_id,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?)",
-                (project_id, name, description, language, manifest_json, last_plan,
+                "INSERT INTO coding_projects(id,user_id,name,description,language,file_manifest,last_plan,"
+                "conversation_id,openhands_project_id,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+                (project_id, user_id, name, description, language, manifest_json, last_plan,
                  conversation_id, openhands_project_id, now, now)
             )
         await db.commit()
@@ -2362,11 +2865,12 @@ async def upsert_coding_project(project_id: str, name: str, conversation_id: str
 
 
 async def get_coding_project_by_conv(conversation_id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
         rows = await db.execute_fetchall(
-            "SELECT * FROM coding_projects WHERE conversation_id = ? ORDER BY updated_at DESC LIMIT 1",
-            (conversation_id,)
+            "SELECT * FROM coding_projects WHERE conversation_id = ? AND user_id=? ORDER BY updated_at DESC LIMIT 1",
+            (conversation_id, user_id)
         )
         if not rows:
             return None
@@ -2381,9 +2885,10 @@ async def get_coding_project_by_conv(conversation_id: str):
 
 
 async def get_coding_project(project_id: str):
+    user_id = _scope_user()
     db = await get_db()
     try:
-        rows = await db.execute_fetchall("SELECT * FROM coding_projects WHERE id = ?", (project_id,))
+        rows = await db.execute_fetchall("SELECT * FROM coding_projects WHERE id = ? AND user_id=?", (project_id, user_id))
         if not rows:
             return None
         p = dict(rows[0])
@@ -2418,8 +2923,12 @@ async def create_run(run_id: str, conversation_id: str, role: str,
                      project_id: str = "", parent_run_id: str = "",
                      status: str = "queued") -> None:
     """Create a new run row. Status defaults to 'queued'; caller transitions to 'running' when it starts."""
+    user_id = _scope_user()
     db = await get_db()
     try:
+        rows = await db.execute_fetchall("SELECT id FROM conversations WHERE id=? AND user_id=?", (conversation_id, user_id))
+        if not rows:
+            return
         now = datetime.utcnow().isoformat()
         await db.execute(
             "INSERT INTO runs(id, conversation_id, role, status, project_id, parent_run_id, "
@@ -2451,10 +2960,14 @@ async def update_run(run_id: str, *, status: str = None, result_envelope: dict =
         vals.append(datetime.utcnow().isoformat())
     if not sets:
         return
-    vals.append(run_id)
+    vals.extend([run_id, _scope_user()])
     db = await get_db()
     try:
-        await db.execute(f"UPDATE runs SET {', '.join(sets)} WHERE id=?", tuple(vals))
+        await db.execute(
+            f"""UPDATE runs SET {', '.join(sets)}
+                WHERE id=? AND conversation_id IN (SELECT id FROM conversations WHERE user_id=?)""",
+            tuple(vals),
+        )
         await db.commit()
     finally:
         await db.close()
@@ -2467,9 +2980,13 @@ async def append_run_event(run_id: str, event: dict) -> None:
     same run are not expected (one writer per run by design); if that ever changes,
     move to a separate run_events table.
     """
+    user_id = _scope_user()
     db = await get_db()
     try:
-        rows = await db.execute_fetchall("SELECT events_log FROM runs WHERE id=?", (run_id,))
+        rows = await db.execute_fetchall(
+            "SELECT events_log FROM runs WHERE id=? AND conversation_id IN (SELECT id FROM conversations WHERE user_id=?)",
+            (run_id, user_id),
+        )
         if not rows:
             return
         try:
@@ -2481,8 +2998,10 @@ async def append_run_event(run_id: str, event: dict) -> None:
         if "ts" not in event:
             event = {**event, "ts": datetime.utcnow().isoformat()}
         log.append(event)
-        await db.execute("UPDATE runs SET events_log=? WHERE id=?",
-                         (json.dumps(log), run_id))
+        await db.execute(
+            "UPDATE runs SET events_log=? WHERE id=? AND conversation_id IN (SELECT id FROM conversations WHERE user_id=?)",
+            (json.dumps(log), run_id, user_id),
+        )
         await db.commit()
     finally:
         await db.close()
@@ -2490,9 +3009,13 @@ async def append_run_event(run_id: str, event: dict) -> None:
 
 async def get_run(run_id: str) -> dict | None:
     """Return a single run with parsed result_envelope and events_log."""
+    user_id = _scope_user()
     db = await get_db()
     try:
-        rows = await db.execute_fetchall("SELECT * FROM runs WHERE id=?", (run_id,))
+        rows = await db.execute_fetchall(
+            "SELECT * FROM runs WHERE id=? AND conversation_id IN (SELECT id FROM conversations WHERE user_id=?)",
+            (run_id, user_id),
+        )
         if not rows:
             return None
         return _row_to_run(rows[0])
@@ -2503,11 +3026,12 @@ async def get_run(run_id: str) -> dict | None:
 async def get_runs_by_conversation(conversation_id: str, limit: int = 100) -> list[dict]:
     """All runs for a conversation, newest first. Used by the frontend on reconnect
     to rebuild the run cards under each message."""
+    user_id = _scope_user()
     db = await get_db()
     try:
         rows = await db.execute_fetchall(
-            "SELECT * FROM runs WHERE conversation_id=? ORDER BY started_at DESC LIMIT ?",
-            (conversation_id, limit)
+            "SELECT * FROM runs WHERE conversation_id=? AND conversation_id IN (SELECT id FROM conversations WHERE user_id=?) ORDER BY started_at DESC LIMIT ?",
+            (conversation_id, user_id, limit)
         )
         return [_row_to_run(r) for r in rows]
     finally:
@@ -2516,11 +3040,12 @@ async def get_runs_by_conversation(conversation_id: str, limit: int = 100) -> li
 
 async def get_runs_by_project(project_id: str, limit: int = 50) -> list[dict]:
     """All runs that touched a given project, newest first."""
+    user_id = _scope_user()
     db = await get_db()
     try:
         rows = await db.execute_fetchall(
-            "SELECT * FROM runs WHERE project_id=? ORDER BY started_at DESC LIMIT ?",
-            (project_id, limit)
+            "SELECT * FROM runs WHERE project_id=? AND conversation_id IN (SELECT id FROM conversations WHERE user_id=?) ORDER BY started_at DESC LIMIT ?",
+            (project_id, user_id, limit)
         )
         return [_row_to_run(r) for r in rows]
     finally:
@@ -2547,8 +3072,12 @@ async def create_coder_workflow(workflow_id: str, conversation_id: str, *,
                                 contract: dict | None = None,
                                 active_run_id: str = "",
                                 artifact_status: str = "not_ready") -> None:
+    user_id = _scope_user()
     db = await get_db()
     try:
+        rows = await db.execute_fetchall("SELECT id FROM conversations WHERE id=? AND user_id=?", (conversation_id, user_id))
+        if not rows:
+            return
         now = datetime.utcnow().isoformat()
         await db.execute(
             "INSERT INTO coder_workflows(id, conversation_id, project_id, mode, state, "
@@ -2595,19 +3124,27 @@ async def update_coder_workflow(workflow_id: str, *, state: str | None = None,
         return
     sets.append("updated_at=?")
     vals.append(datetime.utcnow().isoformat())
-    vals.append(workflow_id)
+    vals.extend([workflow_id, _scope_user()])
     db = await get_db()
     try:
-        await db.execute(f"UPDATE coder_workflows SET {', '.join(sets)} WHERE id=?", tuple(vals))
+        await db.execute(
+            f"""UPDATE coder_workflows SET {', '.join(sets)}
+                WHERE id=? AND conversation_id IN (SELECT id FROM conversations WHERE user_id=?)""",
+            tuple(vals),
+        )
         await db.commit()
     finally:
         await db.close()
 
 
 async def get_coder_workflow(workflow_id: str) -> dict | None:
+    user_id = _scope_user()
     db = await get_db()
     try:
-        rows = await db.execute_fetchall("SELECT * FROM coder_workflows WHERE id=?", (workflow_id,))
+        rows = await db.execute_fetchall(
+            "SELECT * FROM coder_workflows WHERE id=? AND conversation_id IN (SELECT id FROM conversations WHERE user_id=?)",
+            (workflow_id, user_id),
+        )
         if not rows:
             return None
         return _row_to_coder_workflow(rows[0])
@@ -2617,11 +3154,12 @@ async def get_coder_workflow(workflow_id: str) -> dict | None:
 
 async def get_coder_workflows_by_conversation(conversation_id: str,
                                               limit: int = 50) -> list[dict]:
+    user_id = _scope_user()
     db = await get_db()
     try:
         rows = await db.execute_fetchall(
-            "SELECT * FROM coder_workflows WHERE conversation_id=? ORDER BY updated_at DESC LIMIT ?",
-            (conversation_id, limit),
+            "SELECT * FROM coder_workflows WHERE conversation_id=? AND conversation_id IN (SELECT id FROM conversations WHERE user_id=?) ORDER BY updated_at DESC LIMIT ?",
+            (conversation_id, user_id, limit),
         )
         return [_row_to_coder_workflow(r) for r in rows]
     finally:
@@ -2630,19 +3168,20 @@ async def get_coder_workflows_by_conversation(conversation_id: str,
 
 async def get_latest_coder_workflow(conversation_id: str,
                                     project_id: str = "") -> dict | None:
+    user_id = _scope_user()
     db = await get_db()
     try:
         if project_id:
             rows = await db.execute_fetchall(
                 "SELECT * FROM coder_workflows WHERE conversation_id=? AND project_id=? "
-                "ORDER BY updated_at DESC LIMIT 1",
-                (conversation_id, project_id),
+                "AND conversation_id IN (SELECT id FROM conversations WHERE user_id=?) ORDER BY updated_at DESC LIMIT 1",
+                (conversation_id, project_id, user_id),
             )
         else:
             rows = await db.execute_fetchall(
                 "SELECT * FROM coder_workflows WHERE conversation_id=? "
-                "ORDER BY updated_at DESC LIMIT 1",
-                (conversation_id,),
+                "AND conversation_id IN (SELECT id FROM conversations WHERE user_id=?) ORDER BY updated_at DESC LIMIT 1",
+                (conversation_id, user_id),
             )
         if not rows:
             return None

--- a/backend/database.py
+++ b/backend/database.py
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS conversations (
     tool_ids TEXT DEFAULT '[]',
     persona_name TEXT DEFAULT '',
     persona_avatar TEXT DEFAULT '',
+    use_memories TEXT DEFAULT '0',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -143,6 +144,20 @@ CREATE TABLE IF NOT EXISTS memories (
     metadata_json TEXT DEFAULT '{}',
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS user_profile (
+    id TEXT PRIMARY KEY DEFAULT 'default',
+    display_name TEXT DEFAULT '',
+    legal_name TEXT DEFAULT '',
+    birthday TEXT DEFAULT '',
+    age TEXT DEFAULT '',
+    bio TEXT DEFAULT '',
+    interests_json TEXT DEFAULT '[]',
+    links_json TEXT DEFAULT '[]',
+    extra_json TEXT DEFAULT '{}',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS workspace_memory_blocks (
@@ -354,6 +369,20 @@ async def init_db():
             CREATE INDEX IF NOT EXISTS idx_memories_workspace ON memories(workspace_id);
             CREATE INDEX IF NOT EXISTS idx_memories_status ON memories(status);
             CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(type);
+            CREATE INDEX IF NOT EXISTS idx_memories_global_status ON memories(status, type) WHERE workspace_id IS NULL;
+            CREATE TABLE IF NOT EXISTS user_profile (
+                id TEXT PRIMARY KEY DEFAULT 'default',
+                display_name TEXT DEFAULT '',
+                legal_name TEXT DEFAULT '',
+                birthday TEXT DEFAULT '',
+                age TEXT DEFAULT '',
+                bio TEXT DEFAULT '',
+                interests_json TEXT DEFAULT '[]',
+                links_json TEXT DEFAULT '[]',
+                extra_json TEXT DEFAULT '{}',
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
             CREATE TABLE IF NOT EXISTS workspace_memory_blocks (
                 id TEXT PRIMARY KEY,
                 workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
@@ -424,12 +453,26 @@ async def init_db():
 # ============================================================
 # CONVERSATION CRUD
 # ============================================================
-async def create_conversation(id: str, title: str = "New Chat", model: str = "", system_prompt: str = "", model_config_id: str = None):
+async def create_conversation(
+    id: str,
+    title: str = "New Chat",
+    model: str = "",
+    system_prompt: str = "",
+    model_config_id: str = None,
+    use_memories: str = "0",
+):
     db = await get_db()
     try:
         await db.execute(
-            "INSERT INTO conversations (id, title, model, system_prompt, model_config_id) VALUES (?, ?, ?, ?, ?)",
-            (id, title, model, system_prompt, model_config_id)
+            "INSERT INTO conversations (id, title, model, system_prompt, model_config_id, use_memories) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                id,
+                title,
+                model,
+                system_prompt,
+                model_config_id,
+                "1" if str(use_memories).lower() in {"1", "true", "yes", "on"} else "0",
+            ),
         )
         await db.commit()
     finally:
@@ -490,6 +533,19 @@ async def get_conversation(id: str):
         await db.close()
 
 
+async def get_conversation_use_memories(id: str) -> bool:
+    if not id:
+        return False
+    db = await get_db()
+    try:
+        rows = await db.execute_fetchall("SELECT use_memories FROM conversations WHERE id=?", (id,))
+        if not rows:
+            return False
+        return str(rows[0]["use_memories"] or "0").lower() in {"1", "true", "yes", "on"}
+    finally:
+        await db.close()
+
+
 def _scrub_surrogates(v):
     """SQLite's UTF-8 bindings reject any string containing a surrogate
     codepoint (lone \\uD83D etc.). The frontend occasionally sends unpaired
@@ -528,6 +584,8 @@ async def update_conversation(id: str, **kwargs):
         # Serialize list/dict fields
         if "tool_ids" in kwargs and isinstance(kwargs["tool_ids"], list):
             kwargs["tool_ids"] = json.dumps(kwargs["tool_ids"])
+        if "use_memories" in kwargs:
+            kwargs["use_memories"] = "1" if str(kwargs["use_memories"]).lower() in {"1", "true", "yes", "on"} else "0"
         sets = ", ".join(f"{k} = ?" for k in kwargs)
         vals = [_scrub_surrogates(v) for v in kwargs.values()] + [id]
         await db.execute(f"UPDATE conversations SET {sets}, updated_at = CURRENT_TIMESTAMP WHERE id = ?", vals)
@@ -1055,6 +1113,92 @@ def _normalize_memory_status(value: str) -> str:
     return value if value in _MEMORY_STATUSES else "suggested"
 
 
+def _coerce_text_list(value) -> list[str]:
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v or "").strip()]
+    if isinstance(value, str):
+        return [v.strip() for v in re.split(r"[\n,]+", value) if v.strip()]
+    return []
+
+
+def _coerce_links(value) -> list:
+    if not isinstance(value, list):
+        return []
+    links = []
+    for item in value:
+        if isinstance(item, dict):
+            label = _scrub_surrogates(str(item.get("label") or item.get("title") or "").strip())
+            url = _scrub_surrogates(str(item.get("url") or item.get("href") or "").strip())
+            note = _scrub_surrogates(str(item.get("note") or "").strip())
+            if label or url:
+                row = {"label": label, "url": url}
+                if note:
+                    row["note"] = note
+                links.append(row)
+        elif str(item or "").strip():
+            links.append({"label": "", "url": _scrub_surrogates(str(item).strip())})
+    return links
+
+
+def _normalize_profile_row(row) -> dict:
+    d = dict(row)
+    d["interests"] = _loads_json(d.pop("interests_json", "[]"), [])
+    d["links"] = _loads_json(d.pop("links_json", "[]"), [])
+    d["extra"] = _loads_json(d.pop("extra_json", "{}"), {})
+    return d
+
+
+async def _ensure_user_profile(conn: aiosqlite.Connection) -> None:
+    now = datetime.utcnow().isoformat()
+    await conn.execute(
+        """INSERT OR IGNORE INTO user_profile
+           (id,display_name,legal_name,birthday,age,bio,interests_json,links_json,extra_json,created_at,updated_at)
+           VALUES('default','','','','','','[]','[]','{}',?,?)""",
+        (now, now),
+    )
+
+
+async def get_user_profile() -> dict:
+    db = await get_db()
+    try:
+        await _ensure_user_profile(db)
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM user_profile WHERE id='default'")
+        return _normalize_profile_row(rows[0])
+    finally:
+        await db.close()
+
+
+async def update_user_profile(**kwargs) -> dict:
+    allowed = {
+        "display_name", "legal_name", "birthday", "age", "bio",
+        "interests", "links", "extra",
+    }
+    fields = {k: v for k, v in kwargs.items() if k in allowed}
+    db = await get_db()
+    try:
+        await _ensure_user_profile(db)
+        if fields:
+            if "interests" in fields:
+                fields["interests_json"] = json.dumps(_coerce_text_list(fields.pop("interests")))
+            if "links" in fields:
+                fields["links_json"] = json.dumps(_coerce_links(fields.pop("links")))
+            if "extra" in fields:
+                extra = fields.pop("extra")
+                fields["extra_json"] = json.dumps(extra if isinstance(extra, dict) else {"notes": str(extra or "")})
+            for key in ("display_name", "legal_name", "birthday", "age", "bio"):
+                if key in fields:
+                    fields[key] = _scrub_surrogates(str(fields[key] or "").strip())
+            fields["updated_at"] = datetime.utcnow().isoformat()
+            sets = ",".join(f"{k}=?" for k in fields)
+            await db.execute(f"UPDATE user_profile SET {sets} WHERE id='default'", tuple(fields.values()))
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM user_profile WHERE id='default'")
+        return _normalize_profile_row(rows[0])
+    finally:
+        await db.close()
+
+
 async def get_workspace_basic(ws_id: str) -> dict | None:
     db = await get_db()
     try:
@@ -1347,6 +1491,270 @@ def _content_tokens(text: str) -> set[str]:
 
 def _memory_current_clause(now: str) -> str:
     return "(valid_until IS NULL OR valid_until='' OR valid_until>?)"
+
+
+async def list_global_memories(
+    *,
+    status: str | None = None,
+    memory_type: str | None = None,
+    include_archived: bool = True,
+) -> list[dict]:
+    clauses = ["workspace_id IS NULL"]
+    vals = []
+    if status and status != "all":
+        clauses.append("status=?")
+        vals.append(_normalize_memory_status(status))
+    elif not include_archived:
+        clauses.append("status!='archived'")
+    if memory_type and memory_type != "all":
+        clauses.append("type=?")
+        vals.append(_normalize_memory_type(memory_type))
+    db = await get_db()
+    try:
+        rows = await db.execute_fetchall(
+            f"""SELECT * FROM memories WHERE {' AND '.join(clauses)}
+                ORDER BY
+                  CASE status WHEN 'suggested' THEN 0 WHEN 'accepted' THEN 1 ELSE 2 END,
+                  pinned DESC,
+                  importance DESC,
+                  COALESCE(updated_at, created_at) DESC""",
+            vals,
+        )
+        return [_normalize_memory_row(r) for r in rows]
+    finally:
+        await db.close()
+
+
+async def create_global_memory(
+    *,
+    content: str,
+    memory_type: str = "semantic",
+    status: str = "suggested",
+    category: str = "General",
+    importance: int = 3,
+    pinned: int = 0,
+    source_conv_id: str | None = None,
+    source_conversation_id: str | None = None,
+    source_message_id: int | None = None,
+    confidence: float = 0,
+    valid_from: str | None = None,
+    valid_until: str | None = None,
+    supersedes_id: str | None = None,
+    entities: list | None = None,
+    metadata: dict | None = None,
+) -> dict:
+    mem_id = f"mem-{uuid.uuid4().hex[:12]}"
+    now = datetime.utcnow().isoformat()
+    clean_content = _scrub_surrogates((content or "").strip())
+    if not clean_content:
+        raise ValueError("memory content is required")
+    mtype = _normalize_memory_type(memory_type)
+    mstatus = _normalize_memory_status(status)
+    importance = max(1, min(5, int(importance or 3)))
+    db = await get_db()
+    try:
+        await db.execute(
+            """INSERT INTO memories
+               (id,workspace_id,content,type,status,category,importance,pinned,
+                source_conv_id,source_conversation_id,source_message_id,confidence,
+                valid_from,valid_until,supersedes_id,entities_json,metadata_json,updated_at,created_at)
+               VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                mem_id, None, clean_content, mtype, mstatus, category or "General",
+                importance, 1 if pinned else 0, source_conv_id or source_conversation_id,
+                source_conversation_id or source_conv_id, source_message_id,
+                float(confidence or 0), valid_from, valid_until, supersedes_id,
+                json.dumps(entities or []), json.dumps(metadata or {}), now, now,
+            ),
+        )
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=?", (mem_id,))
+        return _normalize_memory_row(rows[0])
+    finally:
+        await db.close()
+
+
+async def update_global_memory(memory_id: str, **kwargs) -> dict | None:
+    allowed = {
+        "content", "type", "status", "category", "importance", "pinned",
+        "confidence", "valid_from", "valid_until", "supersedes_id",
+        "entities", "metadata",
+    }
+    fields = {k: v for k, v in kwargs.items() if k in allowed}
+    if not fields:
+        rows = await list_global_memories(status="all")
+        return next((m for m in rows if m["id"] == memory_id), None)
+    if "type" in fields:
+        fields["type"] = _normalize_memory_type(fields["type"])
+    if "status" in fields:
+        fields["status"] = _normalize_memory_status(fields["status"])
+    if "importance" in fields:
+        fields["importance"] = max(1, min(5, int(fields["importance"] or 3)))
+    if "pinned" in fields:
+        fields["pinned"] = 1 if fields["pinned"] else 0
+    if "content" in fields:
+        fields["content"] = _scrub_surrogates((fields["content"] or "").strip())
+    if "entities" in fields:
+        fields["entities_json"] = json.dumps(fields.pop("entities") or [])
+    if "metadata" in fields:
+        fields["metadata_json"] = json.dumps(fields.pop("metadata") or {})
+    fields["updated_at"] = datetime.utcnow().isoformat()
+    sets = ",".join(f"{k}=?" for k in fields)
+    vals = list(fields.values()) + [memory_id]
+    db = await get_db()
+    try:
+        await db.execute(f"UPDATE memories SET {sets} WHERE id=? AND workspace_id IS NULL", vals)
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=? AND workspace_id IS NULL", (memory_id,))
+        return _normalize_memory_row(rows[0]) if rows else None
+    finally:
+        await db.close()
+
+
+async def accept_global_memory(memory_id: str, supersedes_id: str | None = None) -> dict | None:
+    now = datetime.utcnow().isoformat()
+    db = await get_db()
+    try:
+        if supersedes_id:
+            await db.execute(
+                "UPDATE memories SET valid_until=?, updated_at=? WHERE id=? AND workspace_id IS NULL",
+                (now, now, supersedes_id),
+            )
+        await db.execute(
+            """UPDATE memories
+               SET status='accepted',
+                   supersedes_id=COALESCE(?, supersedes_id),
+                   valid_from=COALESCE(valid_from, ?),
+                   updated_at=?
+               WHERE id=? AND workspace_id IS NULL""",
+            (supersedes_id, now, now, memory_id),
+        )
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=? AND workspace_id IS NULL", (memory_id,))
+        return _normalize_memory_row(rows[0]) if rows else None
+    finally:
+        await db.close()
+
+
+async def reject_global_memory(memory_id: str) -> dict | None:
+    return await update_global_memory(memory_id, status="rejected")
+
+
+async def delete_global_memory(memory_id: str) -> bool:
+    db = await get_db()
+    try:
+        cur = await db.execute("DELETE FROM memories WHERE id=? AND workspace_id IS NULL", (memory_id,))
+        await db.commit()
+        return cur.rowcount > 0
+    finally:
+        await db.close()
+
+
+def _format_profile_context(profile: dict, remaining: int) -> tuple[list[str], int, bool]:
+    lines = []
+    has_content = False
+    field_rows = [
+        ("Preferred name", profile.get("display_name")),
+        ("Legal name", profile.get("legal_name")),
+        ("Birthday", profile.get("birthday")),
+        ("Age", profile.get("age")),
+        ("Bio", profile.get("bio")),
+    ]
+    profile_bits = []
+    for label, value in field_rows:
+        text = str(value or "").strip()
+        if text:
+            profile_bits.append(f"{label}: {text}")
+    interests = [str(v).strip() for v in (profile.get("interests") or []) if str(v or "").strip()]
+    if interests:
+        profile_bits.append("Interests: " + ", ".join(interests[:30]))
+    links = []
+    for link in profile.get("links") or []:
+        if not isinstance(link, dict):
+            continue
+        label = str(link.get("label") or "").strip()
+        url = str(link.get("url") or "").strip()
+        note = str(link.get("note") or "").strip()
+        if label and url:
+            item = f"{label}: {url}"
+        else:
+            item = label or url
+        if item and note:
+            item += f" ({note})"
+        if item:
+            links.append(item)
+    if links:
+        profile_bits.append("Links: " + "; ".join(links[:12]))
+    extra = profile.get("extra") if isinstance(profile.get("extra"), dict) else {}
+    notes = str(extra.get("notes") or "").strip()
+    if notes:
+        profile_bits.append("Notes: " + notes)
+    if profile_bits and remaining > 300:
+        text = "\n".join(profile_bits)
+        chunk = text[:min(len(text), remaining, 2200)]
+        lines.append("[User Profile]\n" + chunk)
+        remaining -= len(chunk)
+        has_content = True
+    return lines, remaining, has_content
+
+
+async def build_global_memory_context(*, query: str = "", max_chars: int = 4200) -> dict:
+    profile = await get_user_profile()
+    remaining = max(1000, int(max_chars or 4200))
+    lines, remaining, has_memory_content = _format_profile_context(profile, remaining)
+
+    now = datetime.utcnow().isoformat()
+    db = await get_db()
+    try:
+        rows = await db.execute_fetchall(
+            f"""SELECT * FROM memories
+                WHERE workspace_id IS NULL
+                  AND status='accepted'
+                  AND {_memory_current_clause(now)}
+                ORDER BY pinned DESC, importance DESC, COALESCE(updated_at, created_at) DESC
+                LIMIT 80""",
+            (now,),
+        )
+    finally:
+        await db.close()
+
+    q_tokens = _content_tokens(query)
+    scored = []
+    for row in rows:
+        mem = _normalize_memory_row(row)
+        m_tokens = _content_tokens(mem.get("content") or "")
+        overlap = len(q_tokens & m_tokens)
+        score = (20 if mem.get("pinned") else 0) + int(mem.get("importance") or 3) * 4 + overlap * 6
+        scored.append((score, mem))
+    scored.sort(key=lambda item: item[0], reverse=True)
+
+    memory_ids = []
+    grouped = {"semantic": [], "episodic": [], "procedural": []}
+    for _, mem in scored:
+        if remaining <= 500:
+            break
+        content = (mem.get("content") or "").strip()
+        if not content:
+            continue
+        prefix = "[pinned] " if mem.get("pinned") else ""
+        item = f"- {prefix}{content}"
+        if len(item) > remaining:
+            item = item[:remaining - 20] + "..."
+        grouped.setdefault(mem.get("type") or "semantic", []).append(item)
+        memory_ids.append(mem["id"])
+        remaining -= len(item)
+        if len(memory_ids) >= 12:
+            break
+
+    for typ, title in [("semantic", "Facts and Preferences"), ("episodic", "Past Events"), ("procedural", "Procedures")]:
+        if grouped.get(typ):
+            lines.append(f"\n[{title}]\n" + "\n".join(grouped[typ]))
+            has_memory_content = True
+
+    context = "\n".join(lines).strip() if has_memory_content else ""
+    if len(context) > max_chars:
+        context = context[:max_chars - 38] + "\n[...HyprChat memory truncated...]"
+    return {"profile": profile, "context": context, "memory_ids": memory_ids}
 
 
 async def build_workspace_memory_context(

--- a/backend/database.py
+++ b/backend/database.py
@@ -5,6 +5,8 @@ Stores conversations, messages, knowledge bases, tools, model configs.
 import aiosqlite
 import os
 import json
+import uuid
+import re
 from datetime import datetime
 from config import DATABASE_PATH
 
@@ -81,6 +83,8 @@ CREATE TABLE IF NOT EXISTS workspaces (
     name TEXT NOT NULL,
     description TEXT DEFAULT '',
     topics TEXT DEFAULT '[]',
+    memory_enabled INTEGER DEFAULT 0,
+    instructions TEXT DEFAULT '',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -121,13 +125,40 @@ CREATE TABLE IF NOT EXISTS council_members (
 
 CREATE TABLE IF NOT EXISTS memories (
     id TEXT PRIMARY KEY,
+    workspace_id TEXT,
     content TEXT NOT NULL,
+    type TEXT DEFAULT 'semantic',
+    status TEXT DEFAULT 'accepted',
     category TEXT DEFAULT 'General',
     importance INTEGER DEFAULT 3,
     pinned INTEGER DEFAULT 0,
     source_conv_id TEXT,
+    source_conversation_id TEXT,
+    source_message_id INTEGER,
+    confidence REAL DEFAULT 0,
+    valid_from TIMESTAMP,
+    valid_until TIMESTAMP,
+    supersedes_id TEXT,
+    entities_json TEXT DEFAULT '[]',
+    metadata_json TEXT DEFAULT '{}',
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS workspace_memory_blocks (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    label TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    value TEXT DEFAULT '',
+    limit_chars INTEGER DEFAULT 1200,
+    read_only INTEGER DEFAULT 0,
+    enabled INTEGER DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(workspace_id, label)
+);
+CREATE INDEX IF NOT EXISTS idx_workspace_memory_blocks_ws ON workspace_memory_blocks(workspace_id);
 
 CREATE TABLE IF NOT EXISTS service_health_log (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -290,6 +321,54 @@ async def init_db():
             except Exception as e:
                 if "duplicate column" not in str(e).lower():
                     print(f"[DB MIGRATION] Warning: {e}")
+        # Migrate workspaces: add reviewed-memory controls
+        for col, coltype, default in [("memory_enabled", "INTEGER", "0"), ("instructions", "TEXT", "''")]:
+            try:
+                await db.execute(f"ALTER TABLE workspaces ADD COLUMN {col} {coltype} DEFAULT {default}")
+            except Exception as e:
+                if "duplicate column" not in str(e).lower():
+                    print(f"[DB MIGRATION] Warning: {e}")
+        # Migrate memories: evolve the legacy global memory table into
+        # workspace-scoped reviewed memories. Old rows remain valid but are not
+        # injected unless assigned to a workspace.
+        for col, coltype, default in [
+            ("workspace_id", "TEXT", "NULL"),
+            ("type", "TEXT", "'semantic'"),
+            ("status", "TEXT", "'accepted'"),
+            ("source_conversation_id", "TEXT", "NULL"),
+            ("source_message_id", "INTEGER", "NULL"),
+            ("confidence", "REAL", "0"),
+            ("valid_from", "TIMESTAMP", "NULL"),
+            ("valid_until", "TIMESTAMP", "NULL"),
+            ("supersedes_id", "TEXT", "NULL"),
+            ("entities_json", "TEXT", "'[]'"),
+            ("metadata_json", "TEXT", "'{}'"),
+            ("updated_at", "TIMESTAMP", "NULL"),
+        ]:
+            try:
+                await db.execute(f"ALTER TABLE memories ADD COLUMN {col} {coltype} DEFAULT {default}")
+            except Exception as e:
+                if "duplicate column" not in str(e).lower():
+                    print(f"[DB MIGRATION] Warning: {e}")
+        await db.executescript("""
+            CREATE INDEX IF NOT EXISTS idx_memories_workspace ON memories(workspace_id);
+            CREATE INDEX IF NOT EXISTS idx_memories_status ON memories(status);
+            CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(type);
+            CREATE TABLE IF NOT EXISTS workspace_memory_blocks (
+                id TEXT PRIMARY KEY,
+                workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+                label TEXT NOT NULL,
+                description TEXT DEFAULT '',
+                value TEXT DEFAULT '',
+                limit_chars INTEGER DEFAULT 1200,
+                read_only INTEGER DEFAULT 0,
+                enabled INTEGER DEFAULT 1,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(workspace_id, label)
+            );
+            CREATE INDEX IF NOT EXISTS idx_workspace_memory_blocks_ws ON workspace_memory_blocks(workspace_id);
+        """)
         # Migrate council_configs: add debate_rounds and kb_ids columns
         for col, coltype, default in [("debate_rounds", "INTEGER", "0"), ("kb_ids", "TEXT", "'[]'")]:
             try:
@@ -725,13 +804,17 @@ async def create_workspace(id: str, name: str, description: str = ""):
     try:
         now = datetime.utcnow().isoformat()
         await db.execute(
-            "INSERT INTO workspaces(id,name,description,topics,created_at,updated_at) VALUES(?,?,?,'[]',?,?)",
+            "INSERT INTO workspaces(id,name,description,topics,memory_enabled,instructions,created_at,updated_at) VALUES(?,?,?,'[]',0,'',?,?)",
             (id, name, description, now, now)
         )
         await db.commit()
     finally:
         await db.close()
-    return {"id": id, "name": name, "description": description, "topics": [], "conv_count": 0, "file_count": 0, "report_count": 0}
+    return {
+        "id": id, "name": name, "description": description, "topics": [],
+        "memory_enabled": 0, "instructions": "",
+        "conv_count": 0, "file_count": 0, "report_count": 0,
+    }
 
 
 async def get_workspaces():
@@ -814,12 +897,14 @@ async def get_workspace(ws_id: str):
 
 
 async def update_workspace(ws_id: str, **kwargs):
-    allowed = {"name", "description", "topics"}
+    allowed = {"name", "description", "topics", "memory_enabled", "instructions"}
     fields = {k: v for k, v in kwargs.items() if k in allowed}
     if not fields:
         return
     if "topics" in fields and isinstance(fields["topics"], list):
         fields["topics"] = json.dumps(fields["topics"])
+    if "memory_enabled" in fields:
+        fields["memory_enabled"] = 1 if str(fields["memory_enabled"]).lower() in {"1", "true", "yes", "on"} else 0
     fields["updated_at"] = datetime.utcnow().isoformat()
     set_clause = ",".join(f"{k}=?" for k in fields)
     db = await get_db()
@@ -903,6 +988,458 @@ async def add_conversation_file(id: str, conv_id: str, filename: str, url: str):
         await db.commit()
     finally:
         await db.close()
+
+
+# ============================================================
+# WORKSPACE MEMORY
+# ============================================================
+_MEMORY_TYPES = {"semantic", "episodic", "procedural"}
+_MEMORY_STATUSES = {"suggested", "accepted", "rejected", "archived"}
+_DEFAULT_MEMORY_BLOCKS = [
+    {
+        "label": "workspace_instructions",
+        "description": "Stable instructions for all chats in this workspace.",
+        "value": "",
+        "limit_chars": 1800,
+        "read_only": 0,
+        "enabled": 1,
+    },
+    {
+        "label": "preferences",
+        "description": "Recurring user or project preferences that should stay in context.",
+        "value": "",
+        "limit_chars": 1200,
+        "read_only": 0,
+        "enabled": 1,
+    },
+    {
+        "label": "procedures",
+        "description": "Reusable workflows, commands, deploy steps, or lessons learned.",
+        "value": "",
+        "limit_chars": 1600,
+        "read_only": 0,
+        "enabled": 1,
+    },
+]
+
+
+def _loads_json(value, fallback):
+    if isinstance(value, (list, dict)):
+        return value
+    try:
+        return json.loads(value or "")
+    except Exception:
+        return fallback
+
+
+def _normalize_memory_row(row) -> dict:
+    d = dict(row)
+    d["entities"] = _loads_json(d.pop("entities_json", "[]"), [])
+    d["metadata"] = _loads_json(d.pop("metadata_json", "{}"), {})
+    d["pinned"] = int(d.get("pinned") or 0)
+    d["importance"] = int(d.get("importance") or 3)
+    try:
+        d["confidence"] = float(d.get("confidence") or 0)
+    except Exception:
+        d["confidence"] = 0.0
+    return d
+
+
+def _normalize_memory_type(value: str) -> str:
+    value = (value or "semantic").strip().lower()
+    return value if value in _MEMORY_TYPES else "semantic"
+
+
+def _normalize_memory_status(value: str) -> str:
+    value = (value or "suggested").strip().lower()
+    return value if value in _MEMORY_STATUSES else "suggested"
+
+
+async def get_workspace_basic(ws_id: str) -> dict | None:
+    db = await get_db()
+    try:
+        rows = await db.execute_fetchall("SELECT * FROM workspaces WHERE id=?", (ws_id,))
+        return dict(rows[0]) if rows else None
+    finally:
+        await db.close()
+
+
+async def get_workspace_for_conversation(conv_id: str) -> dict | None:
+    """Infer a workspace only when the conversation belongs to exactly one.
+
+    This keeps chat context predictable while still supporting older frontend
+    clients that do not send workspace_id yet.
+    """
+    if not conv_id:
+        return None
+    db = await get_db()
+    try:
+        rows = await db.execute_fetchall(
+            """SELECT w.* FROM workspaces w
+               JOIN workspace_conversations wc ON wc.workspace_id=w.id
+               WHERE wc.conversation_id=?
+               ORDER BY wc.added_at DESC""",
+            (conv_id,),
+        )
+        return dict(rows[0]) if len(rows) == 1 else None
+    finally:
+        await db.close()
+
+
+async def _ensure_workspace_memory_blocks(conn: aiosqlite.Connection, ws_id: str) -> None:
+    now = datetime.utcnow().isoformat()
+    for block in _DEFAULT_MEMORY_BLOCKS:
+        await conn.execute(
+            """INSERT OR IGNORE INTO workspace_memory_blocks
+               (id,workspace_id,label,description,value,limit_chars,read_only,enabled,created_at,updated_at)
+               VALUES(?,?,?,?,?,?,?,?,?,?)""",
+            (
+                f"wmb-{uuid.uuid4().hex[:12]}", ws_id, block["label"],
+                block["description"], block["value"], block["limit_chars"],
+                block["read_only"], block["enabled"], now, now,
+            ),
+        )
+
+
+def _normalize_block_row(row) -> dict:
+    d = dict(row)
+    d["enabled"] = int(d.get("enabled") or 0)
+    d["read_only"] = int(d.get("read_only") or 0)
+    d["limit_chars"] = int(d.get("limit_chars") or 1200)
+    return d
+
+
+async def get_workspace_memory_blocks(ws_id: str) -> list[dict]:
+    db = await get_db()
+    try:
+        await _ensure_workspace_memory_blocks(db, ws_id)
+        await db.commit()
+        rows = await db.execute_fetchall(
+            "SELECT * FROM workspace_memory_blocks WHERE workspace_id=? ORDER BY rowid ASC",
+            (ws_id,),
+        )
+        return [_normalize_block_row(r) for r in rows]
+    finally:
+        await db.close()
+
+
+async def update_workspace_memory_blocks(ws_id: str, blocks: list[dict]) -> list[dict]:
+    db = await get_db()
+    try:
+        await _ensure_workspace_memory_blocks(db, ws_id)
+        now = datetime.utcnow().isoformat()
+        for block in blocks or []:
+            block_id = block.get("id")
+            label = block.get("label")
+            if not block_id and not label:
+                continue
+            sets = []
+            vals = []
+            for key in ("description", "value"):
+                if key in block:
+                    sets.append(f"{key}=?")
+                    vals.append(_scrub_surrogates(block.get(key) or ""))
+            if "limit_chars" in block:
+                sets.append("limit_chars=?")
+                vals.append(max(200, min(8000, int(block.get("limit_chars") or 1200))))
+            if "enabled" in block:
+                sets.append("enabled=?")
+                vals.append(1 if block.get("enabled") else 0)
+            if "read_only" in block:
+                sets.append("read_only=?")
+                vals.append(1 if block.get("read_only") else 0)
+            if not sets:
+                continue
+            sets.append("updated_at=?")
+            vals.append(now)
+            if block_id:
+                vals.extend([ws_id, block_id])
+                await db.execute(
+                    f"UPDATE workspace_memory_blocks SET {', '.join(sets)} WHERE workspace_id=? AND id=?",
+                    vals,
+                )
+            else:
+                vals.extend([ws_id, label])
+                await db.execute(
+                    f"UPDATE workspace_memory_blocks SET {', '.join(sets)} WHERE workspace_id=? AND label=?",
+                    vals,
+                )
+        await db.commit()
+        rows = await db.execute_fetchall(
+            "SELECT * FROM workspace_memory_blocks WHERE workspace_id=? ORDER BY rowid ASC",
+            (ws_id,),
+        )
+        return [_normalize_block_row(r) for r in rows]
+    finally:
+        await db.close()
+
+
+async def list_workspace_memories(
+    ws_id: str,
+    *,
+    status: str | None = None,
+    memory_type: str | None = None,
+    include_archived: bool = True,
+) -> list[dict]:
+    clauses = ["workspace_id=?"]
+    vals = [ws_id]
+    if status and status != "all":
+        clauses.append("status=?")
+        vals.append(_normalize_memory_status(status))
+    elif not include_archived:
+        clauses.append("status!='archived'")
+    if memory_type and memory_type != "all":
+        clauses.append("type=?")
+        vals.append(_normalize_memory_type(memory_type))
+    db = await get_db()
+    try:
+        rows = await db.execute_fetchall(
+            f"""SELECT * FROM memories WHERE {' AND '.join(clauses)}
+                ORDER BY
+                  CASE status WHEN 'suggested' THEN 0 WHEN 'accepted' THEN 1 ELSE 2 END,
+                  pinned DESC,
+                  importance DESC,
+                  COALESCE(updated_at, created_at) DESC""",
+            vals,
+        )
+        return [_normalize_memory_row(r) for r in rows]
+    finally:
+        await db.close()
+
+
+async def create_workspace_memory(
+    ws_id: str,
+    *,
+    content: str,
+    memory_type: str = "semantic",
+    status: str = "suggested",
+    category: str = "General",
+    importance: int = 3,
+    pinned: int = 0,
+    source_conv_id: str | None = None,
+    source_conversation_id: str | None = None,
+    source_message_id: int | None = None,
+    confidence: float = 0,
+    valid_from: str | None = None,
+    valid_until: str | None = None,
+    supersedes_id: str | None = None,
+    entities: list | None = None,
+    metadata: dict | None = None,
+) -> dict:
+    mem_id = f"mem-{uuid.uuid4().hex[:12]}"
+    now = datetime.utcnow().isoformat()
+    clean_content = _scrub_surrogates((content or "").strip())
+    if not clean_content:
+        raise ValueError("memory content is required")
+    mtype = _normalize_memory_type(memory_type)
+    mstatus = _normalize_memory_status(status)
+    importance = max(1, min(5, int(importance or 3)))
+    db = await get_db()
+    try:
+        await db.execute(
+            """INSERT INTO memories
+               (id,workspace_id,content,type,status,category,importance,pinned,
+                source_conv_id,source_conversation_id,source_message_id,confidence,
+                valid_from,valid_until,supersedes_id,entities_json,metadata_json,updated_at,created_at)
+               VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                mem_id, ws_id, clean_content, mtype, mstatus, category or "General",
+                importance, 1 if pinned else 0, source_conv_id or source_conversation_id,
+                source_conversation_id or source_conv_id, source_message_id,
+                float(confidence or 0), valid_from, valid_until, supersedes_id,
+                json.dumps(entities or []), json.dumps(metadata or {}), now, now,
+            ),
+        )
+        await db.execute("UPDATE workspaces SET updated_at=? WHERE id=?", (now, ws_id))
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=?", (mem_id,))
+        return _normalize_memory_row(rows[0])
+    finally:
+        await db.close()
+
+
+async def update_workspace_memory(memory_id: str, ws_id: str, **kwargs) -> dict | None:
+    allowed = {
+        "content", "type", "status", "category", "importance", "pinned",
+        "confidence", "valid_from", "valid_until", "supersedes_id",
+        "entities", "metadata",
+    }
+    fields = {k: v for k, v in kwargs.items() if k in allowed}
+    if not fields:
+        rows = await list_workspace_memories(ws_id, status="all")
+        return next((m for m in rows if m["id"] == memory_id), None)
+    if "type" in fields:
+        fields["type"] = _normalize_memory_type(fields["type"])
+    if "status" in fields:
+        fields["status"] = _normalize_memory_status(fields["status"])
+    if "importance" in fields:
+        fields["importance"] = max(1, min(5, int(fields["importance"] or 3)))
+    if "pinned" in fields:
+        fields["pinned"] = 1 if fields["pinned"] else 0
+    if "content" in fields:
+        fields["content"] = _scrub_surrogates((fields["content"] or "").strip())
+    if "entities" in fields:
+        fields["entities_json"] = json.dumps(fields.pop("entities") or [])
+    if "metadata" in fields:
+        fields["metadata_json"] = json.dumps(fields.pop("metadata") or {})
+    fields["updated_at"] = datetime.utcnow().isoformat()
+    sets = ",".join(f"{k}=?" for k in fields)
+    vals = list(fields.values()) + [memory_id, ws_id]
+    db = await get_db()
+    try:
+        await db.execute(f"UPDATE memories SET {sets} WHERE id=? AND workspace_id=?", vals)
+        await db.execute("UPDATE workspaces SET updated_at=? WHERE id=?", (fields["updated_at"], ws_id))
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=? AND workspace_id=?", (memory_id, ws_id))
+        return _normalize_memory_row(rows[0]) if rows else None
+    finally:
+        await db.close()
+
+
+async def accept_workspace_memory(memory_id: str, ws_id: str, supersedes_id: str | None = None) -> dict | None:
+    now = datetime.utcnow().isoformat()
+    db = await get_db()
+    try:
+        if supersedes_id:
+            await db.execute(
+                "UPDATE memories SET valid_until=?, updated_at=? WHERE id=? AND workspace_id=?",
+                (now, now, supersedes_id, ws_id),
+            )
+        await db.execute(
+            """UPDATE memories
+               SET status='accepted',
+                   supersedes_id=COALESCE(?, supersedes_id),
+                   valid_from=COALESCE(valid_from, ?),
+                   updated_at=?
+               WHERE id=? AND workspace_id=?""",
+            (supersedes_id, now, now, memory_id, ws_id),
+        )
+        await db.execute("UPDATE workspaces SET updated_at=? WHERE id=?", (now, ws_id))
+        await db.commit()
+        rows = await db.execute_fetchall("SELECT * FROM memories WHERE id=? AND workspace_id=?", (memory_id, ws_id))
+        return _normalize_memory_row(rows[0]) if rows else None
+    finally:
+        await db.close()
+
+
+async def reject_workspace_memory(memory_id: str, ws_id: str) -> dict | None:
+    return await update_workspace_memory(memory_id, ws_id, status="rejected")
+
+
+async def delete_workspace_memory(memory_id: str, ws_id: str) -> bool:
+    db = await get_db()
+    try:
+        cur = await db.execute("DELETE FROM memories WHERE id=? AND workspace_id=?", (memory_id, ws_id))
+        await db.commit()
+        return cur.rowcount > 0
+    finally:
+        await db.close()
+
+
+def _content_tokens(text: str) -> set[str]:
+    words = re.findall(r"[a-zA-Z0-9_]{3,}", (text or "").lower())
+    stop = {
+        "the", "and", "for", "with", "that", "this", "from", "have", "what",
+        "when", "where", "would", "could", "should", "about", "into", "your",
+    }
+    return {w for w in words if w not in stop}
+
+
+def _memory_current_clause(now: str) -> str:
+    return "(valid_until IS NULL OR valid_until='' OR valid_until>?)"
+
+
+async def build_workspace_memory_context(
+    *,
+    workspace_id: str | None = None,
+    conversation_id: str | None = None,
+    query: str = "",
+    max_chars: int = 5200,
+) -> dict:
+    ws = await get_workspace_basic(workspace_id) if workspace_id else None
+    if not ws and conversation_id:
+        ws = await get_workspace_for_conversation(conversation_id)
+    if not ws or not int(ws.get("memory_enabled") or 0):
+        return {"workspace": ws, "context": "", "memory_ids": [], "block_ids": []}
+
+    ws_id = ws["id"]
+    remaining = max(1000, int(max_chars or 5200))
+    lines = [f"Workspace: {ws.get('name') or ws_id}"]
+    has_memory_content = False
+    block_ids = []
+
+    instructions = (ws.get("instructions") or "").strip()
+    if instructions:
+        chunk = instructions[:min(len(instructions), remaining, 1800)]
+        lines.append("\n[Instructions]\n" + chunk)
+        has_memory_content = True
+        remaining -= len(chunk)
+
+    for block in await get_workspace_memory_blocks(ws_id):
+        if remaining <= 400:
+            break
+        value = (block.get("value") or "").strip()
+        if not value or not int(block.get("enabled") or 0):
+            continue
+        limit = max(200, min(int(block.get("limit_chars") or 1200), remaining))
+        label = block.get("label") or "memory"
+        lines.append(f"\n[{label}]\n{value[:limit]}")
+        has_memory_content = True
+        block_ids.append(block["id"])
+        remaining -= min(len(value), limit)
+
+    now = datetime.utcnow().isoformat()
+    db = await get_db()
+    try:
+        rows = await db.execute_fetchall(
+            f"""SELECT * FROM memories
+                WHERE workspace_id=?
+                  AND status='accepted'
+                  AND {_memory_current_clause(now)}
+                ORDER BY pinned DESC, importance DESC, COALESCE(updated_at, created_at) DESC
+                LIMIT 80""",
+            (ws_id, now),
+        )
+    finally:
+        await db.close()
+
+    q_tokens = _content_tokens(query)
+    scored = []
+    for row in rows:
+        mem = _normalize_memory_row(row)
+        m_tokens = _content_tokens(mem.get("content") or "")
+        overlap = len(q_tokens & m_tokens)
+        score = (20 if mem.get("pinned") else 0) + int(mem.get("importance") or 3) * 4 + overlap * 6
+        scored.append((score, mem))
+    scored.sort(key=lambda item: item[0], reverse=True)
+
+    memory_ids = []
+    grouped = {"semantic": [], "episodic": [], "procedural": []}
+    for _, mem in scored:
+        if remaining <= 500:
+            break
+        content = (mem.get("content") or "").strip()
+        if not content:
+            continue
+        prefix = "[pinned] " if mem.get("pinned") else ""
+        item = f"- {prefix}{content}"
+        if len(item) > remaining:
+            item = item[:remaining - 20] + "..."
+        grouped.setdefault(mem.get("type") or "semantic", []).append(item)
+        memory_ids.append(mem["id"])
+        remaining -= len(item)
+        if len(memory_ids) >= 10:
+            break
+
+    for typ, title in [("semantic", "Facts and Preferences"), ("episodic", "Past Decisions and Events"), ("procedural", "Procedures")]:
+        if grouped.get(typ):
+            lines.append(f"\n[{title}]\n" + "\n".join(grouped[typ]))
+            has_memory_content = True
+
+    context = "\n".join(lines).strip() if has_memory_content else ""
+    if len(context) > max_chars:
+        context = context[:max_chars - 40] + "\n[...workspace memory truncated...]"
+    return {"workspace": ws, "context": context, "memory_ids": memory_ids, "block_ids": block_ids}
 
 
 # ============================================================

--- a/backend/main.py
+++ b/backend/main.py
@@ -36,7 +36,14 @@ from agents.personas import seed_coder_bot as _seed_coder_bot, seed_coder_bot_v2
 import hf as hf_module
 from hf import parse_ollama_progress
 import rag
-from research import REPORT_TEMPLATES, REPORT_TEMPLATE_MAP, fetch_bytes_safely, run_research_report
+from research import (
+    REPORT_TEMPLATES,
+    REPORT_TEMPLATE_MAP,
+    close_web_fetch_client,
+    fetch_bytes_safely,
+    run_research_report,
+    web_get,
+)
 
 # ============================================================
 # SETTINGS — persistent JSON file
@@ -292,6 +299,7 @@ async def lifespan(app: FastAPI):
         if task:
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)
+    await close_web_fetch_client()
 
 app = FastAPI(title="HyprChat", version="2.0.0", lifespan=lifespan)
 
@@ -310,7 +318,7 @@ app.add_middleware(
     allow_headers=["Authorization", "Content-Type", "X-API-Key"],
 )
 
-HTTP_VERIFY_SSL = os.getenv("HTTP_VERIFY_SSL", "true").lower() == "true"
+HTTP_VERIFY_SSL = config.HTTP_VERIFY_SSL
 http = httpx.AsyncClient(timeout=httpx.Timeout(300.0, connect=10.0), verify=HTTP_VERIFY_SSL)
 
 # Workspace helpers only do short classification/title/suggestion work. Keep
@@ -348,6 +356,9 @@ class ChatRequest(BaseModel):
     # Optional workspace context. When memory is enabled for this workspace, the
     # chat agent injects accepted workspace memories and queues new suggestions.
     workspace_id: Optional[str] = None
+    # Optional global HyprChat memory context. When true, the chat agent injects
+    # accepted user-profile/global memories and queues new suggestions.
+    use_memories: Optional[bool] = None
     # Ghost/private mode. When true, this stream must not persist messages,
     # workspace memories, token usage, or RAG/research memory for the turn.
     ephemeral: bool = False
@@ -386,6 +397,7 @@ class ConversationCreate(BaseModel):
     model: str = config.DEFAULT_MODEL
     system_prompt: str = ""
     model_config_id: Optional[str] = None
+    use_memories: Optional[str] = "0"
 
 class ConversationUpdate(BaseModel):
     title: Optional[str] = None
@@ -398,6 +410,7 @@ class ConversationUpdate(BaseModel):
     council_config_id: Optional[str] = None
     model_config_id: Optional[str] = None
     pinned: Optional[str] = None
+    use_memories: Optional[str] = None
 
 class CouncilCreate(BaseModel):
     name: str = "My Council"
@@ -1665,7 +1678,7 @@ async def cancel_coder_workflow(workflow_id: str):
 @app.post("/api/conversations")
 async def create_conversation(req: ConversationCreate):
     id = f"conv-{uuid.uuid4().hex[:12]}"
-    await db.create_conversation(id, req.title, req.model, req.system_prompt, req.model_config_id)
+    await db.create_conversation(id, req.title, req.model, req.system_prompt, req.model_config_id, req.use_memories or "0")
     return {"id": id, **req.model_dump()}
 
 
@@ -2470,6 +2483,202 @@ def _extract_memory_json_array(text: str) -> list:
         return data if isinstance(data, list) else []
     except Exception:
         return []
+
+
+def _looks_like_secret_memory(text: str) -> bool:
+    return bool(re.search(r"(password|api[_ -]?key|secret|private key|token)\s*[:=]", text or "", re.I))
+
+
+@app.get("/api/memory/profile")
+async def get_memory_profile_ep():
+    return await db.get_user_profile()
+
+
+@app.patch("/api/memory/profile")
+async def update_memory_profile_ep(body: dict = Body(...)):
+    return await db.update_user_profile(**body)
+
+
+@app.get("/api/memory/memories")
+async def list_global_memories_ep(
+    status: str = Query("all"),
+    type: str = Query("all"),
+):
+    memories = await db.list_global_memories(
+        status=status,
+        memory_type=type,
+        include_archived=True,
+    )
+    return {"memories": memories}
+
+
+@app.post("/api/memory/memories")
+async def create_global_memory_ep(body: dict = Body(...)):
+    try:
+        mem = await db.create_global_memory(
+            content=body.get("content", ""),
+            memory_type=body.get("type", "semantic"),
+            status=body.get("status", "suggested"),
+            category=body.get("category", "General"),
+            importance=body.get("importance", 3),
+            pinned=body.get("pinned", 0),
+            source_conv_id=body.get("source_conv_id") or body.get("source_conversation_id"),
+            source_conversation_id=body.get("source_conversation_id") or body.get("source_conv_id"),
+            source_message_id=body.get("source_message_id"),
+            confidence=body.get("confidence", 0),
+            valid_from=body.get("valid_from"),
+            valid_until=body.get("valid_until"),
+            supersedes_id=body.get("supersedes_id"),
+            entities=body.get("entities") or [],
+            metadata=body.get("metadata") or {},
+        )
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    return mem
+
+
+@app.patch("/api/memory/memories/{memory_id}")
+async def update_global_memory_ep(memory_id: str, body: dict = Body(...)):
+    mem = await db.update_global_memory(memory_id, **body)
+    if not mem:
+        raise HTTPException(404, "Memory not found")
+    return mem
+
+
+@app.delete("/api/memory/memories/{memory_id}")
+async def delete_global_memory_ep(memory_id: str):
+    ok = await db.delete_global_memory(memory_id)
+    if not ok:
+        raise HTTPException(404, "Memory not found")
+    return {"ok": True}
+
+
+@app.post("/api/memory/memories/{memory_id}/accept")
+async def accept_global_memory_ep(memory_id: str, body: dict = Body(default={})):
+    mem = await db.accept_global_memory(memory_id, supersedes_id=body.get("supersedes_id"))
+    if not mem:
+        raise HTTPException(404, "Memory not found")
+    return mem
+
+
+@app.post("/api/memory/memories/{memory_id}/reject")
+async def reject_global_memory_ep(memory_id: str):
+    mem = await db.reject_global_memory(memory_id)
+    if not mem:
+        raise HTTPException(404, "Memory not found")
+    return mem
+
+
+@app.post("/api/memory/suggest")
+async def suggest_global_memories_ep(body: dict = Body(default={})):
+    conv_id = body.get("conversation_id")
+    conv_refs = []
+    if conv_id:
+        conv_refs = [{"id": conv_id}]
+    else:
+        conv_refs = [
+            c for c in await db.get_conversations(limit=20)
+            if str(c.get("use_memories") or "0").lower() in {"1", "true", "yes", "on"}
+        ][:4]
+
+    transcript_parts = []
+    for conv_ref in conv_refs:
+        conv = await db.get_conversation(conv_ref.get("id", ""))
+        if not conv:
+            continue
+        bits = [f"Conversation: {conv.get('title') or conv.get('id')}"]
+        for msg in (conv.get("messages") or [])[-10:]:
+            if msg.get("role") not in {"user", "assistant"}:
+                continue
+            meta = msg.get("metadata") or {}
+            if meta.get("persona_first_message"):
+                continue
+            content = (msg.get("content") or "").strip()
+            if not content:
+                continue
+            role = "User" if msg.get("role") == "user" else "Assistant"
+            bits.append(f"{role}: {content[:2500]}")
+        if len(bits) > 1:
+            transcript_parts.append("\n".join(bits))
+
+    transcript = "\n\n---\n\n".join(transcript_parts)[:18000]
+    if len(transcript) < 80:
+        return {"created": 0, "memories": [], "message": "No recent memory-enabled chat content to scan."}
+
+    profile = await db.get_user_profile()
+    profile_hint = json.dumps({
+        "display_name": profile.get("display_name", ""),
+        "interests": profile.get("interests", []),
+        "bio": profile.get("bio", ""),
+    }, ensure_ascii=False)[:2000]
+    model = body.get("model") or getattr(config, "WORKSPACE_MODEL", "") or config.DEFAULT_MODEL
+    prompt = (
+        "You extract useful long-term personal memories for a cross-chat AI assistant.\n"
+        "Return ONLY a JSON array with 0-8 objects. Do not include markdown.\n"
+        "Each object shape:\n"
+        "{\"type\":\"semantic|episodic|procedural\",\"content\":\"one durable memory\","
+        "\"importance\":1-5,\"confidence\":0-1,\"entities\":[\"short names\"],"
+        "\"reason\":\"why it should be remembered\"}\n\n"
+        "Rules:\n"
+        "- Suggest only durable information useful across many future chats.\n"
+        "- Good semantic memories include user preferences, personal background, important people, birthdays, interests, names, and stable constraints.\n"
+        "- Good episodic memories include dated user-confirmed events, decisions, or outcomes.\n"
+        "- Good procedural memories include reusable workflows or recurring user instructions.\n"
+        "- Do not save secrets, credentials, private keys, passwords, raw tokens, or credential-bearing URLs.\n"
+        "- Do not infer sensitive facts; only save what the user clearly states or confirms.\n"
+        "- Do not save generic assistant claims or one-off trivia.\n"
+        "- Prefer fewer high-value memories over many weak ones.\n\n"
+        f"Existing user profile summary: {profile_hint}\n\n{transcript}"
+    )
+
+    try:
+        r = await http.post(
+            f"{config.OLLAMA_URL}/api/generate",
+            json={
+                "model": model,
+                "prompt": prompt,
+                "stream": False,
+                "think": False,
+                "options": {"temperature": 0.1, "num_ctx": _WORKSPACE_HELPER_NUM_CTX, "num_predict": 900},
+            },
+            timeout=60,
+        )
+        if r.status_code != 200:
+            detail = r.text[:240] if r.text else f"HTTP {r.status_code}"
+            raise HTTPException(r.status_code, f"Ollama error ({model}): {detail}")
+        suggestions = _extract_memory_json_array(r.json().get("response", ""))
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(500, f"Memory scan failed: {e}")
+
+    existing = await db.list_global_memories(status="all")
+    existing_norm = {re.sub(r"\s+", " ", (m.get("content") or "").strip().lower()) for m in existing}
+    created = []
+    for item in suggestions[:8]:
+        if not isinstance(item, dict):
+            continue
+        content = re.sub(r"\s+", " ", str(item.get("content") or "").strip())
+        if len(content) < 12 or len(content) > 800:
+            continue
+        norm = content.lower()
+        if norm in existing_norm or _looks_like_secret_memory(content):
+            continue
+        mem = await db.create_global_memory(
+            content=content,
+            memory_type=item.get("type", "semantic"),
+            status="suggested",
+            importance=item.get("importance", 3),
+            source_conv_id=conv_id,
+            source_conversation_id=conv_id,
+            confidence=item.get("confidence", 0),
+            entities=item.get("entities") if isinstance(item.get("entities"), list) else [],
+            metadata={"reason": item.get("reason", ""), "suggested_by": "global_scan", "model": model},
+        )
+        existing_norm.add(norm)
+        created.append(mem)
+
+    return {"created": len(created), "memories": created}
 
 
 @app.get("/api/workspaces/{ws_id}/memories")
@@ -3321,7 +3530,8 @@ async def img_proxy(u: str):
     if parsed.scheme not in ("http", "https") or not parsed.netloc:
         raise HTTPException(status_code=400, detail="bad url")
     try:
-        r = await http.get(
+        r = await web_get(
+            http,
             u, timeout=8, follow_redirects=True,
             headers={
                 "User-Agent": "Mozilla/5.0 (compatible; image-proxy)",

--- a/backend/main.py
+++ b/backend/main.py
@@ -345,6 +345,12 @@ class ChatRequest(BaseModel):
     # Metadata for the latest user message (e.g. {"images":[{name,dataUrl,mime}], "pdfs":[...]})
     # so image previews survive page reload.
     user_metadata: Optional[dict] = None
+    # Optional workspace context. When memory is enabled for this workspace, the
+    # chat agent injects accepted workspace memories and queues new suggestions.
+    workspace_id: Optional[str] = None
+    # Ghost/private mode. When true, this stream must not persist messages,
+    # workspace memories, token usage, or RAG/research memory for the turn.
+    ephemeral: bool = False
 
 class ExecuteRequest(BaseModel):
     conversation_id: Optional[str] = None
@@ -2452,6 +2458,223 @@ async def add_research_report_to_ws(ws_id: str, body: dict = Body(...)):
 async def remove_research_report_from_ws(ws_id: str, report_id: str):
     await db.remove_research_report_from_workspace(ws_id, report_id)
     return {"ok": True}
+
+
+def _extract_memory_json_array(text: str) -> list:
+    raw = re.sub(r"<think>.*?</think>", "", text or "", flags=re.DOTALL).strip()
+    start, end = raw.find("["), raw.rfind("]")
+    if start == -1 or end <= start:
+        return []
+    try:
+        data = json.loads(raw[start:end + 1])
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+
+@app.get("/api/workspaces/{ws_id}/memories")
+async def list_workspace_memories_ep(
+    ws_id: str,
+    status: str = Query("all"),
+    type: str = Query("all"),
+):
+    if not await db.get_workspace_basic(ws_id):
+        raise HTTPException(404, "Workspace not found")
+    memories = await db.list_workspace_memories(
+        ws_id,
+        status=status,
+        memory_type=type,
+        include_archived=True,
+    )
+    return {"memories": memories}
+
+
+@app.post("/api/workspaces/{ws_id}/memories/suggest")
+async def suggest_workspace_memories_ep(ws_id: str, body: dict = Body(default={})):
+    ws = await db.get_workspace(ws_id)
+    if not ws:
+        raise HTTPException(404, "Workspace not found")
+
+    conv_id = body.get("conversation_id")
+    conv_refs = []
+    if conv_id:
+        conv_refs = [{"id": conv_id}]
+    else:
+        conv_refs = sorted(
+            ws.get("conversations", []),
+            key=lambda c: c.get("updated_at") or "",
+            reverse=True,
+        )[:4]
+
+    transcript_parts = []
+    for conv_ref in conv_refs:
+        conv = await db.get_conversation(conv_ref.get("id", ""))
+        if not conv:
+            continue
+        bits = [f"Conversation: {conv.get('title') or conv.get('id')}"]
+        for msg in (conv.get("messages") or [])[-8:]:
+            if msg.get("role") not in {"user", "assistant"}:
+                continue
+            meta = msg.get("metadata") or {}
+            if meta.get("persona_first_message"):
+                continue
+            content = (msg.get("content") or "").strip()
+            if not content:
+                continue
+            role = "User" if msg.get("role") == "user" else "Assistant"
+            bits.append(f"{role}: {content[:2500]}")
+        if len(bits) > 1:
+            transcript_parts.append("\n".join(bits))
+
+    transcript = "\n\n---\n\n".join(transcript_parts)[:18000]
+    if len(transcript) < 80:
+        return {"created": 0, "memories": [], "message": "No recent workspace chat content to scan."}
+
+    model = body.get("model") or getattr(config, "WORKSPACE_MODEL", "") or config.DEFAULT_MODEL
+    prompt = (
+        "You extract useful long-term workspace memories from recent chat transcript.\n"
+        "Return ONLY a JSON array with 0-8 objects. Do not include markdown.\n"
+        "Each object shape:\n"
+        "{\"type\":\"semantic|episodic|procedural\",\"content\":\"one durable memory\","
+        "\"importance\":1-5,\"confidence\":0-1,\"entities\":[\"short names\"],"
+        "\"reason\":\"why it should be remembered\"}\n\n"
+        "Rules:\n"
+        "- Suggest only durable, reusable information for this workspace.\n"
+        "- semantic = stable facts/preferences/constraints.\n"
+        "- episodic = dated decisions, outcomes, blockers, or events.\n"
+        "- procedural = repeatable workflows, commands, deployment steps, lessons learned.\n"
+        "- Do not save secrets, credentials, private keys, passwords, or raw tokens.\n"
+        "- Do not save generic facts that are obvious from the chat app.\n"
+        "- Prefer fewer high-value memories over many weak ones.\n\n"
+        f"Workspace: {ws.get('name') or ws_id}\n\n{transcript}"
+    )
+
+    try:
+        r = await http.post(
+            f"{config.OLLAMA_URL}/api/generate",
+            json={
+                "model": model,
+                "prompt": prompt,
+                "stream": False,
+                "think": False,
+                "options": {"temperature": 0.1, "num_ctx": _WORKSPACE_HELPER_NUM_CTX, "num_predict": 900},
+            },
+            timeout=60,
+        )
+        if r.status_code != 200:
+            detail = r.text[:240] if r.text else f"HTTP {r.status_code}"
+            raise HTTPException(r.status_code, f"Ollama error ({model}): {detail}")
+        suggestions = _extract_memory_json_array(r.json().get("response", ""))
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(500, f"Memory scan failed: {e}")
+
+    existing = await db.list_workspace_memories(ws_id, status="all")
+    existing_norm = {re.sub(r"\s+", " ", (m.get("content") or "").strip().lower()) for m in existing}
+    created = []
+    for item in suggestions[:8]:
+        if not isinstance(item, dict):
+            continue
+        content = re.sub(r"\s+", " ", str(item.get("content") or "").strip())
+        if len(content) < 12 or len(content) > 800:
+            continue
+        norm = content.lower()
+        if norm in existing_norm:
+            continue
+        if re.search(r"(password|api[_ -]?key|secret|private key|token)\s*[:=]", content, re.I):
+            continue
+        mem = await db.create_workspace_memory(
+            ws_id,
+            content=content,
+            memory_type=item.get("type", "semantic"),
+            status="suggested",
+            importance=item.get("importance", 3),
+            source_conv_id=conv_id,
+            source_conversation_id=conv_id,
+            confidence=item.get("confidence", 0),
+            entities=item.get("entities") if isinstance(item.get("entities"), list) else [],
+            metadata={"reason": item.get("reason", ""), "suggested_by": "workspace_scan", "model": model},
+        )
+        existing_norm.add(norm)
+        created.append(mem)
+
+    return {"created": len(created), "memories": created}
+
+
+@app.post("/api/workspaces/{ws_id}/memories")
+async def create_workspace_memory_ep(ws_id: str, body: dict = Body(...)):
+    if not await db.get_workspace_basic(ws_id):
+        raise HTTPException(404, "Workspace not found")
+    try:
+        mem = await db.create_workspace_memory(
+            ws_id,
+            content=body.get("content", ""),
+            memory_type=body.get("type", "semantic"),
+            status=body.get("status", "suggested"),
+            category=body.get("category", "General"),
+            importance=body.get("importance", 3),
+            pinned=body.get("pinned", 0),
+            source_conv_id=body.get("source_conv_id") or body.get("source_conversation_id"),
+            source_conversation_id=body.get("source_conversation_id") or body.get("source_conv_id"),
+            source_message_id=body.get("source_message_id"),
+            confidence=body.get("confidence", 0),
+            valid_from=body.get("valid_from"),
+            valid_until=body.get("valid_until"),
+            supersedes_id=body.get("supersedes_id"),
+            entities=body.get("entities") or [],
+            metadata=body.get("metadata") or {},
+        )
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    return mem
+
+
+@app.patch("/api/workspaces/{ws_id}/memories/{memory_id}")
+async def update_workspace_memory_ep(ws_id: str, memory_id: str, body: dict = Body(...)):
+    mem = await db.update_workspace_memory(memory_id, ws_id, **body)
+    if not mem:
+        raise HTTPException(404, "Memory not found")
+    return mem
+
+
+@app.delete("/api/workspaces/{ws_id}/memories/{memory_id}")
+async def delete_workspace_memory_ep(ws_id: str, memory_id: str):
+    ok = await db.delete_workspace_memory(memory_id, ws_id)
+    if not ok:
+        raise HTTPException(404, "Memory not found")
+    return {"ok": True}
+
+
+@app.post("/api/workspaces/{ws_id}/memories/{memory_id}/accept")
+async def accept_workspace_memory_ep(ws_id: str, memory_id: str, body: dict = Body(default={})):
+    mem = await db.accept_workspace_memory(memory_id, ws_id, supersedes_id=body.get("supersedes_id"))
+    if not mem:
+        raise HTTPException(404, "Memory not found")
+    return mem
+
+
+@app.post("/api/workspaces/{ws_id}/memories/{memory_id}/reject")
+async def reject_workspace_memory_ep(ws_id: str, memory_id: str):
+    mem = await db.reject_workspace_memory(memory_id, ws_id)
+    if not mem:
+        raise HTTPException(404, "Memory not found")
+    return mem
+
+
+@app.get("/api/workspaces/{ws_id}/memory-blocks")
+async def get_workspace_memory_blocks_ep(ws_id: str):
+    if not await db.get_workspace_basic(ws_id):
+        raise HTTPException(404, "Workspace not found")
+    return {"blocks": await db.get_workspace_memory_blocks(ws_id)}
+
+
+@app.patch("/api/workspaces/{ws_id}/memory-blocks")
+async def update_workspace_memory_blocks_ep(ws_id: str, body: dict = Body(...)):
+    if not await db.get_workspace_basic(ws_id):
+        raise HTTPException(404, "Workspace not found")
+    blocks = await db.update_workspace_memory_blocks(ws_id, body.get("blocks") or [])
+    return {"blocks": blocks}
 
 
 @app.post("/api/workspaces/{ws_id}/analyze")

--- a/backend/main.py
+++ b/backend/main.py
@@ -315,8 +315,76 @@ app.add_middleware(
     allow_origins=ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type", "X-API-Key"],
+    allow_headers=["Authorization", "Content-Type", "X-API-Key", "X-HyprChat-User", "X-HyprChat-Session"],
 )
+
+_USER_SCOPED_PREFIXES = (
+    "/api/conversations",
+    "/api/chat/stream",
+    "/api/council/chat/stream",
+    "/api/coder",
+    "/api/runs",
+    "/api/knowledge-bases",
+    "/api/tools",
+    "/api/model-configs",
+    "/api/workspaces",
+    "/api/memory",
+    "/api/research/reports",
+    "/api/councils",
+    "/api/analytics",
+    "/api/events",
+)
+
+
+def _request_user_id(request: Request) -> str:
+    raw = (
+        request.headers.get("x-hyprchat-user")
+        or request.query_params.get("user_id")
+        or db.DEFAULT_USER_ID
+    )
+    raw = re.sub(r"[^a-zA-Z0-9_.:-]", "", str(raw or ""))[:80]
+    return raw or db.DEFAULT_USER_ID
+
+
+def _request_session_token(request: Request) -> str:
+    return (
+        request.headers.get("x-hyprchat-session")
+        or request.query_params.get("session")
+        or ""
+    )
+
+
+def _is_user_scoped_path(path: str) -> bool:
+    return any(path.startswith(prefix) for prefix in _USER_SCOPED_PREFIXES)
+
+
+async def _validated_request_user(request: Request) -> dict:
+    user_id = _request_user_id(request)
+    user = await db.get_user_private(user_id)
+    if not user:
+        raise HTTPException(404, "User not found")
+    if user.get("password_hash") and not await db.validate_user_session(user_id, _request_session_token(request)):
+        raise HTTPException(401, "Password required")
+    return user
+
+
+@app.middleware("http")
+async def user_context_middleware(request: Request, call_next):
+    user_id = _request_user_id(request)
+    user = await db.get_user_private(user_id)
+    if not user:
+        user_id = db.DEFAULT_USER_ID
+        user = await db.get_user_private(user_id)
+    valid = True
+    if user and user.get("password_hash"):
+        valid = await db.validate_user_session(user_id, _request_session_token(request))
+    if _is_user_scoped_path(request.url.path) and not valid:
+        return JSONResponse({"detail": "Password required"}, status_code=401)
+    token = db.set_current_user_id(user_id if valid else db.DEFAULT_USER_ID)
+    try:
+        return await call_next(request)
+    finally:
+        db.reset_current_user_id(token)
 
 HTTP_VERIFY_SSL = config.HTTP_VERIFY_SSL
 http = httpx.AsyncClient(timeout=httpx.Timeout(300.0, connect=10.0), verify=HTTP_VERIFY_SSL)
@@ -496,6 +564,82 @@ class ConversationSearchRequest(BaseModel):
 
 class ForkRequest(BaseModel):
     message_id: int
+
+class UserCreate(BaseModel):
+    name: str
+    password: Optional[str] = ""
+
+class UserLogin(BaseModel):
+    user_id: str
+    password: Optional[str] = ""
+
+class UserUpdate(BaseModel):
+    name: Optional[str] = None
+    password: Optional[str] = None
+    clear_password: Optional[bool] = False
+
+
+# ============================================================
+# USERS — lightweight local profile switching
+# ============================================================
+@app.get("/api/users")
+async def list_users_ep():
+    return {"users": await db.list_users()}
+
+
+@app.get("/api/users/current")
+async def current_user_ep(request: Request):
+    user = await _validated_request_user(request)
+    return {"user": await db.get_user(user["id"])}
+
+
+@app.post("/api/users")
+async def create_user_ep(req: UserCreate):
+    user = await db.create_user(req.name, req.password or "")
+    return {"user": user}
+
+
+@app.post("/api/users/login")
+async def login_user_ep(req: UserLogin):
+    user, session_token = await db.login_user(req.user_id, req.password or "")
+    if not user:
+        raise HTTPException(401, "Invalid user or password")
+    return {"user": user, "session_token": session_token}
+
+
+@app.post("/api/users/logout")
+async def logout_user_ep(request: Request):
+    user_id = _request_user_id(request)
+    await db.logout_user_session(user_id, _request_session_token(request) or None)
+    return {"ok": True}
+
+
+@app.patch("/api/users/{user_id}")
+async def update_user_ep(user_id: str, req: UserUpdate, request: Request):
+    current = await _validated_request_user(request)
+    user, _ = await db.update_user(
+        user_id,
+        name=req.name,
+        password=req.password,
+        clear_password=bool(req.clear_password),
+    )
+    if not user:
+        raise HTTPException(404, "User not found")
+    session_token = None
+    if user_id == current["id"] and req.password is not None and not req.clear_password and req.password:
+        session_token = await db.create_user_session(user_id)
+    return {"user": user, "session_token": session_token}
+
+
+@app.delete("/api/users/{user_id}")
+async def delete_user_ep(user_id: str, request: Request):
+    await _validated_request_user(request)
+    if user_id == db.DEFAULT_USER_ID:
+        raise HTTPException(400, "The Main user cannot be deleted")
+    ok = await db.delete_user(user_id)
+    if not ok:
+        raise HTTPException(404, "User not found")
+    return {"ok": True}
 
 
 # ============================================================
@@ -697,9 +841,18 @@ async def chat_stream(req: ChatRequest):
     _all_custom = await db.get_tools()
     custom_tool_map: dict = {t["name"]: t for t in _all_custom}
     custom_tool_id_map: dict = {t["id"]: t for t in _all_custom}
+    user_id = db.current_user_id()
+
+    async def _stream():
+        token = db.set_current_user_id(user_id)
+        try:
+            async for chunk in chat_stream_generate(req, http, events, custom_tool_map, custom_tool_id_map):
+                yield chunk
+        finally:
+            db.reset_current_user_id(token)
 
     return StreamingResponse(
-        chat_stream_generate(req, http, events, custom_tool_map, custom_tool_id_map),
+        _stream(),
         media_type="text/event-stream",
     )
 
@@ -1445,8 +1598,10 @@ async def _create_and_start_research_report(req: ResearchReportCreate) -> dict:
         inputs=req.inputs or [],
         status="queued",
     )
+    user_id = db.current_user_id()
 
     async def _runner():
+        token = db.set_current_user_id(user_id)
         try:
             await run_research_report(
                 http, config.OLLAMA_URL, config.DEFAULT_MODEL, events, report_id,
@@ -1474,6 +1629,8 @@ async def _create_and_start_research_report(req: ResearchReportCreate) -> dict:
                 "timestamp": time.time(),
             })
             await events.emit(report_id, "research_error", {"status": "failed", "error": str(e)})
+        finally:
+            db.reset_current_user_id(token)
 
     asyncio.create_task(_runner())
     return await db.get_research_report(report_id)
@@ -1710,20 +1867,29 @@ async def delete_conversation(conv_id: str):
 
 @app.delete("/api/conversations")
 async def delete_all_conversations():
-    """Delete ALL conversations, messages, and related data."""
+    """Delete all conversations for the active local user/profile."""
     conn = await db.get_db()
+    user_id = db.current_user_id()
     try:
-        await conn.execute("DELETE FROM messages")
-        await conn.execute("DELETE FROM conversation_files")
-        await conn.execute("DELETE FROM workspace_conversations")
-        await conn.execute("DELETE FROM conversations")
+        row = await conn.execute_fetchall("SELECT COUNT(*) AS n FROM conversations WHERE user_id=?", (user_id,))
+        count = row[0]["n"] if row else 0
+        await conn.execute(
+            "DELETE FROM messages WHERE conversation_id IN (SELECT id FROM conversations WHERE user_id=?)",
+            (user_id,),
+        )
+        await conn.execute(
+            "DELETE FROM conversation_files WHERE conversation_id IN (SELECT id FROM conversations WHERE user_id=?)",
+            (user_id,),
+        )
+        await conn.execute(
+            "DELETE FROM workspace_conversations WHERE conversation_id IN (SELECT id FROM conversations WHERE user_id=?)",
+            (user_id,),
+        )
+        await conn.execute("DELETE FROM conversations WHERE user_id=?", (user_id,))
         await conn.commit()
-        cursor = await conn.execute("SELECT changes()")
-        row = await cursor.fetchone()
-        count = row[0] if row else 0
     finally:
         await conn.close()
-    print(f"[Cleanup] Deleted all conversations and related data")
+    print(f"[Cleanup] Deleted {count} conversations and related data for user {user_id}")
     return {"deleted": count}
 
 
@@ -1802,6 +1968,9 @@ async def update_kb(kb_id: str, req: KBCreate):
 
 @app.delete("/api/knowledge-bases/{kb_id}")
 async def delete_kb(kb_id: str):
+    owned = next((k for k in await db.get_kbs() if k["id"] == kb_id), None)
+    if not owned:
+        raise HTTPException(404, "KB not found")
     kb_dir = os.path.join(config.KB_DIR, kb_id)
     if os.path.exists(kb_dir):
         shutil.rmtree(kb_dir)
@@ -1820,6 +1989,9 @@ _indexing_status: dict[str, dict] = {}  # key: "kb_id:filename" → status dict
 
 @app.post("/api/knowledge-bases/{kb_id}/files")
 async def upload_kb_file(kb_id: str, file: UploadFile = File(...)):
+    owned = next((k for k in await db.get_kbs() if k["id"] == kb_id), None)
+    if not owned:
+        raise HTTPException(404, "KB not found")
     kb_dir = os.path.join(config.KB_DIR, kb_id)
     os.makedirs(kb_dir, exist_ok=True)
 
@@ -1859,6 +2031,9 @@ async def upload_kb_file(kb_id: str, file: UploadFile = File(...)):
 @app.get("/api/knowledge-bases/{kb_id}/files/{filename}/status")
 async def get_file_index_status(kb_id: str, filename: str):
     """Check background indexing status for a file."""
+    owned = next((k for k in await db.get_kbs() if k["id"] == kb_id), None)
+    if not owned:
+        raise HTTPException(404, "KB not found")
     status_key = f"{kb_id}:{filename}"
     status = _indexing_status.get(status_key)
     if status:
@@ -1872,9 +2047,15 @@ async def get_file_index_status(kb_id: str, filename: str):
 @app.get("/api/knowledge-bases/{kb_id}/files/{file_id}/preview")
 async def preview_kb_file(kb_id: str, file_id: int, lines: int = 200):
     """Preview first N lines of a KB file."""
+    user_id = db.current_user_id()
     _db = await db.get_db()
     try:
-        cursor = await _db.execute("SELECT filename FROM kb_files WHERE id = ? AND kb_id = ?", (file_id, kb_id))
+        cursor = await _db.execute(
+            """SELECT f.filename FROM kb_files f
+               JOIN knowledge_bases kb ON kb.id=f.kb_id
+               WHERE f.id=? AND f.kb_id=? AND kb.user_id=?""",
+            (file_id, kb_id, user_id),
+        )
         row = await cursor.fetchone()
     finally:
         await _db.close()
@@ -1900,9 +2081,15 @@ async def preview_kb_file(kb_id: str, file_id: int, lines: int = 200):
 @app.get("/api/knowledge-bases/{kb_id}/files/{file_id}/pdf-text")
 async def pdf_text_preview(kb_id: str, file_id: int, pages: int = 10):
     """Extract text from first N pages of a PDF for quick preview."""
+    user_id = db.current_user_id()
     _db = await db.get_db()
     try:
-        cursor = await _db.execute("SELECT filename FROM kb_files WHERE id = ? AND kb_id = ?", (file_id, kb_id))
+        cursor = await _db.execute(
+            """SELECT f.filename FROM kb_files f
+               JOIN knowledge_bases kb ON kb.id=f.kb_id
+               WHERE f.id=? AND f.kb_id=? AND kb.user_id=?""",
+            (file_id, kb_id, user_id),
+        )
         row = await cursor.fetchone()
     finally:
         await _db.close()
@@ -1961,9 +2148,15 @@ async def extract_pdf(file: UploadFile = File(...)):
 @app.get("/api/knowledge-bases/{kb_id}/files/{file_id}/raw")
 async def raw_kb_file(kb_id: str, file_id: int):
     """Serve a KB file raw (for PDF/image preview in browser)."""
+    user_id = db.current_user_id()
     _db = await db.get_db()
     try:
-        cursor = await _db.execute("SELECT filename FROM kb_files WHERE id = ? AND kb_id = ?", (file_id, kb_id))
+        cursor = await _db.execute(
+            """SELECT f.filename FROM kb_files f
+               JOIN knowledge_bases kb ON kb.id=f.kb_id
+               WHERE f.id=? AND f.kb_id=? AND kb.user_id=?""",
+            (file_id, kb_id, user_id),
+        )
         row = await cursor.fetchone()
     finally:
         await _db.close()
@@ -1982,12 +2175,20 @@ async def raw_kb_file(kb_id: str, file_id: int):
 @app.delete("/api/knowledge-bases/files/{file_id}")
 async def delete_kb_file(file_id: int):
     # Get file info before deleting so we can remove from RAG index
+    user_id = db.current_user_id()
     _db = await db.get_db()
     try:
-        cursor = await _db.execute("SELECT kb_id, filename FROM kb_files WHERE id = ?", (file_id,))
+        cursor = await _db.execute(
+            """SELECT f.kb_id, f.filename FROM kb_files f
+               JOIN knowledge_bases kb ON kb.id=f.kb_id
+               WHERE f.id=? AND kb.user_id=?""",
+            (file_id, user_id),
+        )
         row = await cursor.fetchone()
     finally:
         await _db.close()
+    if not row:
+        raise HTTPException(404, "File not found")
 
     await db.delete_kb_file(file_id)
 
@@ -2373,6 +2574,9 @@ async def fix_model_template(model_name: str, body: dict = Body(default={})):
 @app.post("/api/model-configs/{mc_id}/avatar")
 async def upload_persona_avatar(mc_id: str, file: UploadFile = File(...)):
     """Upload an avatar image for a persona/model config."""
+    existing = await db.get_model_config(mc_id)
+    if not existing:
+        raise HTTPException(404, "Model config not found")
     avatar_dir = os.path.join(config.UPLOAD_DIR, "avatars")
     os.makedirs(avatar_dir, exist_ok=True)
 
@@ -2387,7 +2591,6 @@ async def upload_persona_avatar(mc_id: str, file: UploadFile = File(...)):
     with open(avatar_path, "wb") as f:
         f.write(content)
 
-    existing = await db.get_model_config(mc_id)
     params = existing.get("parameters", {}) if existing else {}
     await db.update_model_config(mc_id, parameters={**params, "avatar": f"/api/avatars/{mc_id}.{ext}"})
     return {"avatar_url": f"/api/avatars/{mc_id}.{ext}"}
@@ -3508,9 +3711,18 @@ async def council_chat_stream_ep(req: CouncilChatRequest):
 
     # Merge kb_ids from council config and request
     kb_ids = list(set((council.get("kb_ids") or []) + (req.kb_ids or [])))
+    user_id = db.current_user_id()
+
+    async def _stream():
+        token = db.set_current_user_id(user_id)
+        try:
+            async for chunk in stream_council_chat(http, events, council, req.messages, req.conversation_id, req.quick_search, kb_ids=kb_ids):
+                yield chunk
+        finally:
+            db.reset_current_user_id(token)
 
     return StreamingResponse(
-        stream_council_chat(http, events, council, req.messages, req.conversation_id, req.quick_search, kb_ids=kb_ids),
+        _stream(),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
     )

--- a/backend/quick_search.py
+++ b/backend/quick_search.py
@@ -950,7 +950,29 @@ def _format_now() -> str:
         return datetime.now().strftime("%Y-%m-%d %H:%M")
 
 
-def _strict_day_evidence(results: list, plan=None) -> bool:
+def _has_same_day_text_evidence(text: str, target: date) -> bool:
+    if not text:
+        return False
+    low = text.lower()
+    markers = {
+        target.isoformat().lower(),
+        f"{target.strftime('%B')} {target.day}, {target.year}".lower(),
+        f"{target.strftime('%B')} {target.day} {target.year}".lower(),
+        f"{target.strftime('%b')} {target.day}, {target.year}".lower(),
+        f"{target.strftime('%b')} {target.day} {target.year}".lower(),
+    }
+    if any(marker in low for marker in markers):
+        return True
+    if re.search(
+        r"\b(today|this morning|this afternoon|this evening|"
+        r"\d+\s+(?:minutes?|hours?)\s+ago)\b",
+        low,
+    ):
+        return True
+    return str(target.year) in low and bool(re.search(r"\blive updates?\b", low))
+
+
+def _strict_day_evidence(results: list, plan=None, page_text: dict[str, str] | None = None) -> bool:
     if _plan_get(plan, "freshness_mode", "none") != "day":
         return True
     resolved = _plan_get(plan, "resolved_date", None)
@@ -960,6 +982,14 @@ def _strict_day_evidence(results: list, plan=None) -> bool:
     for r in results:
         published = _result_published_date(r)
         if published and published == target:
+            return True
+        url = r.get("url") or ""
+        result_text = " ".join([
+            r.get("title") or "",
+            r.get("content") or r.get("snippet") or "",
+            page_text.get(url, "") if page_text else "",
+        ])
+        if _has_same_day_text_evidence(result_text, target):
             return True
     return False
 
@@ -995,7 +1025,7 @@ def _build_context(
     ]
     if searxng_engines:
         lines.insert(-1, f"SearXNG engines: {searxng_engines}")
-    if freshness_mode == "day" and not _strict_day_evidence(results, plan):
+    if freshness_mode == "day" and not _strict_day_evidence(results, plan, page_text):
         lines += [
             "FRESHNESS WARNING:",
             f"- These sources do not prove activity on {resolved}.",

--- a/backend/quick_search.py
+++ b/backend/quick_search.py
@@ -31,7 +31,7 @@ from datetime import date, datetime
 from email.utils import parsedate_to_datetime
 
 import config
-from research import _search_searxng, _rank_urls
+from research import _search_searxng, _rank_urls, web_get
 
 
 # ── 10-min TTL cache, keyed by (query, time_range, categories, engines), bounded LRU ──
@@ -813,7 +813,8 @@ async def _fetch_clean_page(http, url: str) -> dict | None:
         return None
     try:
         async with _FETCH_SEMA:
-            r = await http.get(
+            r = await web_get(
+                http,
                 url, timeout=15, follow_redirects=True,
                 headers={"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
                                        "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"},
@@ -1153,7 +1154,8 @@ async def _fetch_og_image(http, page_url: str) -> str:
         return ""
     try:
         async with _FETCH_SEMA:
-            resp = await http.get(
+            resp = await web_get(
+                http,
                 page_url, timeout=6, follow_redirects=True,
                 headers={
                     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "

--- a/backend/research.py
+++ b/backend/research.py
@@ -13,6 +13,52 @@ import urllib.parse
 from collections import OrderedDict
 from datetime import datetime
 
+import httpx
+
+import config
+
+
+_WEB_FETCH_CLIENT = None
+_WEB_FETCH_CLIENT_PROXY = None
+
+
+def _outbound_proxy_url() -> str:
+    return (getattr(config, "OUTBOUND_PROXY_URL", "") or "").strip()
+
+
+def _web_fetch_client(http):
+    """Return the normal client or a proxy-scoped client for public web fetches."""
+    proxy = _outbound_proxy_url()
+    if not proxy:
+        return http
+    global _WEB_FETCH_CLIENT, _WEB_FETCH_CLIENT_PROXY
+    if _WEB_FETCH_CLIENT is None or _WEB_FETCH_CLIENT_PROXY != proxy:
+        _WEB_FETCH_CLIENT = httpx.AsyncClient(
+            timeout=httpx.Timeout(300.0, connect=10.0),
+            verify=getattr(config, "HTTP_VERIFY_SSL", True),
+            proxy=proxy,
+            trust_env=False,
+        )
+        _WEB_FETCH_CLIENT_PROXY = proxy
+    return _WEB_FETCH_CLIENT
+
+
+async def close_web_fetch_client() -> None:
+    global _WEB_FETCH_CLIENT, _WEB_FETCH_CLIENT_PROXY
+    if _WEB_FETCH_CLIENT is not None:
+        await _WEB_FETCH_CLIENT.aclose()
+    _WEB_FETCH_CLIENT = None
+    _WEB_FETCH_CLIENT_PROXY = None
+
+
+async def web_get(http, url: str, **kwargs):
+    return await _web_fetch_client(http).get(url, **kwargs)
+
+
+def web_stream(http, method: str, url: str, **kwargs):
+    return _web_fetch_client(http).stream(method, url, **kwargs)
+
+
 # ── Search rate-limit tuning ──
 _SEARCH_BATCH_SIZE = 3
 _SEARCH_BATCH_DELAY_DEEP = 2.0          # seconds between batches in deep research
@@ -192,7 +238,8 @@ async def fetch_bytes_safely(
         if not await _url_safe_for_fetch(current, resolve_dns=resolve_dns):
             raise ValueError("Unsafe URL")
 
-        async with http.stream(
+        async with web_stream(
+            http,
             "GET",
             current,
             timeout=timeout,
@@ -351,7 +398,7 @@ async def _search_google_fallback(http, query: str, count: int = 10) -> list:
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             "Accept-Language": "en-US,en;q=0.5",
         }
-        r = await http.get(f"https://www.google.com/search?{params}", timeout=12, headers=headers, follow_redirects=True)
+        r = await web_get(http, f"https://www.google.com/search?{params}", timeout=12, headers=headers, follow_redirects=True)
         if r.status_code != 200:
             return []
         html = r.text
@@ -463,7 +510,8 @@ async def _search_wikileaks(http, searxng_url: str, query: str, count: int = 15)
     results = []
     try:
         params = urllib.parse.urlencode({"query": query, "include_onion": "false"})
-        r = await http.get(
+        r = await web_get(
+            http,
             f"https://search.wikileaks.org/?{params}",
             timeout=15,
             headers={"Accept": "application/json, text/html", "User-Agent": "Mozilla/5.0"},
@@ -644,12 +692,13 @@ async def _fetch_github_repo_snapshot(http, url: str) -> dict | None:
     if token:
         headers["Authorization"] = f"Bearer {token}"
     try:
-        meta_r = await http.get(f"https://api.github.com/repos/{owner}/{name}", headers=headers, timeout=15)
+        meta_r = await web_get(http, f"https://api.github.com/repos/{owner}/{name}", headers=headers, timeout=15)
         if meta_r.status_code >= 400:
             return None
         meta = meta_r.json()
         branch = meta.get("default_branch") or "main"
-        tree_r = await http.get(
+        tree_r = await web_get(
+            http,
             f"https://api.github.com/repos/{owner}/{name}/git/trees/{urllib.parse.quote(branch, safe='')}?recursive=1",
             headers=headers,
             timeout=20,
@@ -671,7 +720,7 @@ async def _fetch_github_repo_snapshot(http, url: str) -> dict | None:
             file_url = f"https://api.github.com/repos/{owner}/{name}/contents/{urllib.parse.quote(path, safe='/')}"
             try:
                 file_headers = {**headers, "Accept": "application/vnd.github.raw"}
-                fr = await http.get(file_url, params={"ref": branch}, headers=file_headers, timeout=15)
+                fr = await web_get(http, file_url, params={"ref": branch}, headers=file_headers, timeout=15)
                 if fr.status_code >= 400:
                     continue
                 text = fr.text
@@ -719,8 +768,8 @@ async def _fetch_page(http, url: str) -> dict | None:
     if not await _url_safe_for_fetch(url, resolve_dns=False):
         return None
     try:
-        r = await http.get(url, timeout=15, follow_redirects=True,
-                           headers={"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"})
+        r = await web_get(http, url, timeout=15, follow_redirects=True,
+                          headers={"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"})
         if r.status_code >= 400:
             return None
         final_url = str(getattr(r, "url", "") or url)
@@ -757,8 +806,8 @@ async def _fetch_gov_doc_index(http, url: str) -> dict | None:
     if not await _url_safe_for_fetch(url, resolve_dns=False):
         return None
     try:
-        r = await http.get(url, timeout=15, follow_redirects=True,
-                           headers={"User-Agent": "Mozilla/5.0 (compatible; research-bot)"})
+        r = await web_get(http, url, timeout=15, follow_redirects=True,
+                          headers={"User-Agent": "Mozilla/5.0 (compatible; research-bot)"})
         final_url = str(getattr(r, "url", "") or url)
         if not await _url_safe_for_fetch(final_url, resolve_dns=False):
             return None
@@ -840,8 +889,8 @@ async def _fetch_wikileaks_page(http, url: str) -> dict | None:
     if ".pdf" in lower:
         return {"url": url, "content": f"[PDF document — direct download: {url}]"}
     try:
-        r = await http.get(url, timeout=15, follow_redirects=True,
-                           headers={"User-Agent": "Mozilla/5.0 (compatible; research-bot)"})
+        r = await web_get(http, url, timeout=15, follow_redirects=True,
+                          headers={"User-Agent": "Mozilla/5.0 (compatible; research-bot)"})
         if r.status_code != 200:
             return None
         final_url = str(getattr(r, "url", "") or url)
@@ -2039,7 +2088,6 @@ async def run_research_report(
     This is intentionally additive. `run_deep_research` below keeps the existing
     tool contract used by chat agents and Daedalus.
     """
-    import config
     import database as db
     import rag
     import cancel_registry

--- a/backend/search_agent.py
+++ b/backend/search_agent.py
@@ -187,6 +187,16 @@ _QUESTION_PREFIX_RE = re.compile(
     r"tell me about|give me|show me|find|search for|look up)\s+",
     re.IGNORECASE,
 )
+_EVENT_FILLER_RE = re.compile(
+    r"\b(?:that\s+)?(?:just\s+)?(?:took|takes|taking)\s+place\b|"
+    r"\b(?:happened|happening|going\s+on)\b|"
+    r"\b(?:just|earlier|later|currently|current|latest|recent|recently)\b",
+    re.IGNORECASE,
+)
+_RELATIVE_DAY_RE = re.compile(
+    r"\b(today|tonight|this morning|this afternoon|this evening|yesterday)\b",
+    re.IGNORECASE,
+)
 
 
 def _clean_query_phrase(text: str) -> str:
@@ -201,12 +211,34 @@ def _clean_query_phrase(text: str) -> str:
     return q or (text or "").strip()[:120]
 
 
+def _clean_fresh_subject_phrase(text: str) -> str:
+    q = _clean_query_phrase(text)
+    q = _EVENT_FILLER_RE.sub(" ", q)
+    q = _RELATIVE_DAY_RE.sub(" ", q)
+    q = re.sub(r"\b(news|updates?)\b", " ", q, flags=re.I)
+    q = re.sub(r"\s+", " ", q).strip()
+    return q or _clean_query_phrase(text)
+
+
+def _year_from_resolved_label(resolved_label: str) -> str:
+    m = re.search(r"\b(19\d{2}|20\d{2}|21\d{2})\b", resolved_label or "")
+    return m.group(1) if m else str(datetime.now().year)
+
+
 def _query_variants(base: str, category: str, freshness_mode: str, resolved_label: str, max_queries: int) -> list[str]:
     base = _clean_query_phrase(base)
-    variants = [base]
+    subject = _clean_fresh_subject_phrase(base) if freshness_mode == "day" else base
+    variants = [subject]
     if freshness_mode == "day":
-        dated = _clean_query_phrase(f"{base} {resolved_label}") if resolved_label else base
-        variants = [dated, _clean_query_phrase(f"{base} today"), _clean_query_phrase(f"{base} news")]
+        year = _year_from_resolved_label(resolved_label)
+        dated = _clean_query_phrase(f"{subject} {resolved_label}") if resolved_label else subject
+        year_query = _clean_query_phrase(f"{subject} {year}") if year and year not in subject else subject
+        variants = [
+            year_query,
+            dated,
+            _clean_query_phrase(f"{subject} today"),
+            _clean_query_phrase(f"{subject} news"),
+        ]
     elif category == "news":
         variants = [base]
         low = f" {base.lower()} "
@@ -339,19 +371,35 @@ async def _search_provider(http, plan: SearchPlan, queries: list[str]) -> tuple[
     count = _search_count_for_plan(plan, len(queries))
     categories = _searxng_categories(plan.category, plan.freshness_mode)
     engines = plan.searxng_engines or None
+    attempts: list[tuple[str, int, str | None, str, str | None]] = [
+        (q, count, plan.time_range, categories, engines)
+        for q in queries
+    ]
+    if plan.freshness_mode == "day":
+        # SearXNG's news category and per-engine day filters can miss
+        # same-day tech/event pages until they receive date metadata. Keep the
+        # strict news/day pass, but add a small general-web fallback so pages
+        # like live blogs, official event pages, and tech coverage can surface.
+        fallback_count = max(8, min(count, plan.min_results))
+        general_engines = (getattr(config, "QUICK_SEARCH_SEARXNG_ENGINES", "") or "").strip() or None
+        for q in queries[:2]:
+            attempts.append((q, fallback_count, "day", "general", general_engines))
+            attempts.append((q, fallback_count, None, "general", general_engines))
+
     raw_lists = await asyncio.gather(
         *[
             _qs._cached_search(
-                http, q, count=count, time_range=plan.time_range,
-                categories=categories, engines=engines,
+                http, q, count=attempt_count, time_range=time_range,
+                categories=attempt_categories, engines=attempt_engines,
             )
-            for q in queries
+            for q, attempt_count, time_range, attempt_categories, attempt_engines in attempts
         ],
         return_exceptions=True,
     )
     errors = sum(1 for r in raw_lists if isinstance(r, Exception))
     usable: list[list] = []
-    for q, result in zip(queries, raw_lists):
+    for attempt, result in zip(attempts, raw_lists):
+        q, _, time_range, attempt_categories, _ = attempt
         if not isinstance(result, list):
             continue
         tagged = []
@@ -360,6 +408,8 @@ async def _search_provider(http, plan: SearchPlan, queries: list[str]) -> tuple[
                 continue
             copied = dict(item)
             copied.setdefault("query_origin", q)
+            copied.setdefault("search_time_range", time_range or "")
+            copied.setdefault("search_categories", attempt_categories)
             tagged.append(copied)
         usable.append(tagged)
     return _merge_unique(usable), errors

--- a/backend/tests/test_search_agent.py
+++ b/backend/tests/test_search_agent.py
@@ -401,11 +401,49 @@ def test_run_search_agent_today_uses_day_freshness_and_resolved_date():
 
     search_events = [d for _, evt, d in events.items if evt == "search_results"]
     assert out["skipped"] is False
-    assert {c.kwargs["time_range"] for c in mock_search.await_args_list} == {"day"}
-    assert {c.kwargs["categories"] for c in mock_search.await_args_list} == {"news"}
+    assert {c.kwargs["time_range"] for c in mock_search.await_args_list} == {"day", None}
+    assert {c.kwargs["categories"] for c in mock_search.await_args_list} == {"news", "general"}
     assert search_events[-1]["resolved_date"] == "2026-06-05"
     assert search_events[-1]["freshness_mode"] == "day"
     assert "Resolved date: 2026-06-05" in out["context"]
+    assert "FRESHNESS WARNING" not in out["context"]
+
+
+def test_run_search_agent_today_event_query_uses_general_web_fallback():
+    http = _FakeHTTP([])
+    messages = [{"role": "user", "content": "tell me about wwdc that just took place today"}]
+    captured: list[tuple[str, str | None, str]] = []
+
+    async def fake_cached_search(http, query, count=10, time_range=None, categories="general", engines=None):
+        captured.append((query, time_range, categories))
+        if categories == "general" and time_range is None and query == "wwdc 2026":
+            return [
+                {
+                    "title": "WWDC 2026 announcements live updates",
+                    "url": "https://example.com/wwdc-2026-live",
+                    "content": "Apple WWDC 2026 announcements from today's keynote",
+                    "engine": "test",
+                    "score": 80,
+                    "type": "web",
+                }
+            ]
+        return []
+
+    with patch.object(search_agent, "datetime", _FixedDateTime), \
+         patch.object(quick_search, "_cached_search", new=fake_cached_search), \
+         patch.object(quick_search, "_enrich_with_pages", new=AsyncMock(return_value={})), \
+         patch.object(quick_search, "_enrich_og_images", new=AsyncMock(return_value=None)):
+        out = _run(search_agent.run_search_agent(
+            http, "http://ollama", "test-model", "test-model",
+            events=None, conv_id="conv-wwdc", messages=messages,
+        ))
+
+    assert out["skipped"] is False
+    assert out["reason"] == ""
+    assert any(q == "wwdc 2026" and tr == "day" and cat == "news" for q, tr, cat in captured)
+    assert any(q == "wwdc 2026" and tr is None and cat == "general" for q, tr, cat in captured)
+    assert all("took place" not in q for q, _, _ in captured)
+    assert "WWDC 2026 announcements live updates" in out["context"]
     assert "FRESHNESS WARNING" not in out["context"]
 
 

--- a/backend/tests/test_streaming_context_meter.py
+++ b/backend/tests/test_streaming_context_meter.py
@@ -1,0 +1,31 @@
+"""
+Static guards for chat streaming/context-meter UI contracts.
+
+The chat stream is integration-heavy, so these tests protect the source-level
+contracts that keep live generation visible and token-based.
+"""
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CHAT = ROOT / "backend" / "agents" / "chat.py"
+FRONTEND = ROOT / "frontend" / "dist" / "index.html"
+
+
+def test_tool_enabled_generation_streams_live_and_clears_tool_drafts():
+    source = CHAT.read_text(encoding="utf-8")
+
+    assert "_streamed_content = False" in source
+    assert "Stream assistant text live even when tools" in source
+    assert "'type': 'token', 'content': _chunk_buf" in source
+    assert "if _streamed_content:" in source
+    assert "'type': 'clear'" in source
+
+
+def test_generation_status_and_context_meter_use_tokens_not_chars():
+    chat_source = CHAT.read_text(encoding="utf-8")
+    html = FRONTEND.read_text(encoding="utf-8")
+
+    assert "Generating... (~{_shown_tokens} tokens)" in chat_source
+    assert "Generating... ({len(content)} chars)" not in chat_source
+    assert "Context used: prompt + generated tokens" in html

--- a/deploy_monitor.py
+++ b/deploy_monitor.py
@@ -41,6 +41,7 @@ REMOTE_AGENTS = REMOTE_BACKEND + "agents/"
 REMOTE_FRONTEND = "/opt/hyprchat/frontend/dist/"
 REMOTE_OPENHANDS_WORKER = "/opt/openhands-worker/"
 REMOTE_AIDER_VENV = REMOTE_OPENHANDS_WORKER + "aider-venv"
+SEARXNG_PRIVACY_SCRIPT = "scripts/setup-searxng-privacy.sh"
 
 # ── Watched files → (label, remote_dir, needs_restart) ──
 # needs_restart: whether deploying this file requires restarting hyprchat service
@@ -112,7 +113,7 @@ def normalize_config(cfg):
     """Accept both old deploy_monitor keys and the AGENTS.md template keys."""
     if not cfg:
         return cfg
-    for key in ("hyprchat", "codebox"):
+    for key in ("hyprchat", "codebox", "searxng"):
         server = cfg.get(key)
         if not isinstance(server, dict):
             continue
@@ -121,6 +122,8 @@ def normalize_config(cfg):
         if not server.get("pass") and server.get("password"):
             server["pass"] = server["password"]
         server.setdefault("user", "root")
+        if key == "searxng":
+            server.setdefault("dev_ip", server.get("dev") or server.get("dev_host") or "")
     return cfg
 
 
@@ -148,6 +151,38 @@ def prompt_server(label, default_ip="", default_user="root", default_pass=""):
     return {"ip": ip, "user": user, "pass": pw}
 
 
+def prompt_optional_searxng(default=None):
+    """Prompt for the optional SearXNG host. Empty on first setup means skip."""
+    default = default or {}
+    has_default = bool(default.get("ip") or default.get("host"))
+    prompt = "[Y/n]" if has_default else "[y/N]"
+    choice = input(
+        f"  {BLD}{Y}Configure optional SearXNG privacy host?{RST} {prompt} > "
+    ).strip().lower()
+    if not choice and not has_default:
+        print()
+        return None
+    if choice in ("n", "no", "skip", "s"):
+        print()
+        return None
+
+    sx = prompt_server(
+        "SearXNG Server (existing install)",
+        default_ip=default.get("ip") or default.get("host", ""),
+        default_user=default.get("user", "root"),
+        default_pass=default.get("pass") or default.get("password", ""),
+    )
+    if not sx.get("ip"):
+        return None
+    dev_default = default.get("dev_ip") or default.get("dev", "")
+    dev_ip = input(
+        f"    {DIM}Optional dev IP allowed to use :8888{RST} [{C}{dev_default}{RST}]: "
+    ).strip() or dev_default
+    sx["dev_ip"] = dev_ip
+    print()
+    return sx
+
+
 def setup_servers():
     """Interactive first-time setup or reconfigure."""
     clear()
@@ -161,6 +196,7 @@ def setup_servers():
     cfg = normalize_config(load_config() or {})
     hypr_def = cfg.get("hyprchat", {})
     cb_def   = cfg.get("codebox", {})
+    sx_def   = cfg.get("searxng", {})
 
     print(f"  {BLD}{Y}HyprChat Server{RST} {DIM}(backend + frontend){RST}")
     hypr = prompt_server("",
@@ -174,7 +210,11 @@ def setup_servers():
         default_user=cb_def.get("user", "root"),
         default_pass=cb_def.get("pass") or cb_def.get("password", ""))
 
+    sx = prompt_optional_searxng(sx_def)
+
     cfg = {"hyprchat": hypr, "codebox": cb}
+    if sx:
+        cfg["searxng"] = sx
     save_config(cfg)
     print(f"  {G}Config saved to {CONFIG_FILE}{RST}")
     print()
@@ -243,8 +283,13 @@ def _show_journal(target, unit, lines=20):
             print(f"  {DIM}{line}{RST}")
 
 
-def _default_env_text(codebox_ip):
+def _server_configured(server):
+    return isinstance(server, dict) and bool(server.get("ip"))
+
+
+def _default_env_text(codebox_ip, searxng_ip=""):
     """Minimal .env for a fresh HyprChat host. Existing .env files are kept."""
+    searxng_url = f"http://{searxng_ip}:8888" if searxng_ip else "http://127.0.0.1:8888"
     return "\n".join([
         "HOST=0.0.0.0",
         "PORT=8000",
@@ -252,6 +297,8 @@ def _default_env_text(codebox_ip):
         f"CODEBOX_URL=http://{codebox_ip}:8585",
         f"OPENHANDS_URL=http://{codebox_ip}:8586",
         f"AIDER_WORKER_URL=http://{codebox_ip}:8586",
+        f"SEARXNG_URL={searxng_url}",
+        "HYPRCHAT_OUTBOUND_PROXY=",
         "DATABASE_PATH=/opt/hyprchat/data/hyprchat.db",
         "UPLOAD_DIR=/opt/hyprchat/data/uploads",
         "TOOLS_DIR=/opt/hyprchat/data/tools",
@@ -274,8 +321,8 @@ def _hyprchat_host_ready(hypr):
     return ssh_cmd(hypr["ip"], hypr["user"], hypr["pass"], cmd, timeout=20)
 
 
-def _bootstrap_hyprchat_host(hypr, codebox_ip):
-    env_text = shlex.quote(_default_env_text(codebox_ip))
+def _bootstrap_hyprchat_host(hypr, codebox_ip, searxng_ip=""):
+    env_text = shlex.quote(_default_env_text(codebox_ip, searxng_ip))
     cmd = (
         "set -u\n"
         "if command -v apt-get >/dev/null 2>&1; then\n"
@@ -293,6 +340,107 @@ def _bootstrap_hyprchat_host(hypr, codebox_ip):
         "chown -R hyprchat:hyprchat /opt/hyprchat/data 2>/dev/null || chown -R hyprchat /opt/hyprchat/data\n"
     )
     return ssh_cmd(hypr["ip"], hypr["user"], hypr["pass"], cmd, timeout=180)
+
+
+def _set_hyprchat_env(hypr, key, value):
+    """Set or replace one key in /opt/hyprchat/.env on the HyprChat host."""
+    cmd = (
+        "set -u\n"
+        "env=/opt/hyprchat/.env\n"
+        f"key={shlex.quote(key)}\n"
+        f"value={shlex.quote(value)}\n"
+        "touch \"$env\"\n"
+        "cp -a \"$env\" \"$env.bak.$(date +%Y%m%d%H%M%S)\" 2>/dev/null || true\n"
+        "tmp=\"${env}.tmp.$$\"\n"
+        "awk -v k=\"$key\" -v v=\"$value\" 'BEGIN{done=0} "
+        "$0 ~ \"^\" k \"=\" {print k \"=\" v; done=1; next} "
+        "{print} END{if(!done) print k \"=\" v}' \"$env\" > \"$tmp\"\n"
+        "mv \"$tmp\" \"$env\"\n"
+        "chmod 640 \"$env\" 2>/dev/null || true\n"
+        "chown hyprchat:hyprchat \"$env\" 2>/dev/null || chown hyprchat \"$env\" 2>/dev/null || true\n"
+    )
+    return ssh_cmd(hypr["ip"], hypr["user"], hypr["pass"], cmd, timeout=30)
+
+
+def _restart_hyprchat(hypr):
+    ok, out, err = ssh_cmd(
+        hypr["ip"], hypr["user"], hypr["pass"],
+        "systemctl restart hyprchat 2>&1", timeout=150,
+    )
+    if not ok:
+        return False, out, err
+    time.sleep(3)
+    ok2, out2, err2 = ssh_cmd(
+        hypr["ip"], hypr["user"], hypr["pass"],
+        "systemctl is-active hyprchat 2>&1", timeout=20,
+    )
+    return ok2 and "active" in out2, out2, err2
+
+
+def _run_first_time_searxng_setup(cfg):
+    """Run optional SearXNG privacy setup and wire HyprChat to the proxy if active."""
+    sx = cfg.get("searxng")
+    if not _server_configured(sx):
+        print(f"  {DIM}No SearXNG host configured; skipping privacy setup.{RST}")
+        return
+
+    hypr = cfg["hyprchat"]
+    script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), SEARXNG_PRIVACY_SCRIPT)
+    if not os.path.exists(script_path):
+        print(f"  {Y}!{RST} SearXNG privacy script missing: {SEARXNG_PRIVACY_SCRIPT}")
+        return
+
+    print()
+    print(f"  {Y}\u25b6{RST} Running first-time SearXNG privacy setup...")
+    remote_script = f"/root/{os.path.basename(SEARXNG_PRIVACY_SCRIPT)}"
+    ok, err = scp(script_path, sx["ip"], "/root/", sx["user"], sx.get("pass", ""))
+    if not ok:
+        print(f"  {Y}!{RST} Could not copy SearXNG setup script: {err[:300]}")
+        return
+
+    env_parts = [
+        f"HYPRCHAT_IP={shlex.quote(hypr['ip'])}",
+        f"DEV_IP={shlex.quote(sx.get('dev_ip', ''))}",
+        "PROTON_OPENVPN=auto",
+    ]
+    cmd = " ".join(env_parts + ["bash", shlex.quote(remote_script)])
+    ok, out, err = ssh_cmd(sx["ip"], sx["user"], sx.get("pass", ""), cmd, timeout=300)
+    setup_output = "\n".join(x for x in (out, err) if x).strip()
+    if setup_output:
+        for line in setup_output.splitlines()[-24:]:
+            print(f"  {DIM}{line}{RST}")
+    if not ok:
+        print(f"  {Y}!{RST} SearXNG privacy setup failed; HyprChat deploy remains usable.")
+        return
+
+    env_changed = False
+    searxng_url = f"http://{sx['ip']}:8888"
+    ok_env, env_out, env_err = _set_hyprchat_env(hypr, "SEARXNG_URL", searxng_url)
+    if ok_env:
+        env_changed = True
+        print(f"  {G}\u2713{RST} HyprChat SEARXNG_URL set to {searxng_url}")
+    else:
+        print(f"  {Y}!{RST} Could not set SEARXNG_URL: {(env_err or env_out)[:300]}")
+
+    proxy_active = any(line.strip() == "HYPRCHAT_PROXY_ACTIVE=1" for line in setup_output.splitlines())
+    if proxy_active:
+        proxy_url = f"http://{sx['ip']}:8899"
+        ok_env, env_out, env_err = _set_hyprchat_env(hypr, "HYPRCHAT_OUTBOUND_PROXY", proxy_url)
+        if ok_env:
+            env_changed = True
+            print(f"  {G}\u2713{RST} HyprChat outbound proxy set to {proxy_url}")
+        else:
+            print(f"  {Y}!{RST} Could not set HYPRCHAT_OUTBOUND_PROXY: {(env_err or env_out)[:300]}")
+    else:
+        print(f"  {Y}!{RST} SearXNG proxy was not activated; outbound proxy was not set.")
+
+    if env_changed:
+        print(f"  {Y}\u25b6{RST} Restarting HyprChat after SearXNG env update...")
+        ok_restart, restart_out, restart_err = _restart_hyprchat(hypr)
+        if ok_restart:
+            print(f"  {G}\u2713{RST} HyprChat restarted")
+        else:
+            print(f"  {Y}!{RST} HyprChat restart check failed: {(restart_err or restart_out)[:300]}")
 
 
 def _codebox_host_ready(cb):
@@ -417,6 +565,7 @@ def _aider_worker_ready(cb):
 def deploy_changes(changed, cfg):
     """Deploy changed files and restart service only if needed."""
     hypr = cfg["hyprchat"]
+    sx = cfg.get("searxng") if _server_configured(cfg.get("searxng")) else None
     needs_restart = False
     needs_pip = False
     results = []
@@ -428,7 +577,7 @@ def deploy_changes(changed, cfg):
     print(f"  {Y}\u25b6{RST} Checking remote install prerequisites...")
     hypr_ready, _out, hypr_err = _hyprchat_host_ready(hypr)
     if not hypr_ready:
-        ok, out, err = _bootstrap_hyprchat_host(hypr, cb["ip"])
+        ok, out, err = _bootstrap_hyprchat_host(hypr, cb["ip"], sx["ip"] if sx else "")
         if ok:
             print(f"  {G}\u2713{RST} HyprChat host bootstrapped")
         else:
@@ -596,6 +745,9 @@ def draw_monitor(file_states, prev_times, cfg, last_event=""):
     print(f"  {bar()}")
     print(f"  {C}\u25cf{RST} {BLD}HyprChat{RST}  {G}{hypr['user']}@{hypr['ip']}{RST}")
     print(f"  {M}\u25cf{RST} {BLD}Codebox{RST}   {G}{cb['user']}@{cb['ip']}{RST}")
+    sx = cfg.get("searxng")
+    if _server_configured(sx):
+        print(f"  {Y}\u25cf{RST} {BLD}SearXNG{RST}   {G}{sx['user']}@{sx['ip']}{RST}")
     print(f"  {bar()}")
     print()
 
@@ -665,11 +817,16 @@ def main():
         print()
         hypr = cfg["hyprchat"]
         cb   = cfg["codebox"]
+        sx   = cfg.get("searxng")
+        sx_lines = []
+        if _server_configured(sx):
+            sx_lines = [f"  {Y}SearXNG{RST}   {sx['user']}@{sx['ip']}"]
         print(box([
             f"{BLD}     HyprChat Deploy Monitor{RST}",
             "",
             f"  {C}HyprChat{RST}  {hypr['user']}@{hypr['ip']}",
             f"  {M}Codebox{RST}   {cb['user']}@{cb['ip']}",
+            *sx_lines,
             "",
             f"  {BLD}Enter{RST}  Start watching        ",
             f"  {BLD}p{RST}      Push all files now     ",
@@ -696,6 +853,7 @@ def main():
         choice = input(f"  {BLD}Run first-time full deploy now? {RST}[{G}Y{RST}/{R}n{RST}] > ").strip().lower()
         if choice in ("", "y", "yes"):
             push_all(cfg, file_states)
+            _run_first_time_searxng_setup(cfg)
 
     last_event = f"{DIM}Watching for changes...{RST}"
     draw_monitor(file_states, prev_times, cfg, last_event)

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -8082,49 +8082,55 @@ function HyprChat(){
           </div>
           <button onClick={refreshUsers} style={{...btnS(t.mut),fontSize:11,padding:"5px 10px"}}><IC.Refresh/> Refresh</button>
         </div>
-        <div style={{display:"grid",gridTemplateColumns:"1fr auto",gap:10,alignItems:"center",background:t.bgDeep,border:`1px solid ${t.brd}24`,borderRadius:9,padding:"10px 12px",marginBottom:12}}>
-          <div style={{minWidth:0}}>
-            <div style={{fontSize:10,color:t.mut,textTransform:"uppercase",letterSpacing:.6,fontWeight:800,marginBottom:3}}>Current User</div>
-            <div style={{fontSize:14,color:t.text,fontWeight:800,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{currentUser?.name||"None"}</div>
-          </div>
-          <button onClick={logoutCurrentUser} style={{...btnS(t.warm),fontSize:12,padding:"7px 12px"}}>Log Out</button>
-        </div>
-        <div style={{display:"grid",gridTemplateColumns:"minmax(0,1fr) minmax(0,1fr) auto",gap:8,alignItems:"center",borderTop:`1px solid ${t.brd}22`,paddingTop:12,marginBottom:14}}>
-          <select value={loginUserId} onChange={e=>{setLoginUserId(e.target.value);setLoginPassword("");setLoginError("");}} style={{...inputS,fontSize:12}}>
-            {users.map(u=><option key={u.id} value={u.id}>{u.name}{u.password_enabled?" (password)":""}</option>)}
-          </select>
-          <input type="password" value={loginPassword} onChange={e=>setLoginPassword(e.target.value)} onKeyDown={e=>{if(e.key==="Enter")loginAsUser();}} placeholder={selectedLoginUser?.password_enabled?"Password":"No password required"} disabled={!selectedLoginUser?.password_enabled} style={{...inputS,fontSize:12,opacity:selectedLoginUser?.password_enabled?1:.55}}/>
-          <button onClick={()=>loginAsUser()} disabled={!selectedLoginUser||selectedLoginUser.id===currentUserId} style={{...btnS(t.acc),fontSize:12,padding:"8px 13px",opacity:selectedLoginUser&&selectedLoginUser.id!==currentUserId?1:.45,whiteSpace:"nowrap"}}><IC.User/> Switch</button>
-        </div>
-        {loginError&&<div style={{fontSize:11,color:t.err,background:`${t.err}12`,border:`1px solid ${t.err}24`,borderRadius:7,padding:"7px 9px",marginBottom:12}}>{loginError}</div>}
-        <div style={{display:"grid",gridTemplateColumns:"minmax(0,1fr) minmax(0,1fr) auto",gap:8,alignItems:"center",borderTop:`1px solid ${t.brd}22`,paddingTop:12,marginBottom:14}}>
-          <input value={newUserName} onChange={e=>setNewUserName(e.target.value)} placeholder="New user name" style={{...inputS,fontSize:12}}/>
-          <input type="password" value={newUserPassword} onChange={e=>setNewUserPassword(e.target.value)} placeholder="Optional password" style={{...inputS,fontSize:12}}/>
-          <button onClick={createManagedUser} disabled={!newUserName.trim()} style={{...btnS(t.ok),fontSize:12,padding:"8px 13px",opacity:newUserName.trim()?1:.45,whiteSpace:"nowrap"}}><IC.Plus/> Create</button>
-        </div>
-        <div style={{display:"flex",flexDirection:"column",gap:8,borderTop:`1px solid ${t.brd}22`,paddingTop:12}}>
-          {users.map(u=>{const isCurrent=u.id===currentUserId;const nameDraft=userNameDrafts[u.id]??u.name??"";const pwdDraft=userPasswordDrafts[u.id]||"";return <div key={u.id} style={{display:"grid",gridTemplateColumns:"minmax(150px,1fr) minmax(150px,1fr) auto",gap:8,alignItems:"center",background:t.bgDeep,border:`1px solid ${isCurrent?t.acc:t.brd}26`,borderRadius:9,padding:"9px 10px"}}>
+        <div style={{display:"flex",flexDirection:"column",gap:14}}>
+          <section style={{background:t.bgDeep,border:`1px solid ${t.brd}24`,borderRadius:9,padding:"12px 14px",display:"flex",alignItems:"center",justifyContent:"space-between",gap:14}}>
             <div style={{minWidth:0}}>
-              <div style={{display:"flex",alignItems:"center",gap:6,marginBottom:5}}>
-                <span style={{fontSize:10,color:isCurrent?t.acc:t.mut,fontWeight:900,textTransform:"uppercase",letterSpacing:.6}}>{isCurrent?"Current":"Profile"}</span>
-                {u.password_enabled&&<span style={{fontSize:9,color:t.warm,border:`1px solid ${t.warm}33`,background:`${t.warm}12`,borderRadius:999,padding:"1px 6px",fontWeight:800}}>Password</span>}
-                {u.id==="default"&&<span style={{fontSize:9,color:t.mut,border:`1px solid ${t.brd}33`,borderRadius:999,padding:"1px 6px",fontWeight:800}}>Main</span>}
-              </div>
-              <div style={{display:"flex",gap:6}}>
-                <input value={nameDraft} onChange={e=>setUserNameDrafts(p=>({...p,[u.id]:e.target.value}))} style={{...inputS,fontSize:12,padding:"7px 9px"}}/>
-                <button onClick={()=>updateManagedUser(u.id,{name:nameDraft})} disabled={!nameDraft.trim()||nameDraft===u.name} style={{...btnS(t.f1),fontSize:10,padding:"5px 9px",opacity:nameDraft.trim()&&nameDraft!==u.name?1:.45}}>Save</button>
+              <div style={{fontSize:10,color:t.mut,textTransform:"uppercase",letterSpacing:.6,fontWeight:800,marginBottom:4}}>Current Session</div>
+              <div style={{display:"flex",alignItems:"center",gap:8,minWidth:0}}>
+                <span style={{fontSize:14,color:t.text,fontWeight:900,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{currentUser?.name||"None"}</span>
+                {currentUser?.password_enabled&&<span style={{fontSize:9,color:t.warm,border:`1px solid ${t.warm}33`,background:`${t.warm}12`,borderRadius:999,padding:"1px 7px",fontWeight:800}}>Password</span>}
               </div>
             </div>
-            <div style={{display:"flex",gap:6,minWidth:0}}>
-              <input type="password" value={pwdDraft} onChange={e=>setUserPasswordDrafts(p=>({...p,[u.id]:e.target.value}))} placeholder={u.password_enabled&&!isCurrent?"Password or new password":"New password"} style={{...inputS,fontSize:12,padding:"7px 9px"}}/>
-              <button onClick={()=>updateManagedUser(u.id,{password:pwdDraft})} disabled={!pwdDraft} style={{...btnS(t.warm),fontSize:10,padding:"5px 9px",opacity:pwdDraft?1:.45,whiteSpace:"nowrap"}}>Set</button>
-              {u.password_enabled&&<button onClick={()=>updateManagedUser(u.id,{clear_password:true})} style={{...btnS(t.mut),fontSize:10,padding:"5px 9px",whiteSpace:"nowrap"}}>Clear</button>}
+            <button onClick={logoutCurrentUser} style={{...btnS(t.warm),fontSize:12,padding:"8px 14px",whiteSpace:"nowrap"}}>Log Out</button>
+          </section>
+
+          {loginError&&<div style={{fontSize:11,color:t.err,background:`${t.err}12`,border:`1px solid ${t.err}24`,borderRadius:7,padding:"7px 9px"}}>{loginError}</div>}
+
+          <section style={{borderTop:`1px solid ${t.brd}22`,paddingTop:14}}>
+            <div style={{fontSize:10,color:t.mut,textTransform:"uppercase",letterSpacing:.6,fontWeight:800,marginBottom:8}}>Create Profile</div>
+            <div style={{display:"grid",gridTemplateColumns:"minmax(180px,1fr) minmax(180px,1fr) 96px",gap:8,alignItems:"center"}}>
+              <input value={newUserName} onChange={e=>setNewUserName(e.target.value)} onKeyDown={e=>{if(e.key==="Enter"&&newUserName.trim())createManagedUser();}} placeholder="New user name" style={{...inputS,fontSize:12}}/>
+              <input type="password" value={newUserPassword} onChange={e=>setNewUserPassword(e.target.value)} onKeyDown={e=>{if(e.key==="Enter"&&newUserName.trim())createManagedUser();}} placeholder="Optional password" style={{...inputS,fontSize:12}}/>
+              <button onClick={createManagedUser} disabled={!newUserName.trim()} style={{...btnS(t.ok),fontSize:12,padding:"8px 13px",height:38,opacity:newUserName.trim()?1:.45,whiteSpace:"nowrap",justifyContent:"center"}}><IC.Plus/> Create</button>
             </div>
-            <div style={{display:"flex",gap:6,justifyContent:"flex-end"}}>
-              {!isCurrent&&<button onClick={()=>{setLoginUserId(u.id);loginAsUser(u.id,u.password_enabled?pwdDraft:"");}} style={{...btnS(t.acc),fontSize:10,padding:"5px 9px"}}>Switch</button>}
-              {u.id!=="default"&&<button onClick={()=>deleteManagedUser(u)} style={{...btnS(t.err),fontSize:10,padding:"5px 9px"}}><IC.Trash/></button>}
+          </section>
+
+          <section style={{borderTop:`1px solid ${t.brd}22`,paddingTop:14}}>
+            <div style={{display:"flex",alignItems:"center",justifyContent:"space-between",gap:12,marginBottom:8}}>
+              <div style={{fontSize:10,color:t.mut,textTransform:"uppercase",letterSpacing:.6,fontWeight:800}}>Manage Profiles</div>
+              <div style={{fontSize:10,color:t.dim}}>{users.length} profile{users.length===1?"":"s"}</div>
             </div>
-          </div>;})}
+            <div style={{display:"flex",flexDirection:"column",gap:8}}>
+              {users.map(u=>{const isCurrent=u.id===currentUserId;const nameDraft=userNameDrafts[u.id]??u.name??"";const pwdDraft=userPasswordDrafts[u.id]||"";return <div key={u.id} style={{background:t.bgDeep,border:`1px solid ${isCurrent?t.acc:t.brd}30`,borderRadius:9,padding:"11px 12px"}}>
+                <div style={{display:"flex",alignItems:"center",justifyContent:"space-between",gap:10,marginBottom:10}}>
+                  <div style={{display:"flex",alignItems:"center",gap:7,minWidth:0}}>
+                    <span style={{fontSize:10,color:isCurrent?t.acc:t.mut,fontWeight:900,textTransform:"uppercase",letterSpacing:.6,flexShrink:0}}>{isCurrent?"Current":"Profile"}</span>
+                    <span style={{fontSize:13,color:t.text,fontWeight:800,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{u.name}</span>
+                    {u.password_enabled&&<span style={{fontSize:9,color:t.warm,border:`1px solid ${t.warm}33`,background:`${t.warm}12`,borderRadius:999,padding:"1px 6px",fontWeight:800,flexShrink:0}}>Password</span>}
+                    {u.id==="default"&&<span style={{fontSize:9,color:t.mut,border:`1px solid ${t.brd}33`,borderRadius:999,padding:"1px 6px",fontWeight:800,flexShrink:0}}>Main</span>}
+                  </div>
+                  {u.id!=="default"&&<button onClick={()=>deleteManagedUser(u)} title="Delete profile" style={{...btnS(t.err),fontSize:10,padding:"6px 8px",height:32,flexShrink:0}}><IC.Trash/></button>}
+                </div>
+                <div style={{display:"grid",gridTemplateColumns:"minmax(180px,1fr) 74px minmax(180px,1fr) 74px minmax(72px,auto)",gap:8,alignItems:"center"}}>
+                  <input value={nameDraft} onChange={e=>setUserNameDrafts(p=>({...p,[u.id]:e.target.value}))} placeholder="Display name" style={{...inputS,fontSize:12,padding:"8px 10px"}}/>
+                  <button onClick={()=>updateManagedUser(u.id,{name:nameDraft})} disabled={!nameDraft.trim()||nameDraft===u.name} style={{...btnS(t.f1),fontSize:10,padding:"6px 9px",height:36,opacity:nameDraft.trim()&&nameDraft!==u.name?1:.45,justifyContent:"center"}}>Save</button>
+                  <input type="password" value={pwdDraft} onChange={e=>setUserPasswordDrafts(p=>({...p,[u.id]:e.target.value}))} placeholder={u.password_enabled?"New password":"Set password"} style={{...inputS,fontSize:12,padding:"8px 10px"}}/>
+                  <button onClick={()=>updateManagedUser(u.id,{password:pwdDraft})} disabled={!pwdDraft} style={{...btnS(t.warm),fontSize:10,padding:"6px 9px",height:36,opacity:pwdDraft?1:.45,whiteSpace:"nowrap",justifyContent:"center"}}>Set</button>
+                  {u.password_enabled?<button onClick={()=>updateManagedUser(u.id,{clear_password:true})} style={{...btnS(t.mut),fontSize:10,padding:"6px 9px",height:36,whiteSpace:"nowrap",justifyContent:"center"}}>Clear</button>:<span/>}
+                </div>
+              </div>;})}
+            </div>
+          </section>
         </div>
       </div>
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -5901,7 +5901,7 @@ function HyprChat(){
           <input ref={importRef} type="file" accept=".json" style={{display:"none"}} onChange={e=>{if(e.target.files?.[0])importChatJSON(e.target.files[0]);e.target.value="";}}/>
           <button onClick={()=>importRef.current?.click()} title="Import chat from JSON" style={{background:"none",border:`1px solid ${t.brd}33`,color:t.mut,cursor:"pointer",padding:"4px 8px",borderRadius:8,fontFamily:font,fontSize:10,display:"flex",alignItems:"center",gap:2}}><IC.Download/> import</button>
           {panel==="chat"&&act&&(()=>{
-            // During streaming: show prompt + live gen tokens. After: show total context used.
+            // Context meter: prompt + generated tokens against the active num_ctx.
             const promptToks=ctxTokens||0;
             const liveGen=streaming&&tokC>0?tokC:0;
             const totalCtxUsed=streaming?(promptToks+liveGen):(promptToks||sessionTokens||0);
@@ -5912,7 +5912,7 @@ function HyprChat(){
             const ratio=maxCtx>0?Math.min(1,toks/maxCtx):0;
             const cc=maxCtx>0?(ratio>0.85?t.err:ratio>0.6?t.warm:t.ok):streaming?t.acc:t.warm;
             const fmtK=n=>n>=1000?`${(n/1000).toFixed(1)}k`:String(n);
-            return <div style={{display:"flex",flexDirection:"column",overflow:"hidden",borderRadius:10,border:`1px solid ${cc}45`,background:`${cc}12`,minWidth:90,cursor:"default"}} title={`Context: ${toks} tokens${maxCtx>0?` / ${maxCtx}`:""}${liveGen>0?` | Generating: +${liveGen}`:genTokens>0?` | Generated: ${genTokens}`:""}`}>
+            return <div style={{display:"flex",flexDirection:"column",overflow:"hidden",borderRadius:10,border:`1px solid ${cc}45`,background:`${cc}12`,minWidth:90,cursor:"default"}} title={`Context used: prompt + generated tokens = ${toks}${maxCtx>0?` / ${maxCtx}`:""}${liveGen>0?` | Live generation: +${liveGen} tokens`:genTokens>0?` | Generated this turn: ${genTokens} tokens`:""}`}>
               <div style={{display:"flex",alignItems:"center",gap:5,padding:"5px 11px"}}>
                 <span style={{fontSize:13,display:"inline-block",animation:streaming?"bop 1.5s ease-in-out infinite":"none"}}>🧠</span>
                 <span style={{fontSize:13,color:cc,fontWeight:700,fontFamily:font,letterSpacing:.2}}>{fmtK(toks)}</span>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -2497,12 +2497,13 @@ function initMermaidTheme(theme,font){
   });
 }
 
-function MermaidBlock({code,theme,font,epoch,printMode=false}){
+function MermaidBlock({code,theme,font,epoch,printMode=false,streaming=false}){
   const t=theme;
   const containerRef=useRef(null);
   const fsRef=useRef(null);
   const panZoomRef=useRef(null);
   const [err,setErr]=useState(null);
+  const [pending,setPending]=useState(false);
   const [repaired,setRepaired]=useState(false);
   const [cpd,setCpd]=useState(false);
   const [showSrc,setShowSrc]=useState(false);
@@ -2513,21 +2514,36 @@ function MermaidBlock({code,theme,font,epoch,printMode=false}){
     let cancelled=false;
     setErr(null);
     setRepaired(false);
+    setPending(true);
     try{
       if(printMode)initMermaidTheme(t,font);
       const repairedCode=sanitizeMermaidCode(code);
       const renderOne=(src,suffix)=>window.mermaid.render(`${id}-${suffix}`,src);
       renderOne(code,"raw").then(({svg})=>{
-        if(!cancelled&&containerRef.current)containerRef.current.innerHTML=svg;
+        if(!cancelled&&containerRef.current){containerRef.current.innerHTML=svg;setPending(false);}
       }).catch(firstErr=>{
-        if(repairedCode===code){if(!cancelled)setErr(String(firstErr?.message||firstErr));return;}
+        if(repairedCode===code){
+          if(!cancelled){
+            if(streaming){setErr(null);setPending(true);}
+            else{setPending(false);setErr(String(firstErr?.message||firstErr));}
+          }
+          return;
+        }
         renderOne(repairedCode,"fixed").then(({svg})=>{
-          if(!cancelled&&containerRef.current){containerRef.current.innerHTML=svg;setRepaired(true);}
-        }).catch(e=>{if(!cancelled)setErr(String(e?.message||firstErr?.message||e||firstErr));});
+          if(!cancelled&&containerRef.current){containerRef.current.innerHTML=svg;setRepaired(true);setPending(false);}
+        }).catch(e=>{
+          if(!cancelled){
+            if(streaming){setErr(null);setPending(true);}
+            else{setPending(false);setErr(String(e?.message||firstErr?.message||e||firstErr));}
+          }
+        });
       });
-    }catch(e){setErr(String(e?.message||e));}
+    }catch(e){
+      if(streaming){setErr(null);setPending(true);}
+      else{setPending(false);setErr(String(e?.message||e));}
+    }
     return()=>{cancelled=true;};
-  },[code,epoch,showSrc,id,printMode,t,font]);
+  },[code,epoch,showSrc,id,printMode,t,font,streaming]);
   useEffect(()=>{
     if(!fs||!fsRef.current||!containerRef.current)return;
     const srcSvg=containerRef.current.querySelector("svg");
@@ -2584,7 +2600,13 @@ function MermaidBlock({code,theme,font,epoch,printMode=false}){
       <pre style={{margin:0,padding:12,fontSize:12,lineHeight:1.6,overflowX:"auto",fontFamily:font,color:t.dim}}>{code}</pre>
     </div>
     :showSrc?<pre style={{margin:0,padding:12,fontSize:12,lineHeight:1.6,overflowX:"auto",fontFamily:font,color:t.dim}}>{code}</pre>
-    :<div ref={containerRef} className="mermaid-container" style={{background:printMode?"#ffffff":t.bgDeep}}/>}
+    :<div style={{position:"relative",background:printMode?"#ffffff":t.bgDeep}}>
+      <div ref={containerRef} className="mermaid-container" style={{background:printMode?"#ffffff":t.bgDeep,minHeight:streaming&&pending?120:undefined,opacity:streaming&&pending?0:1,transition:"opacity .18s ease"}}/>
+      {streaming&&pending&&<div style={{position:"absolute",inset:0,display:"flex",alignItems:"center",justifyContent:"center",gap:8,color:t.mut,fontSize:11,fontFamily:font,background:t.bgDeep}}>
+        <span style={{width:5,height:5,borderRadius:"50%",background:t.acc,animation:"pulse 1.4s infinite"}}/>
+        rendering diagram...
+      </div>}
+    </div>}
     {!printMode&&fs&&ReactDOM.createPortal(
       <div style={{position:"fixed",inset:0,zIndex:200,background:"rgba(0,0,0,.82)",display:"flex",alignItems:"center",justifyContent:"center",backdropFilter:"blur(6px)"}} onClick={e=>{if(e.target===e.currentTarget)setFs(false);}}>
         <div style={{background:t.bgDeep,border:`1px solid ${t.brd}44`,borderRadius:16,width:"min(1600px,95vw)",height:"90vh",display:"flex",flexDirection:"column",boxShadow:`0 8px 48px #0008`,overflow:"hidden"}}>
@@ -2626,18 +2648,24 @@ function looksLikeChartConfig(code){
 }
 
 // Chart.js block — renders ```chart / ```pygraph JSON fences as inline charts
-function ChartBlock({code,theme,font,epoch,kind="chart",printMode=false}){
+function ChartBlock({code,theme,font,epoch,kind="chart",printMode=false,streaming=false}){
   const t=theme;
   const canvasRef=useRef(null);
   const chartRef=useRef(null);
   const [err,setErr]=useState(null);
+  const [pending,setPending]=useState(false);
   const [cpd,setCpd]=useState(false);
   const [showSrc,setShowSrc]=useState(false);
   useEffect(()=>{
-    if(!window.Chart||!canvasRef.current||showSrc)return;
+    if(!window.Chart||!canvasRef.current||showSrc){if(streaming&&!showSrc)setPending(true);return;}
     let cfg;
     try{cfg=parseChartConfig(code);}
-    catch(e){setErr("Invalid JSON: "+String(e.message));return;}
+    catch(e){
+      if(streaming){setErr(null);setPending(true);}
+      else{setPending(false);setErr("Invalid JSON: "+String(e.message));}
+      return;
+    }
+    setPending(false);
     const palette=printMode
       ?["#175cd3","#0f766e","#b7791f","#b42318","#7c3aed","#0891b2","#c2410c","#2563eb"]
       :[t.acc,t.ok,t.warm,t.err||"#e06c75","#b39ddb","#80cbc4","#ffab91","#90caf9"];
@@ -2684,9 +2712,12 @@ function ChartBlock({code,theme,font,epoch,kind="chart",printMode=false}){
         }
       });
       setErr(null);
-    }catch(e){setErr("Chart error: "+String(e.message));}
+    }catch(e){
+      if(streaming){setErr(null);setPending(true);}
+      else{setPending(false);setErr("Chart error: "+String(e.message));}
+    }
     return()=>{if(chartRef.current){try{chartRef.current.destroy();}catch{}chartRef.current=null;}};
-  },[code,epoch,showSrc,t,font,printMode]);
+  },[code,epoch,showSrc,t,font,printMode,streaming]);
   const copyCode=()=>{try{navigator.clipboard.writeText(code);setCpd(true);setTimeout(()=>setCpd(false),1500);}catch{}};
   const headerBtn={background:"none",border:"none",cursor:"pointer",padding:"3px 6px",fontSize:10,fontFamily:font,borderRadius:5,display:"flex",alignItems:"center",gap:3};
   const wrapStyle=printMode
@@ -2708,7 +2739,13 @@ function ChartBlock({code,theme,font,epoch,kind="chart",printMode=false}){
       <pre style={{margin:0,padding:12,fontSize:12,lineHeight:1.6,overflowX:"auto",fontFamily:font,color:t.dim}}>{code}</pre>
     </div>
     :showSrc?<pre style={{margin:0,padding:12,fontSize:12,lineHeight:1.6,overflowX:"auto",fontFamily:font,color:t.dim}}>{code}</pre>
-    :<div style={{padding:printMode?"10pt":"14px",height:printMode?280:320,position:"relative",background:"#ffffff"}}><canvas ref={canvasRef}/></div>}
+    :<div style={{padding:printMode?"10pt":"14px",height:printMode?280:320,position:"relative",background:printMode?"#ffffff":t.bgDeep}}>
+      <canvas ref={canvasRef} style={{opacity:streaming&&pending?0:1,transition:"opacity .18s ease"}}/>
+      {streaming&&pending&&<div style={{position:"absolute",inset:0,display:"flex",alignItems:"center",justifyContent:"center",gap:8,color:t.mut,fontSize:11,fontFamily:font,background:t.bgDeep}}>
+        <span style={{width:5,height:5,borderRadius:"50%",background:t.acc,animation:"pulse 1.4s infinite"}}/>
+        rendering chart...
+      </div>}
+    </div>}
   </div>;
 }
 
@@ -2721,6 +2758,28 @@ function CodeBlock({code,lang,t,font}){
   },[code,lang]);
   const cls=lang?`language-${lang}`:"language-none";
   return <pre style={{margin:0,padding:12,fontSize:12,lineHeight:1.6,overflowX:"auto",fontFamily:font,background:"transparent"}}><code ref={ref} className={cls} style={{fontFamily:font,background:"transparent",color:t.dim,padding:0,textShadow:"none"}}>{code}</code></pre>;
+}
+
+function InlineMath({code,raw,theme,font,printMode=false}){
+  const html=useMemo(()=>{
+    if(!window.katex)return null;
+    try{
+      return window.katex.renderToString(code,{displayMode:false,throwOnError:false,strict:"ignore",trust:false});
+    }catch{return null;}
+  },[code]);
+  if(!html)return <span>{raw||`$${code}$`}</span>;
+  return <span style={{color:"inherit",fontFamily:printMode?undefined:font}} dangerouslySetInnerHTML={{__html:html}}/>;
+}
+
+function InlineColorSwatch({value,theme,font,printMode=false}){
+  const t=theme||{};
+  const bg=printMode?"#f8fafc":`${t.surface||"#0f172a"}BB`;
+  const brd=printMode?"#d7dde8":`${t.brd||"#334155"}55`;
+  const label=printMode?"#334155":(t.warm||"#facc15");
+  return <span style={{display:"inline-flex",alignItems:"center",gap:4,padding:"1px 6px 1px 4px",background:bg,border:`1px solid ${brd}`,borderRadius:4,verticalAlign:"middle",margin:"0 1px"}}>
+    <span style={{width:10,height:10,borderRadius:2,background:value,border:`1px solid ${brd}`,flexShrink:0,boxShadow:"inset 0 0 0 1px rgba(255,255,255,.08)"}}/>
+    <code style={{fontSize:"0.85em",color:label,background:"none",padding:0,fontFamily:font}}>{value}</code>
+  </span>;
 }
 
 // Collapsible <details>/<summary> block
@@ -5610,10 +5669,19 @@ function HyprChat(){
   const inlineParse=(text,opts={})=>{
     if(!text)return null;
     const printMode=!!opts.printMode;
-    // Split by: inline-code, images, bold+link, bold, italic(*), italic(_), markdown link, bare URL, double-quoted strings (10+ chars)
-    return text.split(/(`[^`]+`|!\[[^\]]*\]\([^)]+\)|\*\*\[[^\]]+\]\([^)]+\)\*\*|\*\*[^*\n]+\*\*|\*[^*\n]+\*|_[^_\n]+_|\[[^\]]+\]\([^)]+\)|https?:\/\/[^\s"'<>\])\},]+|"[^"\n]{10,}"|<kbd>[^<]+<\/kbd>|rgba?\([^)]+\)|hsla?\([^)]+\)|#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6})\b|[^]+)/g).map((s,k)=>{
+    const mathish=v=>/\\[a-zA-Z]+|[\^_=+\-*/{}]/.test(v||"");
+    const namedColorRe=/^(black|silver|gray|grey|white|maroon|red|purple|fuchsia|magenta|green|lime|olive|yellow|navy|blue|teal|aqua|cyan|orange|aliceblue|rebeccapurple|transparent)$/i;
+    const colorish=v=>/^#[0-9a-fA-F]{3,8}$/.test(v||"")||/^(rgba?|hsla?)\(/i.test(v||"")||namedColorRe.test(v||"");
+    // Split by: math, inline-code, images, bold+link, bold, italic(*), italic(_), markdown link, bare URL, double-quoted strings (10+ chars)
+    return text.split(/(`\$(?=[^`\n]*?(?:\\[a-zA-Z]+|[\^_=+\-*/{}]))[^`\n]+?\$`|(?<![\\$])\$(?![\d\s])(?=[^$\n]*?(?:\\[a-zA-Z]+|[\^_=+\-*/{}]))[^$\n]+?(?<!\\)\$|`[^`]+`|!\[[^\]]*\]\([^)]+\)|\*\*\[[^\]]+\]\([^)]+\)\*\*|\*\*[^*\n]+\*\*|\*[^*\n]+\*|_[^_\n]+_|\[[^\]]+\]\([^)]+\)|https?:\/\/[^\s"'<>\])\},]+|"[^"\n]{10,}"|<kbd>[^<]+<\/kbd>|rgba?\([^)]+\)|hsla?\([^)]+\)|#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6})\b|[^]+)/g).map((s,k)=>{
       if(!s)return null;
       const imgMatch=s.match(/^!\[([^\]]*)\]\(([^)]+)\)$/);
+      const codeText=(s.startsWith("`")&&s.endsWith("`")&&s.length>1)?s.slice(1,-1):null;
+      const codeMath=s.match(/^`\$([\s\S]+)\$`$/);
+      const bareMath=s.match(/^\$([\s\S]+)\$$/);
+      if(codeMath&&mathish(codeMath[1]))return <InlineMath key={k} code={codeMath[1]} raw={s} theme={t} font={font} printMode={printMode}/>;
+      if(bareMath&&mathish(bareMath[1]))return <InlineMath key={k} code={bareMath[1]} raw={s} theme={t} font={font} printMode={printMode}/>;
+      if(codeText&&colorish(codeText))return <InlineColorSwatch key={k} value={codeText} theme={t} font={font} printMode={printMode}/>;
       if(printMode){
         const linkStyle={color:"#175cd3",textDecoration:"none",overflowWrap:"anywhere"};
         if(imgMatch){const[,alt,src]=imgMatch;return <span key={k} className="image-note">Image: {alt||src}</span>;}
@@ -5730,10 +5798,7 @@ function HyprChat(){
       }
       // Inline color swatch: #rrggbb, #rrggbbaa, rgb(), rgba(), hsl(), hsla()
       if(s.match(/^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/)||s.match(/^(rgba?|hsla?)\(/)){
-        return <span key={k} style={{display:"inline-flex",alignItems:"center",gap:4,padding:"1px 6px 1px 4px",background:`${t.surface}BB`,border:`1px solid ${t.brd}55`,borderRadius:4,verticalAlign:"middle",margin:"0 1px"}}>
-          <span style={{width:10,height:10,borderRadius:2,background:s,border:`1px solid ${t.brd}66`,flexShrink:0,boxShadow:"inset 0 0 0 1px rgba(255,255,255,.08)"}}/>
-          <code style={{fontSize:"0.85em",color:t.warm,background:"none",padding:0,fontFamily:font}}>{s}</code>
-        </span>;
+        return <InlineColorSwatch key={k} value={s} theme={t} font={font} printMode={printMode}/>;
       }
       return s;
     });
@@ -5750,12 +5815,13 @@ function HyprChat(){
     const stripped=t2.replace(/```/g,"");
     const ticks=(stripped.match(/`/g)||[]).length;
     if(ticks%2!==0)t2+="`";
-    return md(t2);
+    return md(t2,{streaming:true});
   };
 
   const md=(text,opts={})=>{
     if(!text)return null;
     const printMode=!!opts.printMode;
+    const streaming=!!opts.streaming;
     const rt=opts.theme||t;
     const ip=v=>inlineParse(v,opts);
     // Strip <think>...</think> blocks (model reasoning not for display)
@@ -5787,7 +5853,7 @@ function HyprChat(){
           .trim();
         const open=/^<details[^>]*\bopen\b/i.test(p);
         if(printMode)return <div key={i} className="print-details"><div className="print-details-summary">{summary}</div>{md(body,opts)}</div>;
-        return <Collapsible key={i} theme={t} font={font} summary={summary} defaultOpen={open}>{md(body)}</Collapsible>;
+        return <Collapsible key={i} theme={t} font={font} summary={summary} defaultOpen={open}>{md(body,opts)}</Collapsible>;
       }
       if(/^[ \t]{0,3}```/.test(p)){
         const m=p.match(/^[ \t]*```(\w*)\n?([\s\S]*?)\n?[ \t]*```[ \t]*$/);
@@ -5799,9 +5865,9 @@ function HyprChat(){
         const _minIndent=_indents.length?Math.min(..._indents):0;
         if(_minIndent>0)code=_codeLines.map(l=>l.slice(_minIndent)).join("\n");
         const bid=`c${i}`;
-        if(lang==="mermaid")return <MermaidBlock key={i} code={code} theme={rt} font={font} epoch={mermaidEpoch} printMode={printMode}/>;
-        if(lang==="chart"||lang==="pygraph")return <ChartBlock key={i} code={code} theme={rt} font={font} epoch={mermaidEpoch} kind={lang} printMode={printMode}/>;
-        if((lang==="json"||!lang)&&looksLikeChartConfig(code))return <ChartBlock key={i} code={code} theme={rt} font={font} epoch={mermaidEpoch} kind="chart" printMode={printMode}/>;
+        if(lang==="mermaid")return <MermaidBlock key={i} code={code} theme={rt} font={font} epoch={mermaidEpoch} printMode={printMode} streaming={streaming}/>;
+        if(lang==="chart"||lang==="pygraph")return <ChartBlock key={i} code={code} theme={rt} font={font} epoch={mermaidEpoch} kind={lang} printMode={printMode} streaming={streaming}/>;
+        if((lang==="json"||!lang)&&looksLikeChartConfig(code))return <ChartBlock key={i} code={code} theme={rt} font={font} epoch={mermaidEpoch} kind="chart" printMode={printMode} streaming={streaming}/>;
         const isDiff=lang==="diff";
         if(printMode)return <pre key={i} className="print-code-block"><code>{code}</code></pre>;
         return <div key={i} style={{margin:"10px 0",borderRadius:10,overflow:"hidden",border:`1px solid ${t.brd}55`,background:t.bgDeep}}>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -494,6 +494,46 @@
 const { useState, useEffect, useRef, useCallback, useMemo } = React;
 
 const API = window.HYPRCHAT_API || "";
+const HC_USER_KEY = "hc-current-user";
+const HC_SESSION_PREFIX = "hc-user-session-";
+const hcSessionKey = id => `${HC_SESSION_PREFIX}${id || "default"}`;
+const hcStoredUserId = () => {
+  try { return localStorage.getItem(HC_USER_KEY) || "default"; } catch { return "default"; }
+};
+const hcStoredSession = id => {
+  try { return localStorage.getItem(hcSessionKey(id)) || ""; } catch { return ""; }
+};
+const hcSetUserContext = (id, sessionToken = null) => {
+  const uid = id || "default";
+  window.__hyprchatUserId = uid;
+  if (sessionToken !== null) window.__hyprchatSessionToken = sessionToken || "";
+};
+hcSetUserContext(hcStoredUserId(), hcStoredSession(hcStoredUserId()));
+const dismissHyprLoader = () => {
+  const el = document.getElementById("hc-loading");
+  if (!el || el.classList.contains("hc-dismiss")) return;
+  el.classList.add("hc-dismiss");
+  setTimeout(() => { if (el.parentNode) el.parentNode.removeChild(el); }, 800);
+};
+const userScopedUrl = path => {
+  const uid = window.__hyprchatUserId || hcStoredUserId();
+  const session = window.__hyprchatSessionToken || hcStoredSession(uid);
+  const sep = String(path).includes("?") ? "&" : "?";
+  return `${API}${path}${sep}user_id=${encodeURIComponent(uid)}${session ? `&session=${encodeURIComponent(session)}` : ""}`;
+};
+const _hyprFetch = window.fetch.bind(window);
+window.fetch = (input, init = {}) => {
+  const rawUrl = typeof input === "string" ? input : (input && input.url) || "";
+  const apiPath = `${API}/api/`;
+  const isApi = rawUrl.startsWith("/api/") || rawUrl.startsWith(apiPath) || rawUrl.startsWith(`${window.location.origin}/api/`);
+  if (!isApi) return _hyprFetch(input, init);
+  const uid = window.__hyprchatUserId || hcStoredUserId();
+  const session = window.__hyprchatSessionToken || hcStoredSession(uid);
+  const headers = new Headers(init.headers || (input instanceof Request ? input.headers : undefined));
+  headers.set("X-HyprChat-User", uid);
+  if (session) headers.set("X-HyprChat-Session", session);
+  return _hyprFetch(input, {...init, headers});
+};
 const THEMES = {
   hyprflat:{name:"HyprFlat",bg:"#282C34",bgDeep:"#111418",surface:"#171B21",sfHov:"#20262E",sfBri:"#2B343D",brd:"#355A66",text:"#CDEFF7",dim:"#9CDEF2",mut:"#6B8A94",acc:"#9CDEF2",acc2:"#74CFE7",warm:"#E06C75",ok:"#50FA7B",err:"#E06C75",pink:"#B48EAD",f1:"#88C0D0",f4:"#81A1C1"},
   nord:{name:"Nord",bg:"#2E3440",bgDeep:"#242933",surface:"#3B4252",sfHov:"#434C5E",sfBri:"#4C566A",brd:"#4C566A",text:"#ECEFF4",dim:"#D8DEE9",mut:"#81A1C1",acc:"#88C0D0",acc2:"#81A1C1",warm:"#EBCB8B",ok:"#A3BE8C",err:"#BF616A",pink:"#B48EAD",f1:"#8FBCBB",f4:"#5E81AC"},
@@ -3021,6 +3061,18 @@ function HyprChat(){
   const [panel,setPanel]=useState("chat");
   const previousPanelRef=useRef("chat");
   const [settingsTab,setSettingsTab]=useState("connections");
+  const [users,setUsers]=useState([]);
+  const [currentUser,setCurrentUser]=useState(null);
+  const [currentUserId,setCurrentUserId]=useState(()=>hcStoredUserId());
+  const [authReady,setAuthReady]=useState(false);
+  const [userGateOpen,setUserGateOpen]=useState(false);
+  const [loginUserId,setLoginUserId]=useState(()=>hcStoredUserId());
+  const [loginPassword,setLoginPassword]=useState("");
+  const [loginError,setLoginError]=useState("");
+  const [newUserName,setNewUserName]=useState("");
+  const [newUserPassword,setNewUserPassword]=useState("");
+  const [userNameDrafts,setUserNameDrafts]=useState({});
+  const [userPasswordDrafts,setUserPasswordDrafts]=useState({});
   const [pendingToolIds,setPendingToolIds]=useState([]);
   const [evts,setEvts]=useState([]);
   const evtsRef=useRef([]);
@@ -3290,6 +3342,30 @@ function HyprChat(){
     if(isCoderPersonaName(c?.persona_name)||(c?.tool_ids||[]).length)return "agent";
     return "persona";
   };
+  const replacePersonaPlaceholders=(text,names={})=>{
+    if(text===null||text===undefined)return text;
+    const userName=String(names.userName||currentUser?.name||"User").trim()||"User";
+    const charName=String(names.charName||"the character").trim()||"the character";
+    return String(text).replace(/\{\{\s*(user|char)\s*\}\}|\{\s*(user|char)\s*\}/gi,(_,a,b)=>{
+      const key=String(a||b||"").toLowerCase();
+      return key==="user"?userName:key==="char"?charName:_;
+    });
+  };
+  const personaPlaceholderContextForPayload=(payload,mc=null)=>{
+    const profile=mc||(payload?.model_config_id?mcs.find(x=>x.id===payload.model_config_id):null);
+    const type=profile?getProfileType(profile):(payload?.persona_name?"persona":null);
+    if(type!=="persona")return null;
+    return {userName:currentUser?.name||"User",charName:payload?.persona_name||profile?.name||"the character"};
+  };
+  const personaPlaceholderContextForConversation=(c)=>{
+    if(!c?.persona_name)return null;
+    if(getConversationProfileType(c)!=="persona")return null;
+    return {userName:currentUser?.name||"User",charName:c.persona_name};
+  };
+  const replacePersonaPlaceholdersForConversation=(text,c)=>{
+    const ctx=personaPlaceholderContextForConversation(c);
+    return ctx?replacePersonaPlaceholders(text,ctx):text;
+  };
   const updateProfileLocal=(id,fn)=>setMcs(p=>p.map(mc=>mc.id===id?fn(mc):mc));
   const setProfileParam=(id,key,value)=>updateProfileLocal(id,mc=>({...mc,parameters:{...normalizeProfileParams(mc),[key]:value}}));
   const setPersonaField=(id,key,value)=>updateProfileLocal(id,mc=>{
@@ -3341,7 +3417,9 @@ function HyprChat(){
     if(!mc)return"";
     const params=normalizeProfileParams(mc);
     if(params.profile_type!=="persona")return"";
-    return String(params.persona?.first_message||"").trim();
+    const raw=String(params.persona?.first_message||"").trim();
+    const ctx=personaPlaceholderContextForPayload({...payload,persona_name:payload?.persona_name||mc.name},mc);
+    return ctx?replacePersonaPlaceholders(raw,ctx):raw;
   };
   const makeProfileFirstMessage=(payload)=>{
     const content=profileFirstMessage(payload);
@@ -3390,20 +3468,150 @@ function HyprChat(){
     return merged;
   })();
 
+  const resetUserScopedState=()=>{
+    setConvs([]);setActId(null);setEvts([]);evtsRef.current=[];streamSaveEvtsRef.current=[];
+    setKbs([]);setTools([]);setMcs([]);setWorkspaces([]);setActiveWs(null);setWsDetail(null);setWsPanel(false);
+    setResearchReports([]);setActiveResearchId(null);setActiveResearch(null);setResearchEvents([]);setResearchLiveMarkdown("");setResearchRunning(false);
+    setCouncils([]);setActiveCouncilId(null);setCouncilReport(null);setQuickResults([]);setSearchLoading(false);setQuickSearchError(null);
+    setCoderWorkflows([]);setCoderProjInfo(null);setAttachments([]);setFtsResults([]);setPanel("chat");setLoadingConv(false);
+  };
+  const refreshUsers=useCallback(async()=>{
+    const r=await fetch(`${API}/api/users`);
+    if(!r.ok)throw new Error(`HTTP ${r.status}`);
+    const d=await r.json();
+    const list=d.users||[];
+    setUsers(list);
+    setUserNameDrafts(p=>{const next={...p};list.forEach(u=>{if(next[u.id]===undefined)next[u.id]=u.name||"";});return next;});
+    if(!list.some(u=>u.id===loginUserId))setLoginUserId(list[0]?.id||"default");
+    return list;
+  },[loginUserId]);
+  const applySignedInUser=(user,sessionToken=undefined)=>{
+    if(!user)return;
+    const uid=user.id||"default";
+    const effectiveSession=sessionToken!==undefined?(sessionToken||""):hcStoredSession(uid);
+    hcSetUserContext(uid,effectiveSession);
+    try{
+      localStorage.setItem(HC_USER_KEY,uid);
+      if(sessionToken!==undefined){
+        if(sessionToken)localStorage.setItem(hcSessionKey(uid),sessionToken);
+        else localStorage.removeItem(hcSessionKey(uid));
+      }
+    }catch{}
+    resetUserScopedState();
+    setCurrentUser(user);setCurrentUserId(uid);setLoginUserId(uid);setLoginPassword("");setLoginError("");setUserGateOpen(false);setAuthReady(true);
+  };
+  useEffect(()=>{
+    let cancelled=false;
+    const gate=(list=[],msg="")=>{
+      if(cancelled)return;
+      setUsers(list);setAuthReady(false);setUserGateOpen(true);setLoginError(msg);setLoginPassword("");
+      if(list.length&&!list.some(u=>u.id===loginUserId))setLoginUserId(list[0].id);
+      dismissHyprLoader();
+    };
+    (async()=>{
+      try{
+        const list=await refreshUsers();
+        if(cancelled)return;
+        let rememberedRaw="";
+        try{rememberedRaw=localStorage.getItem(HC_USER_KEY)||"";}catch{}
+        const remembered=rememberedRaw?(list.find(u=>u.id===rememberedRaw)||null):null;
+        if(!remembered){if(list[0])setLoginUserId(list[0].id);gate(list,"");return;}
+        if(remembered.password_enabled){
+          hcSetUserContext(remembered.id,hcStoredSession(remembered.id));
+          const r=await fetch(`${API}/api/users/current`);
+          if(!r.ok){gate(list,"Enter the password for the remembered user.");return;}
+          const d=await r.json();
+          if(!cancelled)applySignedInUser(d.user||remembered);
+        }else if(!cancelled){
+          applySignedInUser(remembered,null);
+        }
+      }catch(e){
+        gate([],e.message||"Could not load users.");
+      }
+    })();
+    return()=>{cancelled=true;};
+  },[]);
+  const loginAsUser=async(userId=loginUserId,password=loginPassword)=>{
+    setLoginError("");
+    try{
+      const r=await fetch(`${API}/api/users/login`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({user_id:userId,password:password||""})});
+      const d=await r.json().catch(()=>({}));
+      if(!r.ok)throw new Error(d.detail||`HTTP ${r.status}`);
+      const user=d.user||users.find(u=>u.id===userId);
+      applySignedInUser(user,d.session_token===undefined?undefined:d.session_token);
+      await refreshUsers().catch(()=>{});
+      notify({type:"success",text:`Signed in as ${user?.name||userId}`,duration:2400});
+    }catch(e){
+      setLoginError(e.message||"Sign in failed");
+      notify({type:"error",text:"Sign in failed",detail:e.message||String(e)});
+    }
+  };
+  const logoutCurrentUser=async()=>{
+    const uid=currentUserId||hcStoredUserId();
+    try{await fetch(`${API}/api/users/logout`,{method:"POST"});}catch{}
+    try{localStorage.removeItem(HC_USER_KEY);localStorage.removeItem(hcSessionKey(uid));}catch{}
+    hcSetUserContext("default","");
+    resetUserScopedState();setCurrentUser(null);setAuthReady(false);setLoginPassword("");setLoginError("");setUserGateOpen(true);
+    await refreshUsers().catch(()=>{});
+    dismissHyprLoader();
+  };
+  const createManagedUser=async()=>{
+    const name=newUserName.trim();
+    if(!name)return;
+    setLoginError("");
+    try{
+      const password=newUserPassword;
+      const r=await fetch(`${API}/api/users`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({name,password})});
+      const d=await r.json().catch(()=>({}));
+      if(!r.ok)throw new Error(d.detail||`HTTP ${r.status}`);
+      setNewUserName("");setNewUserPassword("");
+      await refreshUsers().catch(()=>{});
+      await loginAsUser(d.user.id,password);
+    }catch(e){
+      setLoginError(e.message||"Could not create user");
+      notify({type:"error",text:"User create failed",detail:e.message||String(e)});
+    }
+  };
+  const updateManagedUser=async(userId,patch)=>{
+    try{
+      const r=await fetch(`${API}/api/users/${encodeURIComponent(userId)}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify(patch)});
+      const d=await r.json().catch(()=>({}));
+      if(!r.ok)throw new Error(d.detail||`HTTP ${r.status}`);
+      setUsers(p=>p.map(u=>u.id===userId?d.user:u));
+      setUserNameDrafts(p=>({...p,[userId]:d.user.name||""}));
+      if(patch.password!==undefined||patch.clear_password)setUserPasswordDrafts(p=>({...p,[userId]:""}));
+      if(userId===currentUserId){
+        applySignedInUser(d.user,d.session_token===undefined?undefined:d.session_token);
+      }
+      notify({type:"success",text:"User updated",duration:2200});
+      await refreshUsers().catch(()=>{});
+    }catch(e){
+      notify({type:"error",text:"User update failed",detail:e.message||String(e)});
+    }
+  };
+  const deleteManagedUser=async(user)=>{
+    if(!user||user.id==="default")return;
+    const ok=await confirmAction({title:"Delete user",body:`Delete ${user.name || user.id}? This removes that user's chats, workspaces, knowledge bases, tools, agents, memories, reports, and analytics.`,confirmLabel:"Delete User",tone:"danger"});
+    if(!ok)return;
+    try{
+      const r=await fetch(`${API}/api/users/${encodeURIComponent(user.id)}`,{method:"DELETE"});
+      const d=await r.json().catch(()=>({}));
+      if(!r.ok)throw new Error(d.detail||`HTTP ${r.status}`);
+      try{localStorage.removeItem(hcSessionKey(user.id));if(currentUserId===user.id)localStorage.removeItem(HC_USER_KEY);}catch{}
+      const list=await refreshUsers().catch(()=>users.filter(u=>u.id!==user.id));
+      if(currentUserId===user.id){
+        resetUserScopedState();setCurrentUser(null);setAuthReady(false);setUserGateOpen(true);setLoginUserId((list||[])[0]?.id||"default");
+      }
+      notify({type:"success",text:"User deleted",duration:2400});
+    }catch(e){
+      notify({type:"error",text:"User delete failed",detail:e.message||String(e)});
+    }
+  };
+
   // Load
   useEffect(()=>{
-    const dismissLoader=(()=>{
-      let called=false;
-      return ()=>{
-        if(called)return; called=true;
-        const el=document.getElementById('hc-loading');
-        const root=document.getElementById('root');
-        if(!el)return;
-        // Just fade out the overlay — app is visible underneath
-        el.classList.add('hc-dismiss');
-        setTimeout(()=>{if(el.parentNode)el.parentNode.removeChild(el);},800);
-      };
-    })();
+    if(!authReady){if(userGateOpen)dismissHyprLoader();return;}
+    const dismissLoader=dismissHyprLoader;
     setTimeout(dismissLoader,5000); // fallback
     fetch(`${API}/api/models`).then(r=>r.json()).then(d=>{const next=d.models||[];setModels(next);setModelDetails(d.model_details||{});try{const last=localStorage.getItem("hc-last-model")||"";if(last&&next.length&&!next.includes(last))localStorage.setItem("hc-last-model",next[0]||"");}catch{}dismissLoader();}).catch(()=>{setModels(["qwen3.5:27b","qwen3-coder:30b"]);dismissLoader();});
     fetch(`${API}/api/conversations`).then(r=>r.json()).then(cs=>{if(cs.length){
@@ -3459,7 +3667,7 @@ function HyprChat(){
         quickSearchEntry,
       ]);
     });
-  },[]);
+  },[authReady,currentUserId]);
 
   // SSE — with exponential backoff reconnection
   useEffect(()=>{
@@ -3468,7 +3676,7 @@ function HyprChat(){
     let closed=false,retryDelay=1000,retryTimer=null;
     const connect=()=>{
       if(closed)return;
-      const es=new EventSource(`${API}/api/events/${actId}`);
+      const es=new EventSource(userScopedUrl(`/api/events/${actId}`));
       es.onmessage=e=>{try{const ev=JSON.parse(e.data);if(ev.type!=="heartbeat"&&ev.type!=="keepalive"){setEvts(p=>[...p.slice(-200),ev]);streamSaveEvtsRef.current.push(ev);
         // Route search_agent results into the QUICK SEARCH carousel — same data
         // the chat model saw, instead of the old parallel /api/quick-search call.
@@ -3538,7 +3746,7 @@ function HyprChat(){
     if(researchEventRef.current){researchEventRef.current.close();researchEventRef.current=null;}
     if(!activeResearchId||!researchRunning)return;
     let closed=false;
-    const es=new EventSource(`${API}/api/events/${activeResearchId}`);
+    const es=new EventSource(userScopedUrl(`/api/events/${activeResearchId}`));
     es.onmessage=e=>{try{
       const ev=JSON.parse(e.data);
       if(ev.type==="heartbeat"||ev.type==="keepalive")return;
@@ -4591,12 +4799,12 @@ function HyprChat(){
           if(!ln.startsWith("data: "))continue;
           try{const d=JSON.parse(ln.slice(6));
             if(d.type==="init"){_streamMsgId=d.message_id;}
-            else if(d.type==="token"){full+=d.content;uConv(cid,c=>{const m=[...(c.messages||[])];m[m.length-1]={...m[m.length-1],role:"assistant",content:full,isS:true};return{...c,messages:m};});}
+            else if(d.type==="token"){full+=d.content;const shown=replacePersonaPlaceholdersForConversation(full,cv);uConv(cid,c=>{const m=[...(c.messages||[])];m[m.length-1]={...m[m.length-1],role:"assistant",content:shown,isS:true};return{...c,messages:m};});}
             else if(d.type==="clear"){full="";uConv(cid,c=>{const m=[...(c.messages||[])];m[m.length-1]={...m[m.length-1],role:"assistant",content:"",isS:true};return{...c,messages:m};});}
             else if(d.type==="refinement_start"){full="";refinementsCount=d.round||refinementsCount;uConv(cid,c=>{const m=[...(c.messages||[])];m[m.length-1]={...m[m.length-1],role:"assistant",content:"",isS:true};return{...c,messages:m};});const _refEv={type:"tool_start",data:{tool:"refinement",status:`Refining answer (${d.round}/${d.total})...`,icon:"sparkles",round:d.round,total:d.total},timestamp:Date.now()/1000};streamSaveEvtsRef.current.push(_refEv);setEvts(p=>[...p.slice(-200),_refEv]);}
             else if(d.type==="done"){if(d.message_id)_streamMsgId=d.message_id;setTokS(d.speed);if(d.gen_tokens||d.tokens)setSessionTokens(p=>p+((d.gen_tokens||d.tokens)||0));if(d.prompt_tokens)setCtxTokens(d.prompt_tokens+(d.gen_tokens||0));if(d.gen_tokens){setGenTokens(d.gen_tokens);setTokC(d.gen_tokens);}if(d.refinements)refinementsCount=d.refinements;}
             else if(d.type==="ctx_update"){if(d.gen_tokens)setTokC(d.gen_tokens);if(d.prompt_tokens)setCtxTokens(d.prompt_tokens);}
-            else if(d.type==="error"){const _errBlock=(full?"\n\n":"")+"```\n⚠ "+d.error+"\n```";full=full+_errBlock;uConv(cid,c=>{const m=[...(c.messages||[])];m[m.length-1]={...m[m.length-1],role:"assistant",content:full,isS:false};return{...c,messages:m};});}
+            else if(d.type==="error"){const _errBlock=(full?"\n\n":"")+"```\n⚠ "+d.error+"\n```";full=full+_errBlock;const shown=replacePersonaPlaceholdersForConversation(full,cv);uConv(cid,c=>{const m=[...(c.messages||[])];m[m.length-1]={...m[m.length-1],role:"assistant",content:shown,isS:false};return{...c,messages:m};});}
           }catch{}}
       }
       // Capture relevant events into metadata for persistence (tool status + search results + source links)
@@ -4612,7 +4820,8 @@ function HyprChat(){
         ...(_streamRunIds.length?{run_ids:_streamRunIds}:{}),
         in_progress: false,
       } : {in_progress: false};
-      uConv(cid,c=>{const m=[...(c.messages||[])];m[m.length-1]={...m[m.length-1],role:"assistant",content:full,isS:false,metadata:_msgMeta};return{...c,messages:m};});
+      const finalFull=replacePersonaPlaceholdersForConversation(full,cv);
+      uConv(cid,c=>{const m=[...(c.messages||[])];m[m.length-1]={...m[m.length-1],role:"assistant",content:finalFull,isS:false,metadata:_msgMeta};return{...c,messages:m};});
       // Save final assistant message state to DB. PATCH the row the backend already
       // created at stream start (preferred — exactly one row per turn). Fall back to
       // POST for older backends or if init/done didn't include a message_id.
@@ -4620,9 +4829,9 @@ function HyprChat(){
         // Ghost chats are intentionally local-only: no assistant PATCH/POST,
         // no title generation, no workspace memory suggestion source row.
       }else if(_streamMsgId){
-        fetch(`${API}/api/conversations/${cid}/messages/${_streamMsgId}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({content:full,metadata:_msgMeta})}).catch(()=>{});
+        fetch(`${API}/api/conversations/${cid}/messages/${_streamMsgId}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({content:finalFull,metadata:_msgMeta})}).catch(()=>{});
       }else{
-        fetch(`${API}/api/conversations/${cid}/messages`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({role:"assistant",content:full,metadata:_msgMeta})}).catch(()=>{});
+        fetch(`${API}/api/conversations/${cid}/messages`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({role:"assistant",content:finalFull,metadata:_msgMeta})}).catch(()=>{});
       }
       // Auto-generate title after first exchange
       if(!isGhostSend&&autoTitle&&appendUser){const cv2=convs.find(c=>c.id===cid);const curTitle=cv2?.title||"";if(!curTitle||curTitle==="New Chat"||curTitle===appendUser.slice(0,40))fetch(`${API}/api/conversations/${cid}/generate-title`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({model:wsModel||""})}).then(r=>r.json()).then(d=>{if(d.title)uConv(cid,{title:d.title});}).catch(()=>{});}
@@ -5081,11 +5290,10 @@ function HyprChat(){
     Object.keys(out).forEach(k=>{if(typeof out[k]==="string")out[k]=cleanCardText(out[k]);});
     return out;
   };
-  const compactCardDescription=(raw,name)=>{
-    const text=cleanCardText(raw).replace(/\{\{char\}\}/gi,name).replace(/\{\{user\}\}/gi,"the user").replace(/\s+/g," ");
+  const importedCardDescription=(raw,name)=>{
+    const text=cleanCardText(raw).replace(/\s+/g," ");
     if(!text)return `${name} character card imported from Chub/SillyTavern.`;
-    if(text.length<=260)return text;
-    return text.slice(0,257).trim()+"...";
+    return text;
   };
   const alternateGreetingLore=(greetings)=>{
     if(!Array.isArray(greetings)||!greetings.length)return "";
@@ -5120,7 +5328,7 @@ function HyprChat(){
     const firstMessage=joinCardParts(firstCardValue(d.first_mes,d.first_message,d.firstMessage,d.greeting,d.greeting_message,d.initial_message),split.first_message);
     const examples=joinCardParts(firstCardValue(d.mes_example,d.example_dialogue,d.example_messages,d.sample_messages,d.sample_dialogue,d.dialogue_examples),split.example_dialogue);
     const persona={
-      description:compactCardDescription(rawDescription||d.creatorcomment||d.creator_comment||"",name),
+      description:importedCardDescription(rawDescription||d.creatorcomment||d.creator_comment||"",name),
       personality,
       scenario,
       first_message:firstMessage,
@@ -5806,6 +6014,7 @@ function HyprChat(){
   const composerColor=composerState==="error"?t.err:composerState==="stopped"?t.mut:councilRunning?t.pink:streaming?t.warm:composerFocused?t.acc:quickSearch?t.f1:t.acc;
   const sidebarSearchActive=showMessageSearch||sq||ftsQuery;
   const settingsTabs=[
+    ["users","👤","Users","Profiles and sign-in"],
     ["connections","🔌","Connections","Runtime endpoints and status"],
     ["generation","⚙️","Model & Generation","Global model behavior"],
     ["daedalus","🏛️","Daedalus","Coder-agent routing"],
@@ -5817,6 +6026,7 @@ function HyprChat(){
     ["changelog","📋","Changelog","Release notes and updates"],
   ];
   const activeSettingsTitle=(settingsTabs.find(([id])=>id===settingsTab)||settingsTabs[0])[2];
+  const selectedLoginUser=users.find(u=>u.id===loginUserId)||users[0]||null;
   const mmPanelS={background:`${t.surface}66`,border:`1px solid ${t.brd}24`,borderRadius:8,boxShadow:"none"};
   const mmPanelStrongS={background:`${t.surface}88`,border:`1px solid ${t.brd}33`,borderRadius:8,boxShadow:"none"};
   const mmKickerS={fontSize:10,color:t.mut,textTransform:"uppercase",letterSpacing:.7,fontWeight:800};
@@ -5841,6 +6051,36 @@ function HyprChat(){
     {bgEffect==="dots"&&<div style={{position:"absolute",inset:0,opacity:.42,zIndex:0,pointerEvents:"none",backgroundImage:`radial-gradient(circle,${t.acc}18 1px,transparent 1.4px)`,backgroundSize:"24px 24px"}}/>}
     <BackgroundCanvas effect={bgEffect} t={t}/>
     {bgEffect==="scanlines"&&<div style={{position:"absolute",inset:0,zIndex:1,pointerEvents:"none",background:`linear-gradient(180deg,transparent 0%,${t.acc}04 50%,transparent 100%)`,backgroundSize:"100% 4px",animation:"scanline 8s linear infinite",opacity:.4}}/>}
+
+    {userGateOpen&&<div style={{position:"fixed",inset:0,zIndex:320,background:"rgba(0,0,0,.72)",display:"flex",alignItems:"center",justifyContent:"center",padding:18,backdropFilter:"blur(6px)"}}>
+      <div style={{width:"min(520px,94vw)",background:t.bgDeep,border:`1px solid ${t.brd}55`,borderRadius:14,boxShadow:"0 18px 70px rgba(0,0,0,.55)",padding:20,animation:"fadeIn .18s"}}>
+        <div style={{display:"flex",alignItems:"center",gap:10,marginBottom:16}}>
+          <span style={{display:"flex",color:t.acc}}><IC.User/></span>
+          <div>
+            <div style={{fontSize:15,fontWeight:900,color:t.text,letterSpacing:.4}}>Sign In</div>
+            <div style={{fontSize:10,color:t.mut,marginTop:2}}>HyprChat profiles keep chats, memory, workspaces, agents, and reports separate.</div>
+          </div>
+        </div>
+        <div style={{display:"grid",gap:10,marginBottom:16}}>
+          {users.length>0&&<select value={loginUserId} onChange={e=>{setLoginUserId(e.target.value);setLoginPassword("");setLoginError("");}} style={inputS}>
+            {users.map(u=><option key={u.id} value={u.id}>{u.name}{u.password_enabled?" (password)":""}</option>)}
+          </select>}
+          {selectedLoginUser?.password_enabled&&<input type="password" value={loginPassword} onChange={e=>setLoginPassword(e.target.value)} onKeyDown={e=>{if(e.key==="Enter")loginAsUser();}} placeholder="Password" style={inputS} autoFocus/>}
+          {loginError&&<div style={{fontSize:11,color:t.err,background:`${t.err}12`,border:`1px solid ${t.err}24`,borderRadius:7,padding:"7px 9px"}}>{loginError}</div>}
+          {users.length>0&&<button onClick={()=>loginAsUser()} disabled={!selectedLoginUser} style={{...btnS(t.acc),justifyContent:"center",fontSize:12,padding:"9px 14px",opacity:selectedLoginUser?1:.45}}>
+            <IC.Check/> Sign In
+          </button>}
+        </div>
+        <div style={{borderTop:`1px solid ${t.brd}22`,paddingTop:14}}>
+          <div style={{fontSize:11,fontWeight:800,color:t.dim,textTransform:"uppercase",letterSpacing:.6,marginBottom:8}}>New Profile</div>
+          <div style={{display:"grid",gridTemplateColumns:"minmax(0,1fr) minmax(0,1fr) auto",gap:8}}>
+            <input value={newUserName} onChange={e=>setNewUserName(e.target.value)} onKeyDown={e=>{if(e.key==="Enter"&&newUserName.trim())createManagedUser();}} placeholder="Name" style={inputS}/>
+            <input type="password" value={newUserPassword} onChange={e=>setNewUserPassword(e.target.value)} onKeyDown={e=>{if(e.key==="Enter"&&newUserName.trim())createManagedUser();}} placeholder="Optional password" style={inputS}/>
+            <button onClick={createManagedUser} disabled={!newUserName.trim()} style={{...btnS(t.ok),opacity:newUserName.trim()?1:.45,whiteSpace:"nowrap",justifyContent:"center"}}><IC.Plus/> Create</button>
+          </div>
+        </div>
+      </div>
+    </div>}
 
     {/* NAV RAIL */}
     <div style={{width:68,minWidth:68,display:"flex",flexDirection:"column",alignItems:"center",...glass,borderRight:`1px solid ${t.brd}55`,zIndex:11,padding:"12px 0",gap:4}}>
@@ -5878,7 +6118,12 @@ function HyprChat(){
     {/* CONVERSATION LIST */}
     <div style={{width:sidebar?304:0,minWidth:sidebar?304:0,transition:"all .3s cubic-bezier(.4,0,.2,1)",display:"flex",flexDirection:"column",borderRight:`1px solid ${t.brd}55`,overflow:"hidden",background:`${t.bgDeep}F2`,backdropFilter:"none",position:"relative",zIndex:10}}>
       <div style={{padding:"12px 10px 6px",flexShrink:0}}>
-        <div style={{fontSize:13,fontWeight:800,letterSpacing:1.8,textTransform:"uppercase",color:t.acc,marginBottom:8,paddingLeft:2}}>HyprChat <span style={{fontSize:8,fontWeight:700,letterSpacing:1,color:t.warm,opacity:.95,padding:"1px 5px",background:`${t.warm}14`,border:`1px solid ${t.warm}40`,borderRadius:4}}>ALPHA</span></div>
+        <div style={{fontSize:13,fontWeight:800,letterSpacing:1.8,textTransform:"uppercase",color:t.acc,marginBottom:6,paddingLeft:2}}>HyprChat <span style={{fontSize:8,fontWeight:700,letterSpacing:1,color:t.warm,opacity:.95,padding:"1px 5px",background:`${t.warm}14`,border:`1px solid ${t.warm}40`,borderRadius:4}}>ALPHA</span></div>
+        <button onClick={()=>{openSettings();setSettingsTab("users");}} style={{width:"100%",display:"flex",alignItems:"center",gap:7,background:`${t.surface}44`,border:`1px solid ${t.brd}22`,color:t.dim,borderRadius:8,padding:"6px 8px",fontFamily:font,fontSize:11,cursor:"pointer",marginBottom:8,textAlign:"left"}}>
+          <span style={{display:"flex",color:t.acc}}><IC.User/></span>
+          <span style={{minWidth:0,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap",fontWeight:700}}>{currentUser?.name||"Choose user"}</span>
+          <span style={{marginLeft:"auto",fontSize:9,color:t.mut}}>switch</span>
+        </button>
       </div>
       <div style={{padding:"0 8px 6px",display:"flex",flexDirection:"column",gap:4,flexShrink:0}}>
         <div style={{display:"flex",gap:4}}>
@@ -5918,7 +6163,7 @@ function HyprChat(){
         <div onClick={()=>loadConversation(c.id)} style={{padding:"10px 12px",borderRadius:8,cursor:"pointer",background:isAct?`${accentColor}14`:(isCouncil||hasPersona)?`${accentColor}0C`:"transparent",border:isAct?`1px solid ${accentColor}50`:(isCouncil||hasPersona)?`1px solid ${accentColor}25`:"1px solid transparent",display:"flex",justifyContent:"space-between",alignItems:"center",borderLeft:(isCouncil||hasPersona)?`3px solid ${isAct?accentColor:`${accentColor}66`}`:"3px solid transparent"}}>
           <div style={{overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap",fontSize:13,color:isAct?t.text:t.dim,flex:1,fontWeight:isAct?500:400,display:"flex",alignItems:"center",gap:5}}>
             {isCouncil&&<span style={{flexShrink:0,color:t.pink,display:"flex",opacity:isAct?1:.7}}><IC.Council/></span>}
-            {hasPersona&&(convAvatar?<img src={avatarSrc(convAvatar)} style={{width:14,height:14,borderRadius:4,objectFit:"cover",flexShrink:0,opacity:isAct?1:.8}} alt=""/>:<span style={{flexShrink:0,color:accentColor,display:"flex",opacity:isAct?1:.7}}>{profileType==="persona"?<IC.User/>:<IC.Bot/>}</span>)}
+            {hasPersona&&(convAvatar?<img src={avatarSrc(convAvatar)} style={{width:isAct?24:14,height:isAct?24:14,borderRadius:isAct?7:4,objectFit:"cover",flexShrink:0,opacity:isAct?1:.8}} alt=""/>:<span style={{flexShrink:0,color:accentColor,display:"flex",alignItems:"center",justifyContent:"center",width:isAct?24:14,height:isAct?24:14,opacity:isAct?1:.7}}>{profileType==="persona"?<IC.User/>:<IC.Bot/>}</span>)}
             {c.forked_from&&<span style={{flexShrink:0,color:t.f1||t.acc,display:"flex",opacity:.6,fontSize:9}} title="Forked conversation"><IC.GitBranch/></span>}
             {c.title||"New Chat"}
           </div>
@@ -5982,7 +6227,7 @@ function HyprChat(){
           {panel==="chat"&&!act&&<>
             <ModelPicker value={pendingChatModel||models[0]||""} onChange={setPendingChatModel} models={models} modelDetails={modelDetails} t={t} font={font} compact={true} onRefresh={refreshModels}/>
             {pendingPersona&&(()=>{const pendingProfile=getProfileForConversation(pendingPersona);const type=pendingProfile?getProfileType(pendingProfile):(isCoderPersonaName(pendingPersona.persona_name)||(pendingPersona.tool_ids||[]).length?"agent":"persona");const c=type==="persona"?t.pink:t.acc;const label=type==="persona"?"Persona":"Agent";const avatar=pendingPersona.persona_avatar||profileAvatar(pendingProfile);return <><div style={{display:"flex",alignItems:"center",gap:5,padding:"3px 10px",background:`${c}15`,border:`1px solid ${c}28`,borderRadius:20}}>
-              {avatar?<img src={avatarSrc(avatar)} style={{width:16,height:16,borderRadius:5,objectFit:"cover"}} alt=""/>:<span style={{display:"flex",color:c}}>{type==="persona"?<IC.User/>:<IC.Bot/>}</span>}
+              {avatar?<img src={avatarSrc(avatar)} style={{width:type==="persona"?24:16,height:type==="persona"?24:16,borderRadius:type==="persona"?7:5,objectFit:"cover"}} alt=""/>:<span style={{display:"flex",color:c,alignItems:"center",justifyContent:"center",width:type==="persona"?24:16,height:type==="persona"?24:16}}>{type==="persona"?<IC.User/>:<IC.Bot/>}</span>}
               <span style={{fontSize:9,fontWeight:800,color:c,textTransform:"uppercase",letterSpacing:.5}}>{label}</span>
               <span style={{fontSize:10,fontWeight:600,color:type==="persona"?t.text:c}}>{pendingPersona.persona_name}</span>
             </div>
@@ -6003,7 +6248,7 @@ function HyprChat(){
               <button onClick={()=>newChat(true)} style={{display:"flex",alignItems:"center",gap:3,padding:"3px 9px",background:`${t.err}12`,border:`1px solid ${t.err}33`,borderRadius:16,cursor:"pointer",fontSize:10,fontWeight:600,color:t.err,fontFamily:font}}>✕ Leave Council</button></>;
             })():<ModelPicker value={act.model||models[0]||""} onChange={v=>uConv(actId,{model:v})} models={models} modelDetails={modelDetails} t={t} font={font} compact={true} onRefresh={refreshModels}/>}
             {!act.is_council&&act.persona_name&&(()=>{const type=getConversationProfileType(act);const c=type==="persona"?t.pink:t.acc;const label=type==="persona"?"Persona":"Agent";const avatar=act.persona_avatar||profileAvatar(getProfileForConversation(act));return <><div style={{display:"flex",alignItems:"center",gap:5,padding:"3px 10px",background:`${c}15`,border:`1px solid ${c}28`,borderRadius:20}}>
-              {avatar?<img src={avatarSrc(avatar)} style={{width:16,height:16,borderRadius:5,objectFit:"cover"}} alt=""/>:<span style={{display:"flex",color:c}}>{type==="persona"?<IC.User/>:<IC.Bot/>}</span>}
+              {avatar?<img src={avatarSrc(avatar)} style={{width:type==="persona"?28:16,height:type==="persona"?28:16,borderRadius:type==="persona"?8:5,objectFit:"cover"}} alt=""/>:<span style={{display:"flex",color:c,alignItems:"center",justifyContent:"center",width:type==="persona"?28:16,height:type==="persona"?28:16}}>{type==="persona"?<IC.User/>:<IC.Bot/>}</span>}
               <span style={{fontSize:9,fontWeight:800,color:c,textTransform:"uppercase",letterSpacing:.5}}>{label}</span>
               <span style={{fontSize:10,fontWeight:600,color:type==="persona"?t.text:c}}>{act.persona_name}</span>
             </div>
@@ -6202,7 +6447,7 @@ function HyprChat(){
             <span style={{color:t.f1,flexShrink:0}}>{(()=>{const ext=((f.filename||f.name||"").split(".").pop()||"").toLowerCase();if(ext==="pdf")return"📕";if(["doc","docx"].includes(ext))return"📘";if(["xls","xlsx","csv"].includes(ext))return"📊";if(["json","xml","yaml","yml"].includes(ext))return"🗂";if(["py","js","ts","rs","go","java","c","cpp","h","rb","sh"].includes(ext))return"💻";if(["md"].includes(ext))return"📝";if(["txt","text","log"].includes(ext))return"📝";if(["html","htm"].includes(ext))return"🌐";if(["png","jpg","jpeg","gif","svg","webp"].includes(ext))return"🖼";if(["zip","tar","gz","rar","7z"].includes(ext))return"📦";return"📄";})()}</span>
             <span style={{flex:1,color:t.text,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap",fontWeight:500}}>{f.filename||f.name}</span>
             <span style={{fontSize:9,color:t.mut,flexShrink:0}}>{((f.file_size||f.size||0)/1024).toFixed(1)}KB</span>
-            {f.id&&<button onClick={async()=>{const fn=(f.filename||f.name||"").toLowerCase();const ext=fn.split(".").pop();if(ext==="pdf"){setKbPreview({filename:f.filename||f.name,rawUrl:`${API}/api/knowledge-bases/${kb.id}/files/${f.id}/raw`,isPdf:true,pdfFullView:false,content:null,loading:true});try{const r=await fetch(`${API}/api/knowledge-bases/${kb.id}/files/${f.id}/pdf-text?pages=10`);const d=await r.json();setKbPreview(p=>({...p,content:d.content,total_pages:d.total_pages,previewed_pages:d.previewed_pages,truncated:d.truncated,loading:false}));}catch(e){setKbPreview(p=>({...p,content:"Failed to extract PDF text: "+e.message,loading:false}));}}else if(["png","jpg","jpeg","gif","svg","webp","bmp"].includes(ext)){setKbPreview({filename:f.filename||f.name,rawUrl:`${API}/api/knowledge-bases/${kb.id}/files/${f.id}/raw`,isImage:true,loading:false});}else{setKbPreview({filename:f.filename||f.name,content:null,loading:true});try{const r=await fetch(`${API}/api/knowledge-bases/${kb.id}/files/${f.id}/preview`);const d=await r.json();setKbPreview({filename:d.filename,content:d.content,truncated:d.truncated,total_lines:d.total_lines,loading:false});}catch(e){setKbPreview({filename:f.filename||f.name,content:"Failed to load preview: "+e.message,loading:false});}}}} style={{background:`${t.acc}15`,border:`1px solid ${t.acc}33`,color:t.acc,cursor:"pointer",padding:"2px 8px",borderRadius:5,fontSize:9,fontWeight:600,flexShrink:0}}>Preview</button>}
+            {f.id&&<button onClick={async()=>{const fn=(f.filename||f.name||"").toLowerCase();const ext=fn.split(".").pop();if(ext==="pdf"){setKbPreview({filename:f.filename||f.name,rawUrl:userScopedUrl(`/api/knowledge-bases/${kb.id}/files/${f.id}/raw`),isPdf:true,pdfFullView:false,content:null,loading:true});try{const r=await fetch(`${API}/api/knowledge-bases/${kb.id}/files/${f.id}/pdf-text?pages=10`);const d=await r.json();setKbPreview(p=>({...p,content:d.content,total_pages:d.total_pages,previewed_pages:d.previewed_pages,truncated:d.truncated,loading:false}));}catch(e){setKbPreview(p=>({...p,content:"Failed to extract PDF text: "+e.message,loading:false}));}}else if(["png","jpg","jpeg","gif","svg","webp","bmp"].includes(ext)){setKbPreview({filename:f.filename||f.name,rawUrl:userScopedUrl(`/api/knowledge-bases/${kb.id}/files/${f.id}/raw`),isImage:true,loading:false});}else{setKbPreview({filename:f.filename||f.name,content:null,loading:true});try{const r=await fetch(`${API}/api/knowledge-bases/${kb.id}/files/${f.id}/preview`);const d=await r.json();setKbPreview({filename:d.filename,content:d.content,truncated:d.truncated,total_lines:d.total_lines,loading:false});}catch(e){setKbPreview({filename:f.filename||f.name,content:"Failed to load preview: "+e.message,loading:false});}}}} style={{background:`${t.acc}15`,border:`1px solid ${t.acc}33`,color:t.acc,cursor:"pointer",padding:"2px 8px",borderRadius:5,fontSize:9,fontWeight:600,flexShrink:0}}>Preview</button>}
             <button onClick={()=>{if(f.id)fetch(`${API}/api/knowledge-bases/files/${f.id}`,{method:"DELETE"}).catch(()=>{});setKbs(p=>p.map(k=>k.id===kb.id?{...k,files:(k.files||[]).filter((_,j)=>j!==i)}:k));}} style={{background:"none",border:"none",color:t.err,cursor:"pointer",padding:"2px 4px",fontSize:10,opacity:.6,flexShrink:0}} title="Delete file">✕</button>
           </div>)}
           {!(kb.files||[]).length&&<span style={{fontSize:11,color:t.mut,fontStyle:"italic",padding:"4px 0"}}>No files uploaded</span>}
@@ -6271,6 +6516,10 @@ function HyprChat(){
                 setTimeout(()=>setUploadProgress(p=>{const n={...p};delete n[pKey];return n;}),6000);
               };
               xhr.open("POST",`${API}/api/knowledge-bases/${kbId}/files`);
+              const uid=window.__hyprchatUserId||hcStoredUserId();
+              const sess=window.__hyprchatSessionToken||hcStoredSession(uid);
+              xhr.setRequestHeader("X-HyprChat-User",uid);
+              if(sess)xhr.setRequestHeader("X-HyprChat-Session",sess);
               xhr.send(fd);
             };
             // Fire all uploads in parallel
@@ -7746,6 +7995,61 @@ function HyprChat(){
         </div>
       </div>
 
+      {/* TILE: Users */}
+      <div style={{...settingsCardS,display:settingsTab==="users"?"block":"none"}}>
+        <div style={{display:"flex",justifyContent:"space-between",gap:12,alignItems:"flex-start",marginBottom:14}}>
+          <div>
+            <div style={{fontSize:14,fontWeight:800,color:t.acc,letterSpacing:.5,display:"flex",alignItems:"center",gap:8}}>👤 Users</div>
+            <div style={{...settingsKickerS,marginTop:4}}>Local profiles for keeping HyprChat data separate on this install.</div>
+          </div>
+          <button onClick={refreshUsers} style={{...btnS(t.mut),fontSize:11,padding:"5px 10px"}}><IC.Refresh/> Refresh</button>
+        </div>
+        <div style={{display:"grid",gridTemplateColumns:"1fr auto",gap:10,alignItems:"center",background:t.bgDeep,border:`1px solid ${t.brd}24`,borderRadius:9,padding:"10px 12px",marginBottom:12}}>
+          <div style={{minWidth:0}}>
+            <div style={{fontSize:10,color:t.mut,textTransform:"uppercase",letterSpacing:.6,fontWeight:800,marginBottom:3}}>Current User</div>
+            <div style={{fontSize:14,color:t.text,fontWeight:800,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{currentUser?.name||"None"}</div>
+          </div>
+          <button onClick={logoutCurrentUser} style={{...btnS(t.warm),fontSize:12,padding:"7px 12px"}}>Log Out</button>
+        </div>
+        <div style={{display:"grid",gridTemplateColumns:"minmax(0,1fr) minmax(0,1fr) auto",gap:8,alignItems:"center",borderTop:`1px solid ${t.brd}22`,paddingTop:12,marginBottom:14}}>
+          <select value={loginUserId} onChange={e=>{setLoginUserId(e.target.value);setLoginPassword("");setLoginError("");}} style={{...inputS,fontSize:12}}>
+            {users.map(u=><option key={u.id} value={u.id}>{u.name}{u.password_enabled?" (password)":""}</option>)}
+          </select>
+          <input type="password" value={loginPassword} onChange={e=>setLoginPassword(e.target.value)} onKeyDown={e=>{if(e.key==="Enter")loginAsUser();}} placeholder={selectedLoginUser?.password_enabled?"Password":"No password required"} disabled={!selectedLoginUser?.password_enabled} style={{...inputS,fontSize:12,opacity:selectedLoginUser?.password_enabled?1:.55}}/>
+          <button onClick={()=>loginAsUser()} disabled={!selectedLoginUser||selectedLoginUser.id===currentUserId} style={{...btnS(t.acc),fontSize:12,padding:"8px 13px",opacity:selectedLoginUser&&selectedLoginUser.id!==currentUserId?1:.45,whiteSpace:"nowrap"}}><IC.User/> Switch</button>
+        </div>
+        {loginError&&<div style={{fontSize:11,color:t.err,background:`${t.err}12`,border:`1px solid ${t.err}24`,borderRadius:7,padding:"7px 9px",marginBottom:12}}>{loginError}</div>}
+        <div style={{display:"grid",gridTemplateColumns:"minmax(0,1fr) minmax(0,1fr) auto",gap:8,alignItems:"center",borderTop:`1px solid ${t.brd}22`,paddingTop:12,marginBottom:14}}>
+          <input value={newUserName} onChange={e=>setNewUserName(e.target.value)} placeholder="New user name" style={{...inputS,fontSize:12}}/>
+          <input type="password" value={newUserPassword} onChange={e=>setNewUserPassword(e.target.value)} placeholder="Optional password" style={{...inputS,fontSize:12}}/>
+          <button onClick={createManagedUser} disabled={!newUserName.trim()} style={{...btnS(t.ok),fontSize:12,padding:"8px 13px",opacity:newUserName.trim()?1:.45,whiteSpace:"nowrap"}}><IC.Plus/> Create</button>
+        </div>
+        <div style={{display:"flex",flexDirection:"column",gap:8,borderTop:`1px solid ${t.brd}22`,paddingTop:12}}>
+          {users.map(u=>{const isCurrent=u.id===currentUserId;const nameDraft=userNameDrafts[u.id]??u.name??"";const pwdDraft=userPasswordDrafts[u.id]||"";return <div key={u.id} style={{display:"grid",gridTemplateColumns:"minmax(150px,1fr) minmax(150px,1fr) auto",gap:8,alignItems:"center",background:t.bgDeep,border:`1px solid ${isCurrent?t.acc:t.brd}26`,borderRadius:9,padding:"9px 10px"}}>
+            <div style={{minWidth:0}}>
+              <div style={{display:"flex",alignItems:"center",gap:6,marginBottom:5}}>
+                <span style={{fontSize:10,color:isCurrent?t.acc:t.mut,fontWeight:900,textTransform:"uppercase",letterSpacing:.6}}>{isCurrent?"Current":"Profile"}</span>
+                {u.password_enabled&&<span style={{fontSize:9,color:t.warm,border:`1px solid ${t.warm}33`,background:`${t.warm}12`,borderRadius:999,padding:"1px 6px",fontWeight:800}}>Password</span>}
+                {u.id==="default"&&<span style={{fontSize:9,color:t.mut,border:`1px solid ${t.brd}33`,borderRadius:999,padding:"1px 6px",fontWeight:800}}>Main</span>}
+              </div>
+              <div style={{display:"flex",gap:6}}>
+                <input value={nameDraft} onChange={e=>setUserNameDrafts(p=>({...p,[u.id]:e.target.value}))} style={{...inputS,fontSize:12,padding:"7px 9px"}}/>
+                <button onClick={()=>updateManagedUser(u.id,{name:nameDraft})} disabled={!nameDraft.trim()||nameDraft===u.name} style={{...btnS(t.f1),fontSize:10,padding:"5px 9px",opacity:nameDraft.trim()&&nameDraft!==u.name?1:.45}}>Save</button>
+              </div>
+            </div>
+            <div style={{display:"flex",gap:6,minWidth:0}}>
+              <input type="password" value={pwdDraft} onChange={e=>setUserPasswordDrafts(p=>({...p,[u.id]:e.target.value}))} placeholder={u.password_enabled&&!isCurrent?"Password or new password":"New password"} style={{...inputS,fontSize:12,padding:"7px 9px"}}/>
+              <button onClick={()=>updateManagedUser(u.id,{password:pwdDraft})} disabled={!pwdDraft} style={{...btnS(t.warm),fontSize:10,padding:"5px 9px",opacity:pwdDraft?1:.45,whiteSpace:"nowrap"}}>Set</button>
+              {u.password_enabled&&<button onClick={()=>updateManagedUser(u.id,{clear_password:true})} style={{...btnS(t.mut),fontSize:10,padding:"5px 9px",whiteSpace:"nowrap"}}>Clear</button>}
+            </div>
+            <div style={{display:"flex",gap:6,justifyContent:"flex-end"}}>
+              {!isCurrent&&<button onClick={()=>{setLoginUserId(u.id);loginAsUser(u.id,u.password_enabled?pwdDraft:"");}} style={{...btnS(t.acc),fontSize:10,padding:"5px 9px"}}>Switch</button>}
+              {u.id!=="default"&&<button onClick={()=>deleteManagedUser(u)} style={{...btnS(t.err),fontSize:10,padding:"5px 9px"}}><IC.Trash/></button>}
+            </div>
+          </div>;})}
+        </div>
+      </div>
+
       {/* TILE: Connections */}
       <div style={{...settingsCardS,display:settingsTab==="connections"?"block":"none"}}>
         <div style={{display:"flex",justifyContent:"space-between",gap:12,alignItems:"flex-start",marginBottom:12}}>
@@ -8665,6 +8969,7 @@ function HyprChat(){
               const personaName=!isU&&act?.persona_name;
               const msgProfileType=personaName?getConversationProfileType(act):null;
               const personaColor=!isU&&personaName?(msgProfileType==="persona"?t.pink:t.acc):t.acc;
+              const renderedContent=!isU?replacePersonaPlaceholdersForConversation(msg.content||"",act):msg.content;
               return <React.Fragment key={i}>
               {showQS&&<div style={{marginBottom:16,animation:"fadeIn .3s"}}>
                 <div style={{fontSize:10,fontWeight:700,color:t.f1,textTransform:"uppercase",letterSpacing:.5,marginBottom:8,display:"flex",alignItems:"center",gap:4}}>
@@ -8697,14 +9002,14 @@ function HyprChat(){
                 </div>
               </div>}
               <div style={{marginBottom:compactMode?7:18,display:"flex",gap:9,alignItems:"flex-start",animation:`fadeIn .3s ${Math.min(i*.04,.2)}s both`}}>
-                <div style={{width:28,height:28,borderRadius:7,display:"flex",alignItems:"center",justifyContent:"center",background:isU?t.bgDeep:`${personaColor}10`,border:`1px solid ${isU?t.f4:personaColor}38`,color:isU?t.f4:personaColor,flexShrink:0,marginTop:3,overflow:"hidden",boxShadow:"none"}}>
+                <div style={{width:isU?28:40,height:isU?28:40,borderRadius:isU?7:10,display:"flex",alignItems:"center",justifyContent:"center",background:isU?t.bgDeep:`${personaColor}10`,border:`1px solid ${isU?t.f4:personaColor}38`,color:isU?t.f4:personaColor,flexShrink:0,marginTop:isU?3:1,overflow:"hidden",boxShadow:"none"}}>
                   {isU?<IC.User/>:personaAvatar?<img src={avatarSrc(personaAvatar)} style={{width:"100%",height:"100%",objectFit:"cover"}} alt=""/>:<IC.Bot/>}
                 </div>
                 <div style={{flex:1,minWidth:0,maxWidth:isU?"min(760px,92%)":"100%"}}>
                   <div style={{fontSize:11,marginBottom:5,fontWeight:600,letterSpacing:.4,display:"flex",alignItems:"center",gap:6}}>
                     {isU?<span style={{color:t.mut}}>you</span>:personaName
                       ?<span style={{display:"inline-flex",alignItems:"center",gap:4,padding:"1px 7px",background:`${t.pink}15`,border:`1px solid ${t.pink}28`,borderRadius:10,color:t.pink}}>
-                        {personaAvatar&&<img src={avatarSrc(personaAvatar)} style={{width:11,height:11,borderRadius:3,objectFit:"cover"}} alt=""/>}
+                        {personaAvatar&&<img src={avatarSrc(personaAvatar)} style={{width:14,height:14,borderRadius:4,objectFit:"cover"}} alt=""/>}
                         {personaName}
                       </span>
                       :<span style={{color:t.mut}}>{act.model||"assistant"}</span>}
@@ -8720,7 +9025,7 @@ function HyprChat(){
                         <button onClick={()=>setEditingMsg(null)} style={btnS(t.mut)}>Cancel</button>
                       </div>
                     </div>
-                    :msg.isS?mdStream(msg.content):<MDWrap>{md(msg.content)}</MDWrap>}
+                    :msg.isS?mdStream(renderedContent):<MDWrap>{md(renderedContent)}</MDWrap>}
                     {isU&&msg.metadata?.images?.length>0&&!isEditing&&<div style={{display:"flex",flexWrap:"wrap",gap:8,marginTop:msg.content?10:0}}>
                       {msg.metadata.images.map((img,ii)=><div key={ii} title={img.name} style={{display:"inline-flex",flexDirection:"column",gap:4,alignItems:"flex-start",maxWidth:260}}>
                         <img src={img.dataUrl} alt={img.name} onClick={()=>openPreview&&openPreview(img.name,img.dataUrl)} style={{maxWidth:260,maxHeight:200,borderRadius:8,border:`1px solid ${t.acc}33`,cursor:"pointer",display:"block",boxShadow:"none"}}/>
@@ -8775,7 +9080,7 @@ function HyprChat(){
                     {!collapsed&&d.stderr&&<pre style={{margin:0,padding:"8px 12px",whiteSpace:"pre-wrap",color:t.err,fontSize:11,lineHeight:1.5,background:`${t.err}08`,fontFamily:font}}>{d.stderr}</pre>}
                   </div>;});})()}
                   {!msg.isS&&!isEditing&&<div style={msgToolbarS}>
-                    {!isU&&msg.content&&<button onClick={()=>cp(msg.content,mid)} style={msgActionS(copied===mid?t.ok:t.mut)}>
+                    {!isU&&msg.content&&<button onClick={()=>cp(renderedContent,mid)} style={msgActionS(copied===mid?t.ok:t.mut)}>
                       {copied===mid?<><IC.Check/> copied</>:<><IC.Copy/> copy</>}
                     </button>}
                     {!isU&&msg.content&&!streaming&&<div style={{position:"relative",display:"inline-flex"}}>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -2955,6 +2955,7 @@ function HyprChat(){
   const [pendingEffort,setPendingEffort]=useState(null);
   const [pendingPersona,setPendingPersona]=useState(null);
   const [pendingModel,setPendingModel]=useState(()=>{try{return localStorage.getItem("hc-last-model")||"";}catch{return "";}});
+  const modelChoiceRef=useRef({pending:"",byConv:{}});
   const [showExportMenu,setShowExportMenu]=useState(false);
   const effortPickerRef=useRef(null);
   const exportMenuRef=useRef(null);
@@ -3459,6 +3460,7 @@ function HyprChat(){
   const pendingChatModel=normalizeAvailableModel(pendingPersona?.model||pendingModel||storedLastModel()||models[0]||"");
   const setPendingChatModel=(modelName)=>{
     const chosen=normalizeAvailableModel(modelName)||modelName||"";
+    modelChoiceRef.current.pending=chosen;
     setPendingModel(chosen);
     if(chosen)try{localStorage.setItem("hc-last-model",chosen);}catch{}
     setPendingPersona(p=>p?{...p,model:chosen}:p);
@@ -3510,7 +3512,7 @@ function HyprChat(){
     }else if(profileFirstMessage(payload)){
       setPendingPersona(null);setPendingToolIds([]);
       await newChat(true,{personaOverride:payload});
-    }else{setPendingPersona(payload);setPendingToolIds(payload.tool_ids||[]);setPendingModel(payload.model||pendingChatModel||"");}
+    }else{const pendingProfileModel=payload.model||pendingChatModel||"";modelChoiceRef.current.pending=pendingProfileModel;setPendingPersona(payload);setPendingToolIds(payload.tool_ids||[]);setPendingModel(pendingProfileModel);}
     setLastPersonaId(mc.id);localStorage.setItem("hc-last-persona",mc.id);setPanel("chat");
   };
   const clearPendingProfile=()=>{setPendingPersona(null);setPendingToolIds([]);setLastPersonaId(null);try{localStorage.removeItem("hc-last-persona");}catch{};};
@@ -4397,6 +4399,9 @@ function HyprChat(){
   };
 
   const uConv=useCallback((id,u)=>{
+    if(typeof u!=="function"&&u&&Object.prototype.hasOwnProperty.call(u,"model")){
+      modelChoiceRef.current.byConv[id]=u.model||"";
+    }
     setConvs(p=>p.map(c=>{
       if(c.id!==id)return c;
       const updated=typeof u==="function"?u(c):{...c,...u};
@@ -4405,7 +4410,10 @@ function HyprChat(){
         if(JSON.stringify(updated[k])!==JSON.stringify(c[k])&&updated[k]!==undefined)patch[k]=updated[k];
       }
       // Remember last-used model for new chats
-      if(patch.model)try{localStorage.setItem("hc-last-model",patch.model);}catch{}
+      if(patch.model){
+        modelChoiceRef.current.byConv[id]=patch.model;
+        try{localStorage.setItem("hc-last-model",patch.model);}catch{}
+      }
       if(Object.keys(patch).length&&!id.startsWith("l-")&&!id.startsWith("ghost-")){
         fetch(`${API}/api/conversations/${id}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify(patch)}).catch(()=>{});
       }
@@ -4463,7 +4471,8 @@ function HyprChat(){
     }
 
     const lastModel=storedLastModel();
-    let defaultModel=persona?.model||curConv?.model||(forceBlank?pendingChatModel:"")||lastModel||models[0]||"qwen3.5:27b";
+    const currentModel=curConv?(modelChoiceRef.current.byConv[curConv.id]||curConv.model):"";
+    let defaultModel=persona?.model||currentModel||(forceBlank?(modelChoiceRef.current.pending||pendingChatModel):"")||lastModel||models[0]||"qwen3.5:27b";
     if(defaultModel&&models.length>0&&!models.includes(defaultModel))defaultModel=models[0]||"";
     const pendingTools=forceBlank?(persona?.tool_ids||(opts.carryCurrent?(curConv?.tool_ids||[]):pendingToolIds)):[];
     const pendingEffortValue=forceBlank&&pendingEffort!==null?pendingEffort:null;
@@ -4472,6 +4481,7 @@ function HyprChat(){
     if(useGhost){
       const newId=`ghost-${Date.now()}-${Math.random().toString(16).slice(2,8)}`;
       const c={id:newId,title:"Ghost Chat",messages:[],model:defaultModel,system_prompt:persona?.system_prompt||(opts.carryCurrent?(curConv?.system_prompt||""):""),...(persona||{}),tool_ids:pendingTools,ephemeral:true};
+      modelChoiceRef.current.byConv[newId]=c.model||defaultModel;
       const firstMsg=persona?makeProfileFirstMessage(persona):null;
       if(firstMsg)c.messages=[firstMsg];
       if(pendingEffortValue!==null)setEffortPerChat(p=>({...p,[newId]:pendingEffortValue}));
@@ -4483,6 +4493,7 @@ function HyprChat(){
     try{
       const r=await fetch(`${API}/api/conversations`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({title:"New Chat",model:defaultModel,use_memories:pendingMemoryValue})});
       const c=await r.json();c.messages=[];c.use_memories=c.use_memories??pendingMemoryValue;
+      modelChoiceRef.current.byConv[c.id]=c.model||defaultModel;
       // Apply persona directly to the conv object before adding to state
       if(persona){
         Object.assign(c,persona);
@@ -4502,6 +4513,7 @@ function HyprChat(){
     }catch{
       const newId=`l-${Date.now()}`;
       const c={id:newId,title:"New Chat",messages:[],model:defaultModel,system_prompt:persona?.system_prompt||"",...(persona||{}),tool_ids:pendingTools,use_memories:pendingMemoryValue};
+      modelChoiceRef.current.byConv[newId]=c.model||defaultModel;
       const firstMsg=persona?makeProfileFirstMessage(persona):null;
       if(firstMsg)c.messages=[firstMsg];
       if(pendingEffortValue!==null)setEffortPerChat(p=>({...p,[newId]:pendingEffortValue}));
@@ -4780,7 +4792,7 @@ function HyprChat(){
         return out;
       });
       // Get model-specific params, falling back to globals
-      let modelName=overrides.model||cv?.model||models[0]||"";
+      let modelName=overrides.model||modelChoiceRef.current.byConv[cid]||cv?.model||models[0]||"";
       // If the selected model is no longer available, fall back to first available
       if(modelName&&models.length>0&&!models.includes(modelName)){
         const fb=models[0]||"";
@@ -9301,7 +9313,7 @@ function HyprChat(){
               {showQuickMenu&&<div style={{position:"absolute",bottom:"115%",left:0,zIndex:300,background:t.bgDeep,border:`1px solid ${t.brd}44`,borderRadius:12,boxShadow:`0 4px 24px #0008`,minWidth:220,padding:7,display:"flex",flexDirection:"column",gap:4}}>
                 <button onClick={()=>{fileRef.current?.click();setShowQuickMenu(false);}} style={{display:"flex",alignItems:"center",gap:8,width:"100%",padding:"8px 10px",borderRadius:8,border:"none",background:`${t.surface}66`,color:t.dim,cursor:"pointer",fontFamily:font,fontSize:12,textAlign:"left"}}><IC.Paperclip/> Attach files</button>
                 {prompts.length>0&&<button onClick={()=>{setShowPromptPicker(true);setPromptSearch("");setShowQuickMenu(false);}} style={{display:"flex",alignItems:"center",gap:8,width:"100%",padding:"8px 10px",borderRadius:8,border:"none",background:showPromptPicker?`${t.f1}18`:`${t.surface}66`,color:showPromptPicker?t.f1:t.dim,cursor:"pointer",fontFamily:font,fontSize:12,textAlign:"left"}}>⚡ Prompt Library</button>}
-                {(()=>{const coderMc=mcs.find(m=>isCoderPersonaName(m.name));const isCoderActive=isCoderPersonaName(act?.persona_name)||(!actId&&isCoderPersonaName(pendingPersona?.persona_name));return coderMc?<button onClick={()=>{setShowQuickMenu(false);if(!actId){if(isCoderActive){setPendingPersona(null);setPendingToolIds([]);setLastPersonaId(null);localStorage.removeItem("hc-last-persona");return;}const persona={model:coderMc.base_model||models[0]||"qwen3.5:27b",system_prompt:coderMc.system_prompt,tool_ids:coderMc.tool_ids||[],model_config_id:coderMc.id,persona_name:coderMc.name,persona_avatar:profileAvatar(coderMc)};setPendingPersona(persona);setPendingToolIds(persona.tool_ids||[]);setLastPersonaId(coderMc.id);localStorage.setItem("hc-last-persona",coderMc.id);return;}if(isCoderActive){uConv(actId,{model_config_id:null,persona_name:null,persona_avatar:null,system_prompt:"",tool_ids:[]});setLastPersonaId(null);localStorage.removeItem("hc-last-persona");return;}uConv(actId,{model:coderMc.base_model||act?.model,system_prompt:coderMc.system_prompt,tool_ids:coderMc.tool_ids||[],model_config_id:coderMc.id,persona_name:coderMc.name,persona_avatar:profileAvatar(coderMc)});setLastPersonaId(coderMc.id);localStorage.setItem("hc-last-persona",coderMc.id);}} style={{display:"flex",alignItems:"center",gap:8,width:"100%",padding:"8px 10px",borderRadius:8,border:"none",background:isCoderActive?`${t.ok}18`:`${t.surface}66`,color:isCoderActive?t.ok:t.dim,cursor:"pointer",fontFamily:font,fontSize:12,textAlign:"left"}}>&lt;/&gt; {isCoderActive?"Disable Daedalus":"Activate Daedalus"}</button>:null;})()}
+                {(()=>{const coderMc=mcs.find(m=>isCoderPersonaName(m.name));const isCoderActive=isCoderPersonaName(act?.persona_name)||(!actId&&isCoderPersonaName(pendingPersona?.persona_name));return coderMc?<button onClick={()=>{setShowQuickMenu(false);if(!actId){if(isCoderActive){setPendingPersona(null);setPendingToolIds([]);setLastPersonaId(null);localStorage.removeItem("hc-last-persona");return;}const persona={model:coderMc.base_model||models[0]||"qwen3.5:27b",system_prompt:coderMc.system_prompt,tool_ids:coderMc.tool_ids||[],model_config_id:coderMc.id,persona_name:coderMc.name,persona_avatar:profileAvatar(coderMc)};modelChoiceRef.current.pending=persona.model||"";setPendingPersona(persona);setPendingToolIds(persona.tool_ids||[]);setLastPersonaId(coderMc.id);localStorage.setItem("hc-last-persona",coderMc.id);return;}if(isCoderActive){uConv(actId,{model_config_id:null,persona_name:null,persona_avatar:null,system_prompt:"",tool_ids:[]});setLastPersonaId(null);localStorage.removeItem("hc-last-persona");return;}uConv(actId,{model:coderMc.base_model||act?.model,system_prompt:coderMc.system_prompt,tool_ids:coderMc.tool_ids||[],model_config_id:coderMc.id,persona_name:coderMc.name,persona_avatar:profileAvatar(coderMc)});setLastPersonaId(coderMc.id);localStorage.setItem("hc-last-persona",coderMc.id);}} style={{display:"flex",alignItems:"center",gap:8,width:"100%",padding:"8px 10px",borderRadius:8,border:"none",background:isCoderActive?`${t.ok}18`:`${t.surface}66`,color:isCoderActive?t.ok:t.dim,cursor:"pointer",fontFamily:font,fontSize:12,textAlign:"left"}}>&lt;/&gt; {isCoderActive?"Disable Daedalus":"Activate Daedalus"}</button>:null;})()}
               </div>}
             </div>
             <input ref={fileRef} type="file" multiple style={{display:"none"}} onChange={e=>{if(e.target.files?.length)handleFileUpload(Array.from(e.target.files));e.target.value="";}}/>

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -821,6 +821,7 @@ const IC={
   Trash:()=>sv(<><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></>,14),
   Sidebar:()=>sv(<><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></>,18),
   Bot:()=>sv(<><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/></>),
+  Ghost:()=>sv(<><path d="M9 10h.01"/><path d="M15 10h.01"/><path d="M12 2a7 7 0 0 0-7 7v11l2-1.5L9 20l3-2 3 2 2-1.5L19 20V9a7 7 0 0 0-7-7z"/></>,15),
   User:()=>sv(<><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></>),
   Copy:()=>sv(<><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></>,14),
   Check:()=>sv(<polyline points="20 6 9 17 4 12"/>,14),
@@ -1660,17 +1661,40 @@ const Tip=({k,t})=>{const [show,setShow]=React.useState(false);const txt=TIPS[k]
 // ============================================================
 // WORKSPACE DETAIL COMPONENT
 // ============================================================
-function WorkspaceDetail({ws,wsLoading,t,API,workspaces,setWorkspaces,setActiveWs,setWsDetail,convs,onOpenConv,onOpenReport,onRemoveReport,onPreview,models,wsModel,onPersonaCreated}){
+function WorkspaceDetail({ws,wsLoading,t,API,workspaces,setWorkspaces,setActiveWs,setWsDetail,convs,onOpenConv,onOpenReport,onRemoveReport,onPreview,models,wsModel,onPersonaCreated,notify}){
   const [tab,setTab]=React.useState("convs");
   const [editMode,setEditMode]=React.useState(false);
   const [wsName,setWsName]=React.useState("");
   const [wsDesc,setWsDesc]=React.useState("");
+  const [wsInstructions,setWsInstructions]=React.useState("");
   const [addPanel,setAddPanel]=React.useState(false);
   const [addSearch,setAddSearch]=React.useState("");
   const [analyzing,setAnalyzing]=React.useState(false);
   const [analyzeMsg,setAnalyzeMsg]=React.useState(null);
   const [creatingKb,setCreatingKb]=React.useState(false);
-  React.useEffect(()=>{if(ws){setWsName(ws.name||"");setWsDesc(ws.description||"");};},[ws?.id]);
+  const [memories,setMemories]=React.useState([]);
+  const [memBlocks,setMemBlocks]=React.useState([]);
+  const [memLoading,setMemLoading]=React.useState(false);
+  const [memEdit,setMemEdit]=React.useState(null);
+  const [memEditText,setMemEditText]=React.useState("");
+  const [newMemText,setNewMemText]=React.useState("");
+  const [newMemType,setNewMemType]=React.useState("semantic");
+  const [memScanning,setMemScanning]=React.useState(false);
+  React.useEffect(()=>{if(ws){setWsName(ws.name||"");setWsDesc(ws.description||"");setWsInstructions(ws.instructions||"");};},[ws?.id]);
+  const refreshMemory=React.useCallback(async()=>{
+    if(!ws?.id)return;
+    setMemLoading(true);
+    try{
+      const [mr,br]=await Promise.all([
+        fetch(`${API}/api/workspaces/${ws.id}/memories?status=all`).then(r=>r.json()),
+        fetch(`${API}/api/workspaces/${ws.id}/memory-blocks`).then(r=>r.json()),
+      ]);
+      setMemories(Array.isArray(mr.memories)?mr.memories:[]);
+      setMemBlocks(Array.isArray(br.blocks)?br.blocks:[]);
+    }catch(e){notify&&notify({type:"error",text:"Memory failed to load",detail:e.message||String(e)});}
+    setMemLoading(false);
+  },[API,ws?.id,notify]);
+  React.useEffect(()=>{if(ws?.id&&tab==="memory")refreshMemory();},[ws?.id,tab,refreshMemory]);
   if(wsLoading)return<div style={{flex:1,display:"flex",alignItems:"center",justifyContent:"center",color:t.mut}}><div style={{textAlign:"center"}}><div style={{fontSize:24,marginBottom:8}}>⏳</div>Loading workspace...</div></div>;
   if(!ws)return<div style={{flex:1,display:"flex",alignItems:"center",justifyContent:"center",color:t.mut}}><div style={{textAlign:"center"}}><div style={{fontSize:36,marginBottom:8}}>🗂</div>Select a workspace</div></div>;
   const font="'JetBrains Mono',monospace";
@@ -1729,6 +1753,71 @@ function WorkspaceDetail({ws,wsLoading,t,API,workspaces,setWorkspaces,setActiveW
     setWorkspaces(p=>p.filter(w=>w.id!==ws.id));
     setActiveWs(null);setWsDetail(null);
   };
+  const patchWsMemory=async(fields)=>{
+    await fetch(`${API}/api/workspaces/${ws.id}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify(fields)}).catch(()=>{});
+    setWsDetail(d=>({...d,...fields}));
+    setWorkspaces(p=>p.map(w=>w.id===ws.id?{...w,...fields}:w));
+  };
+  const toggleMemory=()=>patchWsMemory({memory_enabled:(ws.memory_enabled==="1"||ws.memory_enabled===1||ws.memory_enabled===true)?0:1});
+  const saveInstructions=async()=>{
+    await patchWsMemory({instructions:wsInstructions});
+    notify&&notify({type:"success",text:"Workspace instructions saved",duration:2200});
+  };
+  const scanMemory=async()=>{
+    if(!ws?.id)return;
+    setMemScanning(true);
+    try{
+      const r=await fetch(`${API}/api/workspaces/${ws.id}/memories/suggest`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({model:wsModel||""})});
+      const d=await r.json();
+      if(!r.ok)throw new Error(d.detail||`HTTP ${r.status}`);
+      await refreshMemory();
+      notify&&notify({type:d.created?"success":"info",text:d.created?`Queued ${d.created} memory suggestion${d.created===1?"":"s"}`:"No new memory suggestions",detail:d.message||"",duration:4200});
+    }catch(e){notify&&notify({type:"error",text:"Memory scan failed",detail:e.message||String(e)});}
+    setMemScanning(false);
+  };
+  const saveBlocks=async(blocks=memBlocks)=>{
+    try{
+      const r=await fetch(`${API}/api/workspaces/${ws.id}/memory-blocks`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({blocks})});
+      const d=await r.json();
+      setMemBlocks(d.blocks||[]);
+      notify&&notify({type:"success",text:"Memory blocks saved",duration:2200});
+    }catch(e){notify&&notify({type:"error",text:"Memory block save failed",detail:e.message||String(e)});}
+  };
+  const updateBlock=(id,patch)=>setMemBlocks(p=>p.map(b=>b.id===id?{...b,...patch}:b));
+  const updateMemoryLocal=(m)=>setMemories(p=>p.map(x=>x.id===m.id?m:x));
+  const acceptMemory=async(m)=>{
+    try{const r=await fetch(`${API}/api/workspaces/${ws.id}/memories/${m.id}/accept`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({})});updateMemoryLocal(await r.json());notify&&notify({type:"success",text:"Memory accepted",duration:2200});}
+    catch(e){notify&&notify({type:"error",text:"Accept failed",detail:e.message||String(e)});}
+  };
+  const rejectMemory=async(m)=>{
+    try{const r=await fetch(`${API}/api/workspaces/${ws.id}/memories/${m.id}/reject`,{method:"POST"});updateMemoryLocal(await r.json());}
+    catch(e){notify&&notify({type:"error",text:"Reject failed",detail:e.message||String(e)});}
+  };
+  const patchMemory=async(m,patch)=>{
+    try{const r=await fetch(`${API}/api/workspaces/${ws.id}/memories/${m.id}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify(patch)});updateMemoryLocal(await r.json());}
+    catch(e){notify&&notify({type:"error",text:"Memory update failed",detail:e.message||String(e)});}
+  };
+  const deleteMemory=async(m)=>{
+    try{await fetch(`${API}/api/workspaces/${ws.id}/memories/${m.id}`,{method:"DELETE"});setMemories(p=>p.filter(x=>x.id!==m.id));}
+    catch(e){notify&&notify({type:"error",text:"Delete failed",detail:e.message||String(e)});}
+  };
+  const startMemEdit=(m)=>{setMemEdit(m.id);setMemEditText(m.content||"");};
+  const saveMemEdit=async(m,accept=false)=>{
+    const r=await fetch(`${API}/api/workspaces/${ws.id}/memories/${m.id}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({content:memEditText})});
+    let updated=await r.json();
+    if(accept&&updated.status!=="accepted"){
+      const ar=await fetch(`${API}/api/workspaces/${ws.id}/memories/${m.id}/accept`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({})});
+      updated=await ar.json();
+    }
+    updateMemoryLocal(updated);setMemEdit(null);setMemEditText("");
+  };
+  const createManualMemory=async()=>{
+    const content=newMemText.trim();if(!content)return;
+    try{
+      const r=await fetch(`${API}/api/workspaces/${ws.id}/memories`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({content,type:newMemType,status:"accepted",importance:3})});
+      const m=await r.json();setMemories(p=>[m,...p]);setNewMemText("");notify&&notify({type:"success",text:"Memory added",duration:2200});
+    }catch(e){notify&&notify({type:"error",text:"Memory add failed",detail:e.message||String(e)});}
+  };
   const fileIcon=(filename)=>{
     const ext=(filename||"").split(".").pop().toLowerCase();
     if(["py","js","ts","rs","go","java","c","cpp"].includes(ext))return "💻";
@@ -1762,7 +1851,7 @@ function WorkspaceDetail({ws,wsLoading,t,API,workspaces,setWorkspaces,setActiveW
       </div>}
     </div>
     <div style={{display:"flex",gap:0,borderBottom:`1px solid ${t.brd}22`,flexShrink:0}}>
-      {[["convs","💬 Conversations"],["reports","📊 Reports"],["files","📎 Files"]].map(([id,label])=><button key={id} onClick={()=>{setTab(id);setAddPanel(false);}} style={{padding:"10px 16px",background:tab===id?`${t.acc}15`:"transparent",border:"none",borderBottom:tab===id?`2px solid ${t.acc}`:"2px solid transparent",color:tab===id?t.acc:t.mut,cursor:"pointer",fontFamily:font,fontSize:11,fontWeight:tab===id?700:400}}>{label}</button>)}
+      {[["convs","💬 Conversations"],["memory","🧠 Memory"],["reports","📊 Reports"],["files","📎 Files"]].map(([id,label])=><button key={id} onClick={()=>{setTab(id);setAddPanel(false);}} style={{padding:"10px 16px",background:tab===id?`${t.acc}15`:"transparent",border:"none",borderBottom:tab===id?`2px solid ${t.acc}`:"2px solid transparent",color:tab===id?t.acc:t.mut,cursor:"pointer",fontFamily:font,fontSize:11,fontWeight:tab===id?700:400}}>{label}</button>)}
       {tab==="convs"&&<button onClick={()=>setAddPanel(p=>!p)} style={{marginLeft:"auto",padding:"10px 14px",background:addPanel?`${t.warm}15`:"transparent",border:"none",borderBottom:addPanel?`2px solid ${t.warm}`:"2px solid transparent",color:addPanel?t.warm:t.mut,cursor:"pointer",fontFamily:font,fontSize:11}}>+ Add Chats</button>}
     </div>
     {addPanel&&<div style={{padding:12,borderBottom:`1px solid ${t.brd}22`,background:`${t.warm}07`,animation:"fadeIn .2s",flexShrink:0}}>
@@ -1789,6 +1878,67 @@ function WorkspaceDetail({ws,wsLoading,t,API,workspaces,setWorkspaces,setActiveW
           <button onClick={()=>removeConv(c.id)} style={btnS(t.err)}>✕</button>
         </div>)}
       </div>}
+      {tab==="memory"&&(()=>{const enabled=ws.memory_enabled==="1"||ws.memory_enabled===1||ws.memory_enabled===true;const byStatus=s=>memories.filter(m=>m.status===s);const accepted=byStatus("accepted").filter(m=>!m.valid_until);const suggested=byStatus("suggested");const hidden=memories.filter(m=>["rejected","archived"].includes(m.status)||m.valid_until);const typeMeta={semantic:["Facts & Preferences",t.acc],episodic:["Decisions & Events",t.warm],procedural:["Procedures",t.pink]};const card=(m,mode)=>{const meta=typeMeta[m.type]||typeMeta.semantic;const editing=memEdit===m.id;return <div key={m.id} style={{padding:"10px 12px",borderRadius:10,background:`${t.surface}66`,border:`1px solid ${meta[1]}33`,display:"flex",flexDirection:"column",gap:7}}>
+          <div style={{display:"flex",alignItems:"center",gap:6}}>
+            <span style={{fontSize:9,fontWeight:800,color:meta[1],textTransform:"uppercase",letterSpacing:.6}}>{meta[0]}</span>
+            <span style={{fontSize:9,color:t.mut}}>importance {m.importance||3}</span>
+            {m.pinned? <span style={{fontSize:9,color:t.warm}}>pinned</span>:null}
+            {m.confidence? <span style={{fontSize:9,color:t.mut}}>{Math.round((m.confidence||0)*100)}%</span>:null}
+          </div>
+          {editing?<textarea value={memEditText} onChange={e=>setMemEditText(e.target.value)} style={{...inputS,minHeight:72,lineHeight:1.5,resize:"vertical"}}/>:<div style={{fontSize:12,lineHeight:1.55,color:t.text,whiteSpace:"pre-wrap"}}>{m.content}</div>}
+          {m.metadata?.reason&&<div style={{fontSize:10,color:t.mut,lineHeight:1.4}}>Why: {m.metadata.reason}</div>}
+          <div style={{display:"flex",gap:5,flexWrap:"wrap",alignItems:"center"}}>
+            {editing?<><button onClick={()=>saveMemEdit(m,mode==="suggested")} style={btnS(t.ok)}>{mode==="suggested"?"Save + Accept":"Save"}</button><button onClick={()=>{setMemEdit(null);setMemEditText("");}} style={btnS(t.mut)}>Cancel</button></>
+            :mode==="suggested"?<><button onClick={()=>acceptMemory(m)} style={btnS(t.ok)}>Accept</button><button onClick={()=>startMemEdit(m)} style={btnS(t.acc)}>Edit</button><button onClick={()=>rejectMemory(m)} style={btnS(t.err)}>Reject</button></>
+            :<><button onClick={()=>patchMemory(m,{pinned:m.pinned?0:1})} style={btnS(m.pinned?t.warm:t.mut)}>{m.pinned?"Unpin":"Pin"}</button><button onClick={()=>startMemEdit(m)} style={btnS(t.acc)}>Edit</button><button onClick={()=>patchMemory(m,{status:"archived"})} style={btnS(t.mut)}>Archive</button><button onClick={()=>deleteMemory(m)} style={btnS(t.err)}>Delete</button></>}
+            {m.source_conversation_id&&<button onClick={()=>onOpenConv&&onOpenConv(m.source_conversation_id)} style={{...btnS(t.f1),marginLeft:"auto"}}>Source →</button>}
+          </div>
+        </div>;};return <div style={{display:"flex",flexDirection:"column",gap:14}}>
+        <div style={{display:"flex",alignItems:"center",gap:10,padding:"10px 12px",borderRadius:10,background:`${enabled?t.ok:t.surface}10`,border:`1px solid ${enabled?t.ok:t.brd}33`}}>
+          <button onClick={toggleMemory} style={btnS(enabled?t.ok:t.mut)}>{enabled?"On":"Off"}</button>
+          <div style={{flex:1,minWidth:0}}>
+            <div style={{fontSize:12,fontWeight:700,color:enabled?t.ok:t.text}}>Workspace memory {enabled?"enabled":"disabled"}</div>
+            <div style={{fontSize:10,color:t.mut,marginTop:2}}>Accepted memories and enabled blocks are injected into workspace chats. Suggestions are never injected until accepted.</div>
+          </div>
+          <button onClick={scanMemory} disabled={memScanning} style={btnS(t.warm)}>{memScanning?"Scanning":"Scan Recent"}</button>
+          <button onClick={refreshMemory} disabled={memLoading} style={btnS(t.acc)}>{memLoading?"Loading":"Refresh"}</button>
+        </div>
+        <div style={{display:"grid",gridTemplateColumns:"minmax(0,1fr) minmax(260px,.55fr)",gap:12,alignItems:"start"}}>
+          <div style={{display:"flex",flexDirection:"column",gap:8}}>
+            <div style={{fontSize:10,fontWeight:800,color:t.acc,textTransform:"uppercase",letterSpacing:.7}}>Workspace Instructions</div>
+            <textarea value={wsInstructions} onChange={e=>setWsInstructions(e.target.value)} placeholder="Stable project instructions, constraints, tone, or goals..." style={{...inputS,minHeight:92,lineHeight:1.5,resize:"vertical"}}/>
+            <button onClick={saveInstructions} style={{...btnS(t.ok),alignSelf:"flex-start"}}>Save Instructions</button>
+          </div>
+          <div style={{display:"flex",flexDirection:"column",gap:8}}>
+            <div style={{fontSize:10,fontWeight:800,color:t.pink,textTransform:"uppercase",letterSpacing:.7}}>Add Memory</div>
+            <select value={newMemType} onChange={e=>setNewMemType(e.target.value)} style={inputS}><option value="semantic">Semantic</option><option value="episodic">Episodic</option><option value="procedural">Procedural</option></select>
+            <textarea value={newMemText} onChange={e=>setNewMemText(e.target.value)} placeholder="Add an accepted memory manually..." style={{...inputS,minHeight:78,lineHeight:1.5,resize:"vertical"}}/>
+            <button onClick={createManualMemory} disabled={!newMemText.trim()} style={{...btnS(t.ok),opacity:newMemText.trim()?1:.45,alignSelf:"flex-start"}}>Add Accepted Memory</button>
+          </div>
+        </div>
+        {memBlocks.length>0&&<div style={{display:"flex",flexDirection:"column",gap:8}}>
+          <div style={{display:"flex",justifyContent:"space-between",alignItems:"center"}}><div style={{fontSize:10,fontWeight:800,color:t.acc,textTransform:"uppercase",letterSpacing:.7}}>Pinned Blocks</div><button onClick={()=>saveBlocks()} style={btnS(t.ok)}>Save Blocks</button></div>
+          <div style={{display:"grid",gridTemplateColumns:"repeat(auto-fit,minmax(240px,1fr))",gap:8}}>
+            {memBlocks.map(b=><div key={b.id} style={{padding:10,borderRadius:10,background:`${t.surface}55`,border:`1px solid ${b.enabled?t.acc:t.brd}28`,display:"flex",flexDirection:"column",gap:6}}>
+              <div style={{display:"flex",alignItems:"center",gap:8}}><button onClick={()=>updateBlock(b.id,{enabled:b.enabled?0:1})} style={btnS(b.enabled?t.ok:t.mut)}>{b.enabled?"On":"Off"}</button><div style={{fontSize:11,fontWeight:800,color:t.text}}>{b.label}</div></div>
+              <div style={{fontSize:10,color:t.mut,lineHeight:1.35}}>{b.description}</div>
+              <textarea value={b.value||""} onChange={e=>updateBlock(b.id,{value:e.target.value})} style={{...inputS,minHeight:76,lineHeight:1.45,resize:"vertical"}}/>
+            </div>)}
+          </div>
+        </div>}
+        {suggested.length>0&&<div style={{display:"flex",flexDirection:"column",gap:8}}>
+          <div style={{fontSize:10,fontWeight:800,color:t.warm,textTransform:"uppercase",letterSpacing:.7}}>Suggestions ({suggested.length})</div>
+          {suggested.map(m=>card(m,"suggested"))}
+        </div>}
+        {Object.entries(typeMeta).map(([typ,[label,color]])=>{const items=accepted.filter(m=>m.type===typ);return <div key={typ} style={{display:"flex",flexDirection:"column",gap:8}}>
+          <div style={{fontSize:10,fontWeight:800,color,textTransform:"uppercase",letterSpacing:.7}}>{label} ({items.length})</div>
+          {items.length?items.map(m=>card(m,"accepted")):<div style={{fontSize:11,color:t.mut,padding:"12px 0"}}>No accepted {typ} memories.</div>}
+        </div>;})}
+        {hidden.length>0&&<details style={{borderTop:`1px solid ${t.brd}22`,paddingTop:10}}>
+          <summary style={{fontSize:10,color:t.mut,cursor:"pointer",fontWeight:800,textTransform:"uppercase",letterSpacing:.7}}>Rejected, archived, or superseded ({hidden.length})</summary>
+          <div style={{display:"flex",flexDirection:"column",gap:8,marginTop:8}}>{hidden.map(m=>card(m,"hidden"))}</div>
+        </details>}
+      </div>;})()}
       {tab==="reports"&&<div style={{display:"flex",flexDirection:"column",gap:8}}>
         {!(ws.reports||[]).length&&<div style={{textAlign:"center",padding:40,color:t.mut,fontSize:12}}>No reports yet.<br/>Add reports from Deep Research.</div>}
         {(ws.reports||[]).map(r=>{const sm={complete:[t.ok,"Complete"],running:[t.acc,"Running"],queued:[t.warm,"Queued"],failed:[t.err,"Failed"],cancelled:[t.mut,"Cancelled"]}[String(r.status||"queued").toLowerCase()]||[t.warm,"Queued"];return <div key={r.id} style={{padding:"10px 14px",borderRadius:10,background:`${t.surface}66`,border:`1px solid ${t.brd}33`,display:"flex",alignItems:"center",gap:10,animation:"fadeIn .3s"}}>
@@ -2674,6 +2824,7 @@ function HyprChat(){
   const [dragOver,setDragOver]=useState(false);
   const [prevDarkTheme,setPrevDarkTheme]=useState(()=>{try{return localStorage.getItem("hc-prev-dark")||"hyprflat";}catch{return "hyprflat";}});
   const [autoTitle,setAutoTitle]=useState(()=>{try{return localStorage.getItem("hc-auto-title")!=="false";}catch{return true;}});
+  const [ghostMode,setGhostMode]=useState(false);
   useEffect(()=>{try{localStorage.setItem("hc-auto-title",autoTitle?"true":"false");}catch{}},[autoTitle]);
   const [showSysPromptPicker,setShowSysPromptPicker]=useState(false);
   const [tokC,setTokC]=useState(0);
@@ -2828,6 +2979,8 @@ function HyprChat(){
   const chatEnd=useRef(null),inpRef=useRef(null),abortR=useRef(null),sseR=useRef(null),fileRef=useRef(null),loadReqRef=useRef(0),chatScrollRef=useRef(null),dlPanelRef=useRef(null),quickMenuRef=useRef(null),promptPickerRef=useRef(null),actIdRef=useRef(actId),titleSearchRef=useRef(null),ftsRef=useRef(null),importRef=useRef(null),charCardImportRef=useRef(null);
   actIdRef.current=actId;
   const act = convs.find(c=>c.id===actId);
+  const isGhostConv=(c)=>!!c?.ephemeral||String(c?.id||"").startsWith("ghost-");
+  const ghostActive=ghostMode||isGhostConv(act);
   const DAEDALUS_AVATAR="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMDAgMTAwJz48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9J2cnIHgxPScxMicgeTE9JzgnIHgyPSc4OCcgeTI9JzkyJyBncmFkaWVudFVuaXRzPSd1c2VyU3BhY2VPblVzZSc+PHN0b3Agc3RvcC1jb2xvcj0nIzBiMTIyMCcvPjxzdG9wIG9mZnNldD0nLjU1JyBzdG9wLWNvbG9yPScjMWQyYTQ0Jy8+PHN0b3Agb2Zmc2V0PScxJyBzdG9wLWNvbG9yPScjNGIyZDczJy8+PC9saW5lYXJHcmFkaWVudD48bGluZWFyR3JhZGllbnQgaWQ9J2EnIHgxPScyNCcgeTE9JzE4JyB4Mj0nNzgnIHkyPSc4NCcgZ3JhZGllbnRVbml0cz0ndXNlclNwYWNlT25Vc2UnPjxzdG9wIHN0b3AtY29sb3I9JyM4ZmQ4ZmYnLz48c3RvcCBvZmZzZXQ9Jy41NScgc3RvcC1jb2xvcj0nI2E4OGNmZicvPjxzdG9wIG9mZnNldD0nMScgc3RvcC1jb2xvcj0nIzZmZmZkMicvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHdpZHRoPScxMDAnIGhlaWdodD0nMTAwJyByeD0nMTgnIGZpbGw9J3VybCgjZyknLz48cGF0aCBkPSdNMTggNDloMTVNNjcgNDloMTVNNTAgMTh2MTNNNTAgNjl2MTNNMjkgMjlsLTktOU03MSA3MWw5IDknIHN0cm9rZT0nIzZmZmZkMicgc3Ryb2tlLXdpZHRoPSczJyBzdHJva2UtbGluZWNhcD0ncm91bmQnIG9wYWNpdHk9Jy43MicvPjxwYXRoIGQ9J00yOCA3MlYyOGgyMmMxNiAwIDI2IDkgMjYgMjJTNjYgNzIgNTAgNzJIMjh6JyBmaWxsPSdub25lJyBzdHJva2U9J3VybCgjYSknIHN0cm9rZS13aWR0aD0nNycgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCcvPjxwYXRoIGQ9J000MiAzNnYyOGg4YzkgMCAxNS01IDE1LTE0UzU5IDM2IDUwIDM2aC04eicgZmlsbD0nIzExMTgyNycgc3Ryb2tlPScjZDhlNmZmJyBzdHJva2Utd2lkdGg9JzMnIHN0cm9rZS1saW5lam9pbj0ncm91bmQnLz48Y2lyY2xlIGN4PSc1MCcgY3k9JzUwJyByPSc1JyBmaWxsPScjNmZmZmQyJy8+PGNpcmNsZSBjeD0nMjAnIGN5PScyMCcgcj0nNCcgZmlsbD0nI2E4OGNmZicvPjxjaXJjbGUgY3g9JzgwJyBjeT0nODAnIHI9JzQnIGZpbGw9JyM4ZmQ4ZmYnLz48L3N2Zz4=";
   const isDaedalusProfileName=(name)=>String(name||"").toLowerCase().includes("daedalus");
   const isCoderPersonaName = (name)=>{const n=(name||"").toLowerCase();return n.includes("coder")||n.includes("daedalus");};
@@ -2960,6 +3113,8 @@ function HyprChat(){
   // Quick search — derived from active conversation tool_ids, or pending empty-chat selections.
   const activeToolIds=act?(act.tool_ids||[]):pendingToolIds;
   const quickSearch = activeToolIds.includes("quick_search");
+  const activeMemoryWs=(wsDetail&&wsDetail.id&&Array.isArray(wsDetail.conversations)&&actId&&wsDetail.conversations.some(wc=>wc.id===actId))?wsDetail:null;
+  const memoryActive=!ghostActive&&activeMemoryWs&&(activeMemoryWs.memory_enabled==="1"||activeMemoryWs.memory_enabled===1||activeMemoryWs.memory_enabled===true);
   const storedLastModel=()=>{try{return localStorage.getItem("hc-last-model")||"";}catch{return "";}};
   const normalizeAvailableModel=(modelName)=>{
     const chosen=modelName||"";
@@ -2996,6 +3151,7 @@ function HyprChat(){
   const persistProfileFirstMessage=async(convId,payload)=>{
     const msg=makeProfileFirstMessage(payload);
     if(!msg)return null;
+    if(String(convId||"").startsWith("ghost-"))return msg;
     try{
       const r=await fetch(`${API}/api/conversations/${convId}/messages`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({role:"assistant",content:msg.content,metadata:msg.metadata})});
       const d=await r.json().catch(()=>({}));
@@ -3627,13 +3783,15 @@ function HyprChat(){
       // Check if messages exist — if not, fall through to reload from DB
       let _hasMessages=false;
       setConvs(prev=>{_hasMessages=prev.some(c=>c.id===id&&c.messages?.length>0);return prev;});
-      if(_hasMessages){setPanel("chat");return;}
+      if(_hasMessages){setGhostMode(false);setPanel("chat");return;}
     }
     // Save current council stream state to ref before switching away
     if(councilStreamRef.current?.cid===actIdRef.current&&councilStreamRef.current?.running){
       // Already tracked in ref by the stream loop — no action needed
     }
     const reqId = ++loadReqRef.current;
+    setConvs(prev=>prev.filter(c=>!isGhostConv(c)));
+    setGhostMode(false);
     setActId(id);setPanel("chat");setEvts([]);setExpandedPill(null);setQuickResults([]);
     // Check if we're navigating back to an active council stream
     const activeStream=councilStreamRef.current;
@@ -3781,7 +3939,7 @@ function HyprChat(){
       }
       // Remember last-used model for new chats
       if(patch.model)try{localStorage.setItem("hc-last-model",patch.model);}catch{}
-      if(Object.keys(patch).length&&!id.startsWith("l-")){
+      if(Object.keys(patch).length&&!id.startsWith("l-")&&!id.startsWith("ghost-")){
         fetch(`${API}/api/conversations/${id}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify(patch)}).catch(()=>{});
       }
       return updated;
@@ -3815,6 +3973,8 @@ function HyprChat(){
     let persona=null;
     if(forceBlank&&opts.personaOverride){
       persona={...opts.personaOverride,tool_ids:opts.personaOverride.tool_ids||[]};
+    }else if(forceBlank&&opts.carryCurrent&&curConv?.persona_name){
+      persona={model:curConv.model,system_prompt:curConv.system_prompt||"",tool_ids:curConv.tool_ids||[],model_config_id:curConv.model_config_id,persona_name:curConv.persona_name,persona_avatar:curConv.persona_avatar};
     }else if(forceBlank&&pendingPersona){
       persona={...pendingPersona,tool_ids:pendingToolIds};
     }else if(!forceBlank){
@@ -3826,8 +3986,19 @@ function HyprChat(){
     const lastModel=storedLastModel();
     let defaultModel=persona?.model||curConv?.model||(forceBlank?pendingChatModel:"")||lastModel||models[0]||"qwen3.5:27b";
     if(defaultModel&&models.length>0&&!models.includes(defaultModel))defaultModel=models[0]||"";
-    const pendingTools=forceBlank?(persona?.tool_ids||pendingToolIds):[];
+    const pendingTools=forceBlank?(persona?.tool_ids||(opts.carryCurrent?(curConv?.tool_ids||[]):pendingToolIds)):[];
     const pendingEffortValue=forceBlank&&pendingEffort!==null?pendingEffort:null;
+    const useGhost=ghostMode||opts.ephemeral;
+    if(useGhost){
+      const newId=`ghost-${Date.now()}-${Math.random().toString(16).slice(2,8)}`;
+      const c={id:newId,title:"Ghost Chat",messages:[],model:defaultModel,system_prompt:persona?.system_prompt||(opts.carryCurrent?(curConv?.system_prompt||""):""),...(persona||{}),tool_ids:pendingTools,ephemeral:true};
+      const firstMsg=persona?makeProfileFirstMessage(persona):null;
+      if(firstMsg)c.messages=[firstMsg];
+      if(pendingEffortValue!==null)setEffortPerChat(p=>({...p,[newId]:pendingEffortValue}));
+      setConvs(p=>[c,...p]);setActId(newId);setGhostMode(true);
+      setPanel("chat");setEvts([]);setSessionTokens(0);setCtxTokens(0);setGenTokens(0);setExpandedPill(null);setCouncilRunning(false);setCouncilResponses({});setCouncilHostContent("");
+      return opts.returnConv?c:newId;
+    }
     try{
       const r=await fetch(`${API}/api/conversations`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({title:"New Chat",model:defaultModel})});
       const c=await r.json();c.messages=[];
@@ -3859,6 +4030,8 @@ function HyprChat(){
   };
 
   const startBlankChat=()=>{
+    setGhostMode(false);
+    setConvs(p=>p.filter(c=>!isGhostConv(c)));
     setActId(null);
     clearPendingProfile();
     setPanel("chat");
@@ -3874,6 +4047,30 @@ function HyprChat(){
     setCouncilResponses({});
     setCouncilHostContent("");
     setLoadingConv(false);
+  };
+
+  const toggleGhostMode=async()=>{
+    if(streaming||councilRunning){
+      notify({type:"warning",text:"Finish the current response first",detail:"Ghost mode can only change between turns."});
+      return;
+    }
+    if(ghostActive){
+      setGhostMode(false);
+      if(isGhostConv(act)){
+        setConvs(p=>p.filter(c=>!isGhostConv(c)));
+        setActId(null);
+        setEvts([]);setQuickResults([]);setSessionTokens(0);setCtxTokens(0);setGenTokens(0);setExpandedPill(null);
+      }
+      notify({type:"info",text:"Ghost mode off",detail:"Saved chats will work normally again.",duration:2600});
+      return;
+    }
+    setGhostMode(true);
+    if(act&&!isGhostConv(act)){
+      await newChat(true,{ephemeral:true,carryCurrent:true});
+      notify({type:"info",text:"Ghost chat started",detail:"This chat stays local and is discarded on reload.",duration:3600});
+    }else{
+      notify({type:"info",text:"Ghost mode on",detail:"The next chat will not be saved or indexed.",duration:3600});
+    }
   };
 
   const closeSidebarSearch=()=>{
@@ -3902,7 +4099,7 @@ function HyprChat(){
   });
 
   const delChat=async id=>{
-    fetch(`${API}/api/conversations/${id}`,{method:"DELETE"}).catch(()=>{});
+    if(!String(id||"").startsWith("ghost-"))fetch(`${API}/api/conversations/${id}`,{method:"DELETE"}).catch(()=>{});
     setConvTags(p=>{const n={...p};delete n[id];return n;});
     setConvs(p=>{const n=p.filter(c=>c.id!==id);if(actId===id){setActId(n[0]?.id||null);setCouncilRunning(false);setCouncilResponses({});setCouncilHostContent("");}return n;});
   };
@@ -4080,6 +4277,7 @@ function HyprChat(){
     // doing it from the client too would race and create duplicates.
     try{
       const cv=convs.find(c=>c.id===cid)||{tool_ids:pendingToolIds,system_prompt:pendingPersona?.system_prompt||"",model_config_id:pendingPersona?.model_config_id||null,persona_name:pendingPersona?.persona_name||null,persona_avatar:pendingPersona?.persona_avatar||null,model:pendingPersona?.model};
+      const isGhostSend=!!overrides.ephemeral||ghostMode||isGhostConv(cv)||String(cid||"").startsWith("ghost-");
       let am = messagesToSend.map(m=>{
         let baseContent=m._fullContent||m.content||"";
         // After reload _fullContent is gone; reconstruct the `[Attached N image: ...]` hint
@@ -4131,6 +4329,9 @@ function HyprChat(){
 
       const ctrl=new AbortController();abortR.current=ctrl;
       const body={conversation_id:cid,model:modelName,messages:am,system_prompt:cv?.system_prompt||"",tool_ids:cv?.tool_ids||[],persona_id:overrides.persona_id!==undefined?overrides.persona_id:(cv?.model_config_id||null)};
+      if(isGhostSend)body.ephemeral=true;
+      const _wsForChat=(wsDetail&&wsDetail.id&&Array.isArray(wsDetail.conversations)&&wsDetail.conversations.some(wc=>wc.id===cid))?wsDetail:null;
+      if(_wsForChat?.id&&!isGhostSend)body.workspace_id=_wsForChat.id;
       // Send the user's typed text + attachment metadata separately so the backend's
       // defensive save persists the clean content + image previews (not the bloated
       // `[Attached N image: ...]` model-facing string).
@@ -4198,13 +4399,16 @@ function HyprChat(){
       // Save final assistant message state to DB. PATCH the row the backend already
       // created at stream start (preferred — exactly one row per turn). Fall back to
       // POST for older backends or if init/done didn't include a message_id.
-      if(_streamMsgId){
+      if(isGhostSend){
+        // Ghost chats are intentionally local-only: no assistant PATCH/POST,
+        // no title generation, no workspace memory suggestion source row.
+      }else if(_streamMsgId){
         fetch(`${API}/api/conversations/${cid}/messages/${_streamMsgId}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({content:full,metadata:_msgMeta})}).catch(()=>{});
       }else{
         fetch(`${API}/api/conversations/${cid}/messages`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({role:"assistant",content:full,metadata:_msgMeta})}).catch(()=>{});
       }
       // Auto-generate title after first exchange
-      if(autoTitle&&appendUser){const cv2=convs.find(c=>c.id===cid);const curTitle=cv2?.title||"";if(!curTitle||curTitle==="New Chat"||curTitle===appendUser.slice(0,40))fetch(`${API}/api/conversations/${cid}/generate-title`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({model:wsModel||""})}).then(r=>r.json()).then(d=>{if(d.title)uConv(cid,{title:d.title});}).catch(()=>{});}
+      if(!isGhostSend&&autoTitle&&appendUser){const cv2=convs.find(c=>c.id===cid);const curTitle=cv2?.title||"";if(!curTitle||curTitle==="New Chat"||curTitle===appendUser.slice(0,40))fetch(`${API}/api/conversations/${cid}/generate-title`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({model:wsModel||""})}).then(r=>r.json()).then(d=>{if(d.title)uConv(cid,{title:d.title});}).catch(()=>{});}
     }catch(e){if(e.name!=="AbortError"){setCurrentRunNotice({type:"failed",label:"Failed",detail:e.message||"Stream failed",at:Date.now()});uConv(cid,c=>{const m=[...(c.messages||[])];m[m.length-1]={...m[m.length-1],role:"assistant",content:`\`\`\`\n⚠ ${e.message}\n\`\`\``,isS:false};return{...c,messages:m};});}}
     setStreaming(false);setAttachments([]);streamingCidRef.current=null;
   };
@@ -4761,7 +4965,7 @@ function HyprChat(){
       setConvs(prev=>prev.map(c=>{
         if(c.model===m){
           const patch={model:fallback};
-          if(!c.id.startsWith("l-"))fetch(`${API}/api/conversations/${c.id}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify(patch)}).catch(()=>{});
+          if(!c.id.startsWith("l-")&&!c.id.startsWith("ghost-"))fetch(`${API}/api/conversations/${c.id}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify(patch)}).catch(()=>{});
           return{...c,...patch};
         }
         return c;
@@ -5331,6 +5535,7 @@ function HyprChat(){
   const nb=(p,ico,lab)=><button onClick={()=>setPanel(p)} title={lab} style={{width:52,height:showNavLabels?48:46,display:"flex",flexDirection:"column",alignItems:"center",justifyContent:"center",gap:0,borderRadius:8,cursor:"pointer",border:`1px solid ${panel===p?`${t.acc}55`:"transparent"}`,background:panel===p?`${t.acc}14`:"transparent",color:panel===p?t.acc:t.mut,position:"relative",transition:"all .15s",flexShrink:0,boxShadow:"none",padding:showNavLabels?"3px 0 1px":0}}><span style={{fontSize:showNavLabels?15:18,display:"flex",alignItems:"center",justifyContent:"center"}}>{ico}</span>{showNavLabels&&<div style={{fontSize:8,marginTop:2,lineHeight:1,opacity:.78,textAlign:"center"}}>{_navShort[lab]||lab}</div>}{panel===p&&<div style={{position:"absolute",left:-1,top:"20%",width:3,height:"60%",borderRadius:"0 2px 2px 0",background:t.warm}}/>}</button>;
   const svc=n=>{const s=health[n];const c=s?.status==="ok"?t.ok:s?.status==="degraded"?"#f0a030":t.err;const rl=s?.rate_limited?" [Rate Limited]":"";return <div title={`${n}: ${s?.status||"?"}${rl}${s?.response_ms!=null?" ("+s.response_ms+"ms)":""}`} style={{width:6,height:6,borderRadius:"50%",background:c,boxShadow:`0 0 6px ${c}88`}}/>;};
   const filtC=convs.filter(c=>{
+    if(isGhostConv(c))return false;
     const matchSearch=(c.title||"").toLowerCase().includes(sq.toLowerCase());
     const tags=convTags[c.id]||[];
     const matchTag=!activeTagFilter||tags.includes(activeTagFilter);
@@ -5579,13 +5784,13 @@ function HyprChat(){
               </button>
               {showSysPromptPicker&&<div style={{position:"absolute",top:"calc(100% + 6px)",left:0,zIndex:9999,background:t.bgDeep,border:`1px solid ${t.brd}44`,borderRadius:12,boxShadow:`0 4px 24px #0008`,minWidth:260,maxWidth:340,padding:8,animation:"fadeIn .15s"}}>
                 {(()=>{const sysPrompts=prompts.filter(p=>p.is_system||(p.category&&p.category.toLowerCase()==="system prompt"));return sysPrompts.length?<><div style={{maxHeight:200,overflowY:"auto",display:"flex",flexDirection:"column",gap:2}}>
-                  {sysPrompts.map(p=><div key={p.id} onClick={()=>{uConv(actId,{system_prompt:p.content});fetch(`${API}/api/conversations/${actId}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({system_prompt:p.content})});setShowSysPromptPicker(false);}} style={{padding:"7px 10px",borderRadius:8,cursor:"pointer",background:`${t.surface}66`,border:`1px solid ${t.brd}22`,transition:"background .12s"}} onMouseEnter={e=>e.currentTarget.style.background=`${t.warm}15`} onMouseLeave={e=>e.currentTarget.style.background=`${t.surface}66`}>
+                  {sysPrompts.map(p=><div key={p.id} onClick={()=>{uConv(actId,{system_prompt:p.content});if(!isGhostConv(act))fetch(`${API}/api/conversations/${actId}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({system_prompt:p.content})});setShowSysPromptPicker(false);}} style={{padding:"7px 10px",borderRadius:8,cursor:"pointer",background:`${t.surface}66`,border:`1px solid ${t.brd}22`,transition:"background .12s"}} onMouseEnter={e=>e.currentTarget.style.background=`${t.warm}15`} onMouseLeave={e=>e.currentTarget.style.background=`${t.surface}66`}>
                     <div style={{fontSize:11,fontWeight:600,color:t.text}}>{p.title}</div>
                     <div style={{fontSize:9,color:t.mut,marginTop:1,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{p.content.slice(0,80)}...</div>
                   </div>)}
                 </div>
                 {act.system_prompt&&<div style={{borderTop:`1px solid ${t.brd}22`,marginTop:4,paddingTop:4}}>
-                  <button onClick={()=>{uConv(actId,{system_prompt:""});fetch(`${API}/api/conversations/${actId}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({system_prompt:""})});setShowSysPromptPicker(false);}} style={{...btnS(t.err),width:"100%",justifyContent:"center",fontSize:9}}>Clear System Prompt</button>
+                  <button onClick={()=>{uConv(actId,{system_prompt:""});if(!isGhostConv(act))fetch(`${API}/api/conversations/${actId}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({system_prompt:""})});setShowSysPromptPicker(false);}} style={{...btnS(t.err),width:"100%",justifyContent:"center",fontSize:9}}>Clear System Prompt</button>
                 </div>}</>
                 :<div style={{padding:12,textAlign:"center",color:t.mut,fontSize:11}}>No system prompt templates. Check "Available as System Prompt" on any prompt in the Prompt Library.</div>;})()}
               </div>}
@@ -5672,6 +5877,15 @@ function HyprChat(){
                 </div>}
             </div>;
           })()}
+          {panel==="chat"&&memoryActive&&<span title={`Workspace memory active: ${activeMemoryWs.name}`} style={{display:"inline-flex",alignItems:"center",gap:6,padding:"4px 9px",borderRadius:8,background:`${t.ok}10`,border:`1px solid ${t.ok}30`,color:t.ok,fontSize:10,fontWeight:800,maxWidth:160,overflow:"hidden",whiteSpace:"nowrap"}}>
+            <span style={{width:6,height:6,borderRadius:"50%",background:t.ok,flexShrink:0}}/>
+            Memory
+            <span style={{color:t.mut,fontWeight:500,overflow:"hidden",textOverflow:"ellipsis"}}>{activeMemoryWs.name}</span>
+          </span>}
+          {panel==="chat"&&ghostActive&&<span title="Ghost mode: this chat stays local and is not saved, indexed, or added to history." style={{display:"inline-flex",alignItems:"center",gap:6,padding:"4px 9px",borderRadius:8,background:`${t.pink}10`,border:`1px solid ${t.pink}30`,color:t.pink,fontSize:10,fontWeight:800,whiteSpace:"nowrap"}}>
+            <IC.Ghost/> Ghost
+          </span>}
+          {panel==="chat"&&<button onClick={toggleGhostMode} aria-pressed={ghostActive} title={ghostActive?"Ghost mode on: this chat is local only and will not be saved or indexed":"Ghost mode: start a chat that is never saved or indexed"} style={{background:ghostActive?`${t.pink}18`:"none",border:`1px solid ${ghostActive?t.pink:t.brd}33`,color:ghostActive?t.pink:t.mut,cursor:"pointer",padding:"4px 8px",borderRadius:8,fontSize:13,display:"flex",alignItems:"center",boxShadow:ghostActive?`0 0 0 1px ${t.pink}22 inset`:"none"}}><IC.Ghost/></button>}
           {/* Dark/Light mode toggle */}
           <button onClick={()=>{if(isLightTheme){setTm(prevDarkTheme);}else{setPrevDarkTheme(tm);localStorage.setItem("hc-prev-dark",tm);setTm(LIGHT_PAIRS[tm]||"oneLight");}}} title={isLightTheme?"Switch to dark mode":"Switch to light mode"} style={{background:"none",border:`1px solid ${t.brd}33`,color:t.mut,cursor:"pointer",padding:"4px 8px",borderRadius:8,fontSize:13,display:"flex",alignItems:"center"}}>{isLightTheme?"\u2600\uFE0F":"\uD83C\uDF19"}</button>
           {/* Export / Import */}
@@ -5727,6 +5941,7 @@ function HyprChat(){
             onOpenReport={id=>{setWsPanel(false);setPanel("research");setResearchView("reports");loadResearchReport(id);}}
             onRemoveReport={removeResearchReportFromWorkspace}
             onPreview={openPreview} models={models} wsModel={wsModel}
+            notify={notify}
             onPersonaCreated={mc=>{const norm={...mc,parameters:normalizeProfileParams(mc)};setMcs(p=>[...p,norm]);setProfileTab(getProfileType(norm)==="persona"?"personas":"agents");setPanel("personas");setEditMc(mc.id);}}/>
       :panel==="kb"?<div style={{flex:1,display:"flex",flexDirection:"column",overflow:"hidden"}}>
     <div style={{padding:"16px 20px",borderBottom:`1px solid ${t.brd}28`,display:"flex",justifyContent:"space-between",alignItems:"center"}}>
@@ -8324,7 +8539,7 @@ function HyprChat(){
                     {isU&&!streaming&&<button onClick={()=>setEditingMsg({index:i,content:msg.content})} style={msgActionS(t.mut)}>
                       <IC.Pencil/> edit
                     </button>}
-                    {!streaming&&<button onClick={()=>forkAt(i)} title="Fork conversation from this point" style={msgActionS(t.mut)}>
+                    {!streaming&&!ghostActive&&<button onClick={()=>forkAt(i)} title="Fork conversation from this point" style={msgActionS(t.mut)}>
                       <IC.GitBranch/> fork
                     </button>}
                     {!streaming&&<button onClick={()=>delMsg(i)} title="Delete this message" style={msgActionS(t.mut)}>
@@ -8347,7 +8562,7 @@ function HyprChat(){
               const on=activeToolIds.includes(tl.id);
               const isQs=tl.id==="quick_search";
               const col=isQs?t.f1:t.warm;
-              return <button key={tl.id} onClick={()=>{
+              return <button key={tl.id} title={tl.description||tl.name} onClick={()=>{
                 if(!actId){
                   setPendingToolIds(ids=>on?ids.filter(x=>x!==tl.id):[...ids,tl.id]);
                   return;

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -826,6 +826,9 @@ const IC={
   Copy:()=>sv(<><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></>,14),
   Check:()=>sv(<polyline points="20 6 9 17 4 12"/>,14),
   Search:()=>sv(<><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></>,14),
+  Research:()=>sv(<><path d="M10 2v7L5.5 18.5A2.4 2.4 0 0 0 7.7 22h8.6a2.4 2.4 0 0 0 2.2-3.5L14 9V2"/><path d="M8 2h8"/><path d="M7.2 16h9.6"/></>,15),
+  Brain:()=>sv(<><path d="M9.5 2A3.5 3.5 0 0 0 6 5.5v.2A3.5 3.5 0 0 0 4 9v1a4 4 0 0 0 0 8 3 3 0 0 0 3 3h2.5V2Z"/><path d="M14.5 2A3.5 3.5 0 0 1 18 5.5v.2A3.5 3.5 0 0 1 20 9v1a4 4 0 0 1 0 8 3 3 0 0 1-3 3h-2.5V2Z"/><path d="M9.5 8H8"/><path d="M14.5 8H16"/><path d="M9.5 13H7"/><path d="M14.5 13H17"/></>,15),
+  More:()=>sv(<><circle cx="5" cy="12" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/></>,16),
   Stop:()=><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>,
   ChevDown:()=>sv(<polyline points="6 9 12 15 18 9"/>,14),
   Database:()=>sv(<><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></>),
@@ -1661,6 +1664,189 @@ const Tip=({k,t})=>{const [show,setShow]=React.useState(false);const txt=TIPS[k]
 // ============================================================
 // WORKSPACE DETAIL COMPONENT
 // ============================================================
+function MemoryProfilePanel({t,API,font,notify,onOpenConv,models,wsModel}){
+  const inputS={width:"100%",background:`${t.bgDeep}E6`,border:`1px solid ${t.brd}55`,color:t.text,padding:"9px 12px",borderRadius:7,fontFamily:font,fontSize:13,outline:"none",boxSizing:"border-box"};
+  const btnS=(c,bg)=>({background:bg||`${c}18`,border:`1px solid ${c}4D`,color:c,padding:"6px 12px",borderRadius:7,cursor:"pointer",fontFamily:font,fontSize:11,display:"flex",alignItems:"center",gap:5,boxShadow:"none"});
+  const emptyDraft={display_name:"",legal_name:"",birthday:"",age:"",bio:"",interestsText:"",linksText:"",notes:""};
+  const [profile,setProfile]=React.useState(null);
+  const [draft,setDraft]=React.useState(emptyDraft);
+  const [memories,setMemories]=React.useState([]);
+  const [loading,setLoading]=React.useState(false);
+  const [saving,setSaving]=React.useState(false);
+  const [scanning,setScanning]=React.useState(false);
+  const [newMemText,setNewMemText]=React.useState("");
+  const [newMemType,setNewMemType]=React.useState("semantic");
+  const [memEdit,setMemEdit]=React.useState(null);
+  const [memEditText,setMemEditText]=React.useState("");
+  const parseLinks=(text)=>String(text||"").split("\n").map(line=>{
+    const parts=line.split("|").map(x=>x.trim()).filter(Boolean);
+    if(!parts.length)return null;
+    if(parts.length===1)return {label:"",url:parts[0]};
+    return {label:parts[0],url:parts[1]||"",...(parts[2]?{note:parts.slice(2).join(" | ")}:{})};
+  }).filter(Boolean);
+  const linksToText=(links)=>Array.isArray(links)?links.map(l=>[l.label,l.url,l.note].filter(Boolean).join(" | ")).join("\n"):"";
+  const hydrateProfile=(p)=>{
+    const extra=p?.extra||{};
+    setProfile(p||{});
+    setDraft({
+      display_name:p?.display_name||"",
+      legal_name:p?.legal_name||"",
+      birthday:p?.birthday||"",
+      age:p?.age||"",
+      bio:p?.bio||"",
+      interestsText:(p?.interests||[]).join("\n"),
+      linksText:linksToText(p?.links||[]),
+      notes:extra.notes||"",
+    });
+  };
+  const refresh=React.useCallback(async()=>{
+    setLoading(true);
+    try{
+      const [pr,mr]=await Promise.all([
+        fetch(`${API}/api/memory/profile`).then(r=>r.json()),
+        fetch(`${API}/api/memory/memories?status=all`).then(r=>r.json()),
+      ]);
+      hydrateProfile(pr);
+      setMemories(Array.isArray(mr.memories)?mr.memories:[]);
+    }catch(e){notify&&notify({type:"error",text:"Memory failed to load",detail:e.message||String(e)});}
+    setLoading(false);
+  },[API]);
+  React.useEffect(()=>{refresh();},[refresh]);
+  const saveProfile=async()=>{
+    setSaving(true);
+    try{
+      const body={
+        display_name:draft.display_name,
+        legal_name:draft.legal_name,
+        birthday:draft.birthday,
+        age:draft.age,
+        bio:draft.bio,
+        interests:draft.interestsText.split(/[\n,]+/).map(x=>x.trim()).filter(Boolean),
+        links:parseLinks(draft.linksText),
+        extra:{...(profile?.extra||{}),notes:draft.notes},
+      };
+      const r=await fetch(`${API}/api/memory/profile`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});
+      hydrateProfile(await r.json());
+      notify&&notify({type:"success",text:"Profile saved",duration:2200});
+    }catch(e){notify&&notify({type:"error",text:"Profile save failed",detail:e.message||String(e)});}
+    setSaving(false);
+  };
+  const scanMemory=async()=>{
+    setScanning(true);
+    try{
+      const r=await fetch(`${API}/api/memory/suggest`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({model:wsModel||""})});
+      const d=await r.json();
+      await refresh();
+      notify&&notify({type:d.created?"success":"info",text:d.created?`Queued ${d.created} memory suggestion${d.created===1?"":"s"}`:"No new memory suggestions",detail:d.message||"",duration:4200});
+    }catch(e){notify&&notify({type:"error",text:"Memory scan failed",detail:e.message||String(e)});}
+    setScanning(false);
+  };
+  const updateMemoryLocal=(m)=>setMemories(p=>p.map(x=>x.id===m.id?m:x));
+  const acceptMemory=async(m)=>{
+    try{const r=await fetch(`${API}/api/memory/memories/${m.id}/accept`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({})});updateMemoryLocal(await r.json());notify&&notify({type:"success",text:"Memory accepted",duration:2200});}
+    catch(e){notify&&notify({type:"error",text:"Memory accept failed",detail:e.message||String(e)});}
+  };
+  const rejectMemory=async(m)=>{
+    try{const r=await fetch(`${API}/api/memory/memories/${m.id}/reject`,{method:"POST"});updateMemoryLocal(await r.json());}
+    catch(e){notify&&notify({type:"error",text:"Memory reject failed",detail:e.message||String(e)});}
+  };
+  const patchMemory=async(m,patch)=>{
+    try{const r=await fetch(`${API}/api/memory/memories/${m.id}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify(patch)});updateMemoryLocal(await r.json());}
+    catch(e){notify&&notify({type:"error",text:"Memory update failed",detail:e.message||String(e)});}
+  };
+  const deleteMemory=async(m)=>{
+    try{await fetch(`${API}/api/memory/memories/${m.id}`,{method:"DELETE"});setMemories(p=>p.filter(x=>x.id!==m.id));}
+    catch(e){notify&&notify({type:"error",text:"Memory delete failed",detail:e.message||String(e)});}
+  };
+  const startMemEdit=(m)=>{setMemEdit(m.id);setMemEditText(m.content||"");};
+  const saveMemEdit=async(m,accept=false)=>{
+    const r=await fetch(`${API}/api/memory/memories/${m.id}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({content:memEditText})});
+    let updated=await r.json();
+    if(accept){
+      const ar=await fetch(`${API}/api/memory/memories/${m.id}/accept`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({})});
+      updated=await ar.json();
+    }
+    updateMemoryLocal(updated);setMemEdit(null);setMemEditText("");
+  };
+  const createManualMemory=async()=>{
+    try{
+      const r=await fetch(`${API}/api/memory/memories`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({content:newMemText,type:newMemType,status:"accepted",importance:3})});
+      const m=await r.json();setMemories(p=>[m,...p]);setNewMemText("");notify&&notify({type:"success",text:"Memory added",duration:2200});
+    }catch(e){notify&&notify({type:"error",text:"Memory add failed",detail:e.message||String(e)});}
+  };
+  const byStatus=s=>memories.filter(m=>m.status===s);
+  const accepted=byStatus("accepted").filter(m=>!m.valid_until);
+  const suggested=byStatus("suggested");
+  const hidden=memories.filter(m=>["rejected","archived"].includes(m.status)||m.valid_until);
+  const typeMeta={semantic:["Facts & Preferences",t.acc],episodic:["Events & People",t.warm],procedural:["Procedures",t.pink]};
+  const card=(m,mode)=>{const meta=typeMeta[m.type]||typeMeta.semantic;const editing=memEdit===m.id;return <div key={m.id} style={{padding:"10px 12px",borderRadius:8,background:`${t.surface}66`,border:`1px solid ${meta[1]}33`,display:"flex",flexDirection:"column",gap:7}}>
+    <div style={{display:"flex",alignItems:"center",gap:6}}>
+      <span style={{fontSize:9,fontWeight:800,color:meta[1],textTransform:"uppercase",letterSpacing:.6}}>{meta[0]}</span>
+      <span style={{fontSize:9,color:t.mut}}>importance {m.importance||3}</span>
+      {m.pinned?<span style={{fontSize:9,color:t.warm}}>pinned</span>:null}
+      {m.confidence?<span style={{fontSize:9,color:t.mut}}>{Math.round((m.confidence||0)*100)}%</span>:null}
+    </div>
+    {editing?<textarea value={memEditText} onChange={e=>setMemEditText(e.target.value)} style={{...inputS,minHeight:72,lineHeight:1.5,resize:"vertical"}}/>:<div style={{fontSize:12,lineHeight:1.55,color:t.text,whiteSpace:"pre-wrap"}}>{m.content}</div>}
+    {m.metadata?.reason&&<div style={{fontSize:10,color:t.mut,lineHeight:1.4}}>Why: {m.metadata.reason}</div>}
+    <div style={{display:"flex",gap:5,flexWrap:"wrap",alignItems:"center"}}>
+      {editing?<><button onClick={()=>saveMemEdit(m,mode==="suggested")} style={btnS(t.ok)}>{mode==="suggested"?"Save + Accept":"Save"}</button><button onClick={()=>{setMemEdit(null);setMemEditText("");}} style={btnS(t.mut)}>Cancel</button></>
+      :mode==="suggested"?<><button onClick={()=>acceptMemory(m)} style={btnS(t.ok)}>Accept</button><button onClick={()=>startMemEdit(m)} style={btnS(t.acc)}>Edit</button><button onClick={()=>rejectMemory(m)} style={btnS(t.err)}>Reject</button></>
+      :<><button onClick={()=>patchMemory(m,{pinned:m.pinned?0:1})} style={btnS(m.pinned?t.warm:t.mut)}>{m.pinned?"Unpin":"Pin"}</button><button onClick={()=>startMemEdit(m)} style={btnS(t.acc)}>Edit</button><button onClick={()=>patchMemory(m,{status:"archived"})} style={btnS(t.mut)}>Archive</button><button onClick={()=>deleteMemory(m)} style={btnS(t.err)}>Delete</button></>}
+      {m.source_conversation_id&&<button onClick={()=>onOpenConv&&onOpenConv(m.source_conversation_id)} style={{...btnS(t.f1),marginLeft:"auto"}}>Source -></button>}
+    </div>
+  </div>;};
+  return <div style={{flex:1,display:"flex",flexDirection:"column",overflow:"hidden"}}>
+    <div style={{padding:"16px 20px",borderBottom:`1px solid ${t.brd}28`,display:"flex",justifyContent:"space-between",alignItems:"center",gap:12}}>
+      <div style={{display:"flex",alignItems:"center",gap:8}}><span style={{display:"flex",color:t.acc}}><IC.Brain/></span><span style={{fontSize:14,fontWeight:700,letterSpacing:1,textTransform:"uppercase",color:t.acc}}>Memory & Profile</span></div>
+      <div style={{display:"flex",gap:8}}><button onClick={scanMemory} disabled={scanning} style={btnS(t.warm)}>{scanning?"Scanning":"Scan Recent"}</button><button onClick={refresh} disabled={loading} style={btnS(t.acc)}>{loading?"Loading":"Refresh"}</button></div>
+    </div>
+    <div style={{flex:1,overflowY:"auto",padding:20}}>
+      <div style={{display:"grid",gridTemplateColumns:"minmax(280px,0.62fr) minmax(280px,1fr)",gap:14,alignItems:"start"}}>
+        <div style={{background:`${t.surface}F0`,border:`1px solid ${t.brd}55`,borderRadius:8,padding:16}}>
+          <div style={{fontSize:10,fontWeight:800,color:t.acc,textTransform:"uppercase",letterSpacing:.7,marginBottom:12}}>User Profile</div>
+          <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:10,marginBottom:10}}>
+            <div><label style={{fontSize:10,color:t.mut,display:"block",marginBottom:4}}>Preferred name</label><input value={draft.display_name} onChange={e=>setDraft(p=>({...p,display_name:e.target.value}))} style={inputS}/></div>
+            <div><label style={{fontSize:10,color:t.mut,display:"block",marginBottom:4}}>Full name</label><input value={draft.legal_name} onChange={e=>setDraft(p=>({...p,legal_name:e.target.value}))} style={inputS}/></div>
+            <div><label style={{fontSize:10,color:t.mut,display:"block",marginBottom:4}}>Birthday</label><input value={draft.birthday} onChange={e=>setDraft(p=>({...p,birthday:e.target.value}))} style={inputS}/></div>
+            <div><label style={{fontSize:10,color:t.mut,display:"block",marginBottom:4}}>Age</label><input value={draft.age} onChange={e=>setDraft(p=>({...p,age:e.target.value}))} style={inputS}/></div>
+          </div>
+          <label style={{fontSize:10,color:t.mut,display:"block",marginBottom:4}}>Bio</label>
+          <textarea value={draft.bio} onChange={e=>setDraft(p=>({...p,bio:e.target.value}))} style={{...inputS,minHeight:86,lineHeight:1.5,resize:"vertical",marginBottom:10}}/>
+          <label style={{fontSize:10,color:t.mut,display:"block",marginBottom:4}}>Interests</label>
+          <textarea value={draft.interestsText} onChange={e=>setDraft(p=>({...p,interestsText:e.target.value}))} style={{...inputS,minHeight:74,lineHeight:1.45,resize:"vertical",marginBottom:10}}/>
+          <label style={{fontSize:10,color:t.mut,display:"block",marginBottom:4}}>Links</label>
+          <textarea value={draft.linksText} onChange={e=>setDraft(p=>({...p,linksText:e.target.value}))} placeholder="Portfolio | https://example.com" style={{...inputS,minHeight:74,lineHeight:1.45,resize:"vertical",marginBottom:10}}/>
+          <label style={{fontSize:10,color:t.mut,display:"block",marginBottom:4}}>Notes</label>
+          <textarea value={draft.notes} onChange={e=>setDraft(p=>({...p,notes:e.target.value}))} style={{...inputS,minHeight:82,lineHeight:1.45,resize:"vertical",marginBottom:12}}/>
+          <button onClick={saveProfile} disabled={saving} style={{...btnS(t.ok),justifyContent:"center"}}>{saving?"Saving":"Save Profile"}</button>
+        </div>
+        <div style={{display:"flex",flexDirection:"column",gap:12}}>
+          <div style={{background:`${t.surface}F0`,border:`1px solid ${t.brd}55`,borderRadius:8,padding:16}}>
+            <div style={{fontSize:10,fontWeight:800,color:t.pink,textTransform:"uppercase",letterSpacing:.7,marginBottom:10}}>Add Memory</div>
+            <div style={{display:"grid",gridTemplateColumns:"160px 1fr",gap:8,alignItems:"start"}}>
+              <select value={newMemType} onChange={e=>setNewMemType(e.target.value)} style={inputS}><option value="semantic">Semantic</option><option value="episodic">Episodic</option><option value="procedural">Procedural</option></select>
+              <textarea value={newMemText} onChange={e=>setNewMemText(e.target.value)} placeholder="Add an accepted memory manually..." style={{...inputS,minHeight:78,lineHeight:1.5,resize:"vertical"}}/>
+            </div>
+            <button onClick={createManualMemory} disabled={!newMemText.trim()} style={{...btnS(t.ok),opacity:newMemText.trim()?1:.45,marginTop:8}}>Add Accepted Memory</button>
+          </div>
+          {suggested.length>0&&<div style={{display:"flex",flexDirection:"column",gap:8}}>
+            <div style={{fontSize:10,fontWeight:800,color:t.warm,textTransform:"uppercase",letterSpacing:.7}}>Suggestions ({suggested.length})</div>
+            {suggested.map(m=>card(m,"suggested"))}
+          </div>}
+          {Object.entries(typeMeta).map(([typ,[label,color]])=>{const items=accepted.filter(m=>m.type===typ);return <div key={typ} style={{display:"flex",flexDirection:"column",gap:8}}>
+            <div style={{fontSize:10,fontWeight:800,color,textTransform:"uppercase",letterSpacing:.7}}>{label} ({items.length})</div>
+            {items.length?items.map(m=>card(m,"accepted")):<div style={{fontSize:11,color:t.mut,padding:"12px 0"}}>No accepted {typ} memories.</div>}
+          </div>;})}
+          {hidden.length>0&&<details style={{borderTop:`1px solid ${t.brd}22`,paddingTop:10}}>
+            <summary style={{fontSize:10,color:t.mut,cursor:"pointer",fontWeight:800,textTransform:"uppercase",letterSpacing:.7}}>Rejected, archived, or superseded ({hidden.length})</summary>
+            <div style={{display:"flex",flexDirection:"column",gap:8,marginTop:8}}>{hidden.map(m=>card(m,"hidden"))}</div>
+          </details>}
+        </div>
+      </div>
+    </div>
+  </div>;
+}
+
 function WorkspaceDetail({ws,wsLoading,t,API,workspaces,setWorkspaces,setActiveWs,setWsDetail,convs,onOpenConv,onOpenReport,onRemoveReport,onPreview,models,wsModel,onPersonaCreated,notify}){
   const [tab,setTab]=React.useState("convs");
   const [editMode,setEditMode]=React.useState(false);
@@ -2561,6 +2747,7 @@ function HyprChat(){
   const [autoExpandThink,setAutoExpandThink]=useState(()=>{try{return localStorage.getItem("hc-auto-expand-think")==="1";}catch{return false;}});
   const [bgEffect,setBgEffect]=useState(()=>{try{const saved=localStorage.getItem("hc-bg-effect");if(saved&&BACKGROUND_EFFECTS.some(e=>e.id===saved))return saved;return localStorage.getItem("hc-scanline")==="1"?"scanlines":"dots";}catch{return "dots";}});
   const [showNavLabels,setShowNavLabels]=useState(()=>{try{return localStorage.getItem("hc-nav-labels")!=="0";}catch{return true;}});
+  const [showNavMore,setShowNavMore]=useState(false);
   const [thinkMode,setThinkMode]=useState(()=>{try{return localStorage.getItem("hc-think-mode")||"auto";}catch{return "auto";}});
   // Effort Level — global default (0=Blurt, 1=Ponder, 2=Forge, 3=Galaxy Brain)
   const [globalEffort,setGlobalEffort]=useState(()=>{try{return parseInt(localStorage.getItem("hc-effort-level")||"0")||0;}catch{return 0;}});
@@ -2825,6 +3012,7 @@ function HyprChat(){
   const [prevDarkTheme,setPrevDarkTheme]=useState(()=>{try{return localStorage.getItem("hc-prev-dark")||"hyprflat";}catch{return "hyprflat";}});
   const [autoTitle,setAutoTitle]=useState(()=>{try{return localStorage.getItem("hc-auto-title")!=="false";}catch{return true;}});
   const [ghostMode,setGhostMode]=useState(false);
+  const [pendingUseMemories,setPendingUseMemories]=useState(false);
   useEffect(()=>{try{localStorage.setItem("hc-auto-title",autoTitle?"true":"false");}catch{}},[autoTitle]);
   const [showSysPromptPicker,setShowSysPromptPicker]=useState(false);
   const [tokC,setTokC]=useState(0);
@@ -3114,7 +3302,19 @@ function HyprChat(){
   const activeToolIds=act?(act.tool_ids||[]):pendingToolIds;
   const quickSearch = activeToolIds.includes("quick_search");
   const activeMemoryWs=(wsDetail&&wsDetail.id&&Array.isArray(wsDetail.conversations)&&actId&&wsDetail.conversations.some(wc=>wc.id===actId))?wsDetail:null;
-  const memoryActive=!ghostActive&&activeMemoryWs&&(activeMemoryWs.memory_enabled==="1"||activeMemoryWs.memory_enabled===1||activeMemoryWs.memory_enabled===true);
+  const workspaceMemoryActive=!ghostActive&&activeMemoryWs&&(activeMemoryWs.memory_enabled==="1"||activeMemoryWs.memory_enabled===1||activeMemoryWs.memory_enabled===true);
+  const globalMemoryActive=!ghostActive&&(act?(act.use_memories==="1"||act.use_memories===1||act.use_memories===true):pendingUseMemories);
+  const toggleGlobalMemory=()=>{
+    if(ghostActive)return;
+    const next=globalMemoryActive?"0":"1";
+    if(!actId||!act){
+      setPendingUseMemories(next==="1");
+      notify({type:next==="1"?"success":"info",text:next==="1"?"Memory enabled for next chat":"Memory disabled for next chat",duration:2200});
+      return;
+    }
+    uConv(actId,{use_memories:next});
+    notify({type:next==="1"?"success":"info",text:next==="1"?"Memory enabled for this chat":"Memory disabled for this chat",duration:2200});
+  };
   const storedLastModel=()=>{try{return localStorage.getItem("hc-last-model")||"";}catch{return "";}};
   const normalizeAvailableModel=(modelName)=>{
     const chosen=modelName||"";
@@ -3819,7 +4019,7 @@ function HyprChat(){
         // If this conversation is being streamed right now, local state is authoritative for messages —
         // skip the overwrite so the stream's m[m.length-1] assistant update doesn't clobber the user message.
         const skipMessages = streamingCidRef.current === id;
-        setConvs(prev=>prev.map(c=>c.id===id ? {...c, ...(skipMessages ? {} : {messages: full.messages.map(m=>({id:m.id,role:m.role,content:m.content,metadata:parseMeta(m),created_at:m.created_at}))}), model: full.model||c.model, system_prompt: full.system_prompt||c.system_prompt, tool_ids: full.tool_ids||c.tool_ids||[], model_config_id: full.model_config_id||null, is_council: isCouncil(full.is_council), council_config_id: full.council_config_id||null} : c));
+        setConvs(prev=>prev.map(c=>c.id===id ? {...c, ...(skipMessages ? {} : {messages: full.messages.map(m=>({id:m.id,role:m.role,content:m.content,metadata:parseMeta(m),created_at:m.created_at}))}), model: full.model||c.model, system_prompt: full.system_prompt||c.system_prompt, tool_ids: full.tool_ids||c.tool_ids||[], model_config_id: full.model_config_id||null, use_memories: full.use_memories??c.use_memories??"0", is_council: isCouncil(full.is_council), council_config_id: full.council_config_id||null} : c));
         // Fetch suggestions for council chats with no messages yet
         if(isCouncil(full.is_council)&&full.council_config_id&&!(full.messages||[]).length){
           fetchCouncilSuggestions(full.council_config_id);
@@ -3889,7 +4089,7 @@ function HyprChat(){
   useEffect(()=>{
     const handler=(e)=>{
       if(e.key!=="Escape")return;
-      setDownloadsExpanded(false);setShowPromptPicker(false);setShowQuickMenu(false);setShowEffortPicker(false);setShowExportMenu(false);setShowSysPromptPicker(false);setRegenPopover(null);setQuickSearchError(null);
+      setDownloadsExpanded(false);setShowPromptPicker(false);setShowQuickMenu(false);setShowEffortPicker(false);setShowExportMenu(false);setShowSysPromptPicker(false);setShowNavMore(false);setRegenPopover(null);setQuickSearchError(null);
       setConfirmDialog(d=>{if(d?.resolve)d.resolve(false);return null;});
       if(panel==="chat")setTimeout(()=>{try{inpRef.current?.focus({preventScroll:true});}catch{inpRef.current?.focus();}},0);
     };
@@ -3934,7 +4134,7 @@ function HyprChat(){
       if(c.id!==id)return c;
       const updated=typeof u==="function"?u(c):{...c,...u};
       const patch={};
-      for(const k of ["title","model","system_prompt","tool_ids","persona_name","persona_avatar","is_council","council_config_id","model_config_id"]){
+      for(const k of ["title","model","system_prompt","tool_ids","persona_name","persona_avatar","is_council","council_config_id","model_config_id","use_memories"]){
         if(JSON.stringify(updated[k])!==JSON.stringify(c[k])&&updated[k]!==undefined)patch[k]=updated[k];
       }
       // Remember last-used model for new chats
@@ -3945,6 +4145,18 @@ function HyprChat(){
       return updated;
     }));
   },[]);
+  const useModelFromManager=(modelName)=>{
+    if(!modelName)return;
+    const hasActive=!!(actId&&convs.some(c=>c.id===actId));
+    if(hasActive){
+      uConv(actId,{model:modelName});
+      notify({type:"success",text:"Model selected",detail:modelName,duration:2200});
+    }else{
+      setPendingChatModel(modelName);
+      notify({type:"success",text:"Model selected for new chats",detail:modelName,duration:2600});
+    }
+    setPanel("chat");
+  };
   const leaveActiveProfile=()=>{
     clearPendingProfile();
     if(actId){
@@ -3989,19 +4201,21 @@ function HyprChat(){
     const pendingTools=forceBlank?(persona?.tool_ids||(opts.carryCurrent?(curConv?.tool_ids||[]):pendingToolIds)):[];
     const pendingEffortValue=forceBlank&&pendingEffort!==null?pendingEffort:null;
     const useGhost=ghostMode||opts.ephemeral;
+    const pendingMemoryValue=(!useGhost&&forceBlank&&pendingUseMemories)?"1":"0";
     if(useGhost){
       const newId=`ghost-${Date.now()}-${Math.random().toString(16).slice(2,8)}`;
       const c={id:newId,title:"Ghost Chat",messages:[],model:defaultModel,system_prompt:persona?.system_prompt||(opts.carryCurrent?(curConv?.system_prompt||""):""),...(persona||{}),tool_ids:pendingTools,ephemeral:true};
       const firstMsg=persona?makeProfileFirstMessage(persona):null;
       if(firstMsg)c.messages=[firstMsg];
       if(pendingEffortValue!==null)setEffortPerChat(p=>({...p,[newId]:pendingEffortValue}));
+      setPendingUseMemories(false);
       setConvs(p=>[c,...p]);setActId(newId);setGhostMode(true);
       setPanel("chat");setEvts([]);setSessionTokens(0);setCtxTokens(0);setGenTokens(0);setExpandedPill(null);setCouncilRunning(false);setCouncilResponses({});setCouncilHostContent("");
       return opts.returnConv?c:newId;
     }
     try{
-      const r=await fetch(`${API}/api/conversations`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({title:"New Chat",model:defaultModel})});
-      const c=await r.json();c.messages=[];
+      const r=await fetch(`${API}/api/conversations`,{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({title:"New Chat",model:defaultModel,use_memories:pendingMemoryValue})});
+      const c=await r.json();c.messages=[];c.use_memories=c.use_memories??pendingMemoryValue;
       // Apply persona directly to the conv object before adding to state
       if(persona){
         Object.assign(c,persona);
@@ -4014,15 +4228,17 @@ function HyprChat(){
         fetch(`${API}/api/conversations/${c.id}`,{method:"PATCH",headers:{"Content-Type":"application/json"},body:JSON.stringify({tool_ids:pendingTools})}).catch(()=>{});
       }
       if(pendingEffortValue!==null)setEffortPerChat(p=>({...p,[c.id]:pendingEffortValue}));
+      setPendingUseMemories(false);
       setConvs(p=>[c,...p]);setActId(c.id);
       setPanel("chat");setEvts([]);setSessionTokens(0);setCtxTokens(0);setGenTokens(0);setExpandedPill(null);setCouncilRunning(false);setCouncilResponses({});setCouncilHostContent("");
       return opts.returnConv?c:c.id;
     }catch{
       const newId=`l-${Date.now()}`;
-      const c={id:newId,title:"New Chat",messages:[],model:defaultModel,system_prompt:persona?.system_prompt||"",...(persona||{}),tool_ids:pendingTools};
+      const c={id:newId,title:"New Chat",messages:[],model:defaultModel,system_prompt:persona?.system_prompt||"",...(persona||{}),tool_ids:pendingTools,use_memories:pendingMemoryValue};
       const firstMsg=persona?makeProfileFirstMessage(persona):null;
       if(firstMsg)c.messages=[firstMsg];
       if(pendingEffortValue!==null)setEffortPerChat(p=>({...p,[newId]:pendingEffortValue}));
+      setPendingUseMemories(false);
       setConvs(p=>[c,...p]);setActId(newId);
       setPanel("chat");setEvts([]);setSessionTokens(0);setCtxTokens(0);setGenTokens(0);setExpandedPill(null);setCouncilRunning(false);setCouncilResponses({});setCouncilHostContent("");
       return opts.returnConv?c:newId;
@@ -4031,6 +4247,7 @@ function HyprChat(){
 
   const startBlankChat=()=>{
     setGhostMode(false);
+    setPendingUseMemories(false);
     setConvs(p=>p.filter(c=>!isGhostConv(c)));
     setActId(null);
     clearPendingProfile();
@@ -4328,7 +4545,7 @@ function HyprChat(){
       }
 
       const ctrl=new AbortController();abortR.current=ctrl;
-      const body={conversation_id:cid,model:modelName,messages:am,system_prompt:cv?.system_prompt||"",tool_ids:cv?.tool_ids||[],persona_id:overrides.persona_id!==undefined?overrides.persona_id:(cv?.model_config_id||null)};
+      const body={conversation_id:cid,model:modelName,messages:am,system_prompt:cv?.system_prompt||"",tool_ids:cv?.tool_ids||[],persona_id:overrides.persona_id!==undefined?overrides.persona_id:(cv?.model_config_id||null),use_memories:!isGhostSend&&(cv?.use_memories==="1"||cv?.use_memories===1||cv?.use_memories===true)};
       if(isGhostSend)body.ephemeral=true;
       const _wsForChat=(wsDetail&&wsDetail.id&&Array.isArray(wsDetail.conversations)&&wsDetail.conversations.some(wc=>wc.id===cid))?wsDetail:null;
       if(_wsForChat?.id&&!isGhostSend)body.workspace_id=_wsForChat.id;
@@ -4682,7 +4899,7 @@ function HyprChat(){
     try{
       const cv=convs.find(c=>c.id===actId);
       if(!cv)return;
-      const data={id:cv.id,title:cv.title,model:cv.model,system_prompt:cv.system_prompt,persona_name:cv.persona_name||null,created_at:cv.created_at,messages:(cv.messages||[]).filter(m=>m.role!=="system").map(m=>({role:m.role,content:m.content,metadata:m.metadata,created_at:m.created_at}))};
+      const data={id:cv.id,title:cv.title,model:cv.model,system_prompt:cv.system_prompt,persona_name:cv.persona_name||null,use_memories:cv.use_memories||"0",created_at:cv.created_at,messages:(cv.messages||[]).filter(m=>m.role!=="system").map(m=>({role:m.role,content:m.content,metadata:m.metadata,created_at:m.created_at}))};
       const blob=new Blob([JSON.stringify(data,null,2)],{type:"application/json"});
       const a=document.createElement("a");
       a.href=URL.createObjectURL(blob);
@@ -5529,10 +5746,17 @@ function HyprChat(){
   };
 
   const glass={background:`${t.surface}F2`,backdropFilter:"none",border:`1px solid ${t.brd}55`,boxShadow:"none"};
-  const _navShort={Chat:"Chat","Knowledge Bases":"KB",Tools:"Tools",Agents:"Agents","Prompt Library":"Prompts","Deep Research":"Research","Council of AI":"Council","Model Manager":"Models",Analytics:"Stats",Settings:"Settings"};
-  const openSettings=()=>{if(panel!=="settings")previousPanelRef.current=panel;setPanel("settings");};
+  const _navShort={Chat:"Chat",Memory:"Memory","Knowledge Bases":"KB",Tools:"Tools",Agents:"Agents","Prompt Library":"Prompts","Deep Research":"Research","Council of AI":"Council","Model Manager":"Models",Analytics:"Stats",Settings:"Settings",More:"More"};
+  const openSettings=()=>{setShowNavMore(false);if(panel!=="settings")previousPanelRef.current=panel;setPanel("settings");};
   const closeSettings=()=>{setShowHealthMonitor(false);setPanel(previousPanelRef.current||"chat");};
   const nb=(p,ico,lab)=><button onClick={()=>setPanel(p)} title={lab} style={{width:52,height:showNavLabels?48:46,display:"flex",flexDirection:"column",alignItems:"center",justifyContent:"center",gap:0,borderRadius:8,cursor:"pointer",border:`1px solid ${panel===p?`${t.acc}55`:"transparent"}`,background:panel===p?`${t.acc}14`:"transparent",color:panel===p?t.acc:t.mut,position:"relative",transition:"all .15s",flexShrink:0,boxShadow:"none",padding:showNavLabels?"3px 0 1px":0}}><span style={{fontSize:showNavLabels?15:18,display:"flex",alignItems:"center",justifyContent:"center"}}>{ico}</span>{showNavLabels&&<div style={{fontSize:8,marginTop:2,lineHeight:1,opacity:.78,textAlign:"center"}}>{_navShort[lab]||lab}</div>}{panel===p&&<div style={{position:"absolute",left:-1,top:"20%",width:3,height:"60%",borderRadius:"0 2px 2px 0",background:t.warm}}/>}</button>;
+  const moreNavItems=[
+    ["kb",<IC.Database/>,"Knowledge Bases",t.ok],
+    ["tools",<IC.Tool/>,"Tools",t.warm],
+    ["models",<IC.Layers/>,"Model Manager",t.f1],
+    ["analytics",<IC.BarChart/>,"Analytics",t.mut],
+  ];
+  const moreNavActive=moreNavItems.some(([p])=>panel===p);
   const svc=n=>{const s=health[n];const c=s?.status==="ok"?t.ok:s?.status==="degraded"?"#f0a030":t.err;const rl=s?.rate_limited?" [Rate Limited]":"";return <div title={`${n}: ${s?.status||"?"}${rl}${s?.response_ms!=null?" ("+s.response_ms+"ms)":""}`} style={{width:6,height:6,borderRadius:"50%",background:c,boxShadow:`0 0 6px ${c}88`}}/>;};
   const filtC=convs.filter(c=>{
     if(isGhostConv(c))return false;
@@ -5593,6 +5817,13 @@ function HyprChat(){
     ["changelog","📋","Changelog","Release notes and updates"],
   ];
   const activeSettingsTitle=(settingsTabs.find(([id])=>id===settingsTab)||settingsTabs[0])[2];
+  const mmPanelS={background:`${t.surface}66`,border:`1px solid ${t.brd}24`,borderRadius:8,boxShadow:"none"};
+  const mmPanelStrongS={background:`${t.surface}88`,border:`1px solid ${t.brd}33`,borderRadius:8,boxShadow:"none"};
+  const mmKickerS={fontSize:10,color:t.mut,textTransform:"uppercase",letterSpacing:.7,fontWeight:800};
+  const mmMetaS={fontSize:10,color:t.mut,lineHeight:1.4};
+  const mmChipS=(c=t.acc,bg)=>({fontSize:10,padding:"2px 7px",borderRadius:6,background:bg||`${c}16`,border:`1px solid ${c}35`,color:c,fontWeight:800,lineHeight:1.15,whiteSpace:"nowrap"});
+  const mmIconBtnS=(c=t.mut)=>({width:28,height:28,borderRadius:7,border:`1px solid ${c}30`,background:`${c}10`,color:c,cursor:"pointer",display:"inline-flex",alignItems:"center",justifyContent:"center",padding:0,flexShrink:0});
+  const mmSectionTitleS={fontSize:12,fontWeight:900,color:t.dim,textTransform:"uppercase",letterSpacing:.7,marginBottom:10};
 
   // ============================================================
   // PANELS
@@ -5613,28 +5844,27 @@ function HyprChat(){
 
     {/* NAV RAIL */}
     <div style={{width:68,minWidth:68,display:"flex",flexDirection:"column",alignItems:"center",...glass,borderRight:`1px solid ${t.brd}55`,zIndex:11,padding:"12px 0",gap:4}}>
-      {/* Logo dot */}
-      <div style={{width:52,height:48,display:"flex",alignItems:"center",justifyContent:"center",marginBottom:6}}>
-        <div style={{width:24,height:24,borderRadius:8,background:t.bgDeep,border:`1px solid ${t.brd}66`,position:"relative",overflow:"hidden"}}>
-          <div style={{position:"absolute",left:5,top:5,width:7,height:14,background:t.acc,opacity:.95}}/>
-          <div style={{position:"absolute",right:5,bottom:5,width:7,height:14,background:t.warm,opacity:.9}}/>
+      <div style={{flex:1,minHeight:0,width:"100%",display:"flex",flexDirection:"column",alignItems:"center",gap:4,overflowY:"auto",overflowX:"hidden",scrollbarWidth:"none",paddingBottom:4}}>
+        <button onClick={()=>{if(showMessageSearch&&sidebar)closeSidebarSearch();else openSidebarSearch("titles");}} title="Search conversations" style={{width:52,height:showNavLabels?48:46,display:"flex",flexDirection:"column",alignItems:"center",justifyContent:"center",gap:0,borderRadius:8,cursor:"pointer",border:`1px solid ${sidebarSearchActive?`${t.acc}55`:"transparent"}`,background:sidebarSearchActive?`${t.acc}14`:"transparent",color:sidebarSearchActive?t.acc:t.mut,position:"relative",transition:"all .15s",flexShrink:0,boxShadow:"none",padding:showNavLabels?"3px 0 1px":0}}>
+          <span style={{fontSize:showNavLabels?15:18,display:"flex",alignItems:"center",justifyContent:"center"}}><IC.Search/></span>
+          {showNavLabels&&<div style={{fontSize:8,marginTop:2,lineHeight:1,opacity:.78,textAlign:"center"}}>Search</div>}
+          {sidebarSearchActive&&<div style={{position:"absolute",left:-1,top:"20%",width:3,height:"60%",borderRadius:"0 2px 2px 0",background:t.warm}}/>}
+        </button>
+        {nb("chat",<IC.Chat/>,"Chat")}
+        {nb("research",<IC.Research/>,"Deep Research")}
+        {nb("council",<IC.Council/>,"Council of AI")}
+        {nb("memory",<IC.Brain/>,"Memory")}
+        {nb("personas",<IC.Cube/>,"Agents")}
+        {nb("prompts",<IC.Zap/>,"Prompt Library")}
+        <button onClick={()=>setShowNavMore(p=>!p)} title="More" aria-expanded={showNavMore} style={{width:52,height:showNavLabels?48:46,display:"flex",flexDirection:"column",alignItems:"center",justifyContent:"center",gap:0,borderRadius:8,cursor:"pointer",border:`1px solid ${(showNavMore||moreNavActive)?`${t.acc}55`:"transparent"}`,background:(showNavMore||moreNavActive)?`${t.acc}14`:"transparent",color:(showNavMore||moreNavActive)?t.acc:t.mut,position:"relative",transition:"all .15s",flexShrink:0,boxShadow:"none",padding:showNavLabels?"3px 0 1px":0}}>
+          <span style={{fontSize:showNavLabels?15:18,display:"flex",alignItems:"center",justifyContent:"center"}}><IC.More/></span>
+          {showNavLabels&&<div style={{fontSize:8,marginTop:2,lineHeight:1,opacity:.78,textAlign:"center"}}>More</div>}
+          {moreNavActive&&<div style={{position:"absolute",left:-1,top:"20%",width:3,height:"60%",borderRadius:"0 2px 2px 0",background:t.warm}}/>}
+        </button>
+        <div aria-hidden={!showNavMore} style={{width:"100%",display:"flex",flexDirection:"column",alignItems:"center",gap:4,overflow:"hidden",maxHeight:showNavMore?220:0,opacity:showNavMore?1:0,transform:showNavMore?"translateY(0)":"translateY(-6px)",transition:"max-height .22s ease, opacity .16s ease, transform .18s ease",pointerEvents:showNavMore?"auto":"none",flexShrink:0}}>
+          {moreNavItems.map(([p,ico,lab])=><React.Fragment key={p}>{nb(p,ico,lab)}</React.Fragment>)}
         </div>
       </div>
-      <button onClick={()=>{if(showMessageSearch&&sidebar)closeSidebarSearch();else openSidebarSearch("titles");}} title="Search conversations" style={{width:52,height:showNavLabels?48:46,display:"flex",flexDirection:"column",alignItems:"center",justifyContent:"center",gap:0,borderRadius:8,cursor:"pointer",border:`1px solid ${sidebarSearchActive?`${t.acc}55`:"transparent"}`,background:sidebarSearchActive?`${t.acc}14`:"transparent",color:sidebarSearchActive?t.acc:t.mut,position:"relative",transition:"all .15s",flexShrink:0,boxShadow:"none",padding:showNavLabels?"3px 0 1px":0}}>
-        <span style={{fontSize:showNavLabels?15:18,display:"flex",alignItems:"center",justifyContent:"center"}}><IC.Search/></span>
-        {showNavLabels&&<div style={{fontSize:8,marginTop:2,lineHeight:1,opacity:.78,textAlign:"center"}}>Search</div>}
-        {sidebarSearchActive&&<div style={{position:"absolute",left:-1,top:"20%",width:3,height:"60%",borderRadius:"0 2px 2px 0",background:t.warm}}/>}
-      </button>
-      {nb("chat",<IC.Chat/>,"Chat")}
-      {nb("kb",<IC.Database/>,"Knowledge Bases")}
-      {nb("tools",<IC.Tool/>,"Tools")}
-      {nb("personas",<IC.Cube/>,"Agents")}
-      {nb("prompts",<IC.Zap/>,"Prompt Library")}
-      {nb("research",<IC.Search/>,"Deep Research")}
-      {nb("council",<IC.Council/>,"Council of AI")}
-      {nb("models",<IC.Layers/>,"Model Manager")}
-      {nb("analytics",<IC.BarChart/>,"Analytics")}
-      <div style={{flex:1}}/>
       <button onClick={openSettings} title="Settings" style={{width:52,height:showNavLabels?48:46,display:"flex",flexDirection:"column",alignItems:"center",justifyContent:"center",gap:0,borderRadius:8,cursor:"pointer",border:`1px solid ${panel==="settings"?`${t.acc}55`:"transparent"}`,background:panel==="settings"?`${t.acc}14`:"transparent",color:panel==="settings"?t.acc:t.mut,position:"relative",transition:"all .15s",flexShrink:0,boxShadow:"none",padding:showNavLabels?"3px 0 1px":0}}>
         <span style={{fontSize:showNavLabels?15:18,display:"flex",alignItems:"center",justifyContent:"center"}}><IC.Settings/></span>
         {showNavLabels&&<div style={{fontSize:8,marginTop:2,lineHeight:1,opacity:.78,textAlign:"center"}}>Settings</div>}
@@ -5877,7 +6107,12 @@ function HyprChat(){
                 </div>}
             </div>;
           })()}
-          {panel==="chat"&&memoryActive&&<span title={`Workspace memory active: ${activeMemoryWs.name}`} style={{display:"inline-flex",alignItems:"center",gap:6,padding:"4px 9px",borderRadius:8,background:`${t.ok}10`,border:`1px solid ${t.ok}30`,color:t.ok,fontSize:10,fontWeight:800,maxWidth:160,overflow:"hidden",whiteSpace:"nowrap"}}>
+          {panel==="chat"&&globalMemoryActive&&<span title="HyprChat memory active for this chat" style={{display:"inline-flex",alignItems:"center",gap:6,padding:"4px 9px",borderRadius:8,background:`${t.acc}10`,border:`1px solid ${t.acc}30`,color:t.acc,fontSize:10,fontWeight:800,whiteSpace:"nowrap"}}>
+            <span style={{width:6,height:6,borderRadius:"50%",background:t.acc,flexShrink:0}}/>
+            Memory
+            <span style={{color:t.mut,fontWeight:500}}>HyprChat</span>
+          </span>}
+          {panel==="chat"&&workspaceMemoryActive&&<span title={`Workspace memory active: ${activeMemoryWs.name}`} style={{display:"inline-flex",alignItems:"center",gap:6,padding:"4px 9px",borderRadius:8,background:`${t.ok}10`,border:`1px solid ${t.ok}30`,color:t.ok,fontSize:10,fontWeight:800,maxWidth:160,overflow:"hidden",whiteSpace:"nowrap"}}>
             <span style={{width:6,height:6,borderRadius:"50%",background:t.ok,flexShrink:0}}/>
             Memory
             <span style={{color:t.mut,fontWeight:500,overflow:"hidden",textOverflow:"ellipsis"}}>{activeMemoryWs.name}</span>
@@ -5885,6 +6120,7 @@ function HyprChat(){
           {panel==="chat"&&ghostActive&&<span title="Ghost mode: this chat stays local and is not saved, indexed, or added to history." style={{display:"inline-flex",alignItems:"center",gap:6,padding:"4px 9px",borderRadius:8,background:`${t.pink}10`,border:`1px solid ${t.pink}30`,color:t.pink,fontSize:10,fontWeight:800,whiteSpace:"nowrap"}}>
             <IC.Ghost/> Ghost
           </span>}
+          {panel==="chat"&&<button onClick={toggleGlobalMemory} aria-pressed={globalMemoryActive} disabled={ghostActive} title={act?(globalMemoryActive?"HyprChat memory on: this chat recalls accepted global memories and queues suggestions":"HyprChat memory: recall accepted global memories and queue suggestions for this chat"):(globalMemoryActive?"HyprChat memory on for the next chat":"HyprChat memory: enable recall for the next chat")} style={{background:globalMemoryActive?`${t.acc}18`:"none",border:`1px solid ${globalMemoryActive?t.acc:t.brd}33`,color:ghostActive?`${t.mut}66`:globalMemoryActive?t.acc:t.mut,cursor:ghostActive?"default":"pointer",padding:"4px 8px",borderRadius:8,fontSize:13,display:"flex",alignItems:"center",boxShadow:globalMemoryActive?`0 0 0 1px ${t.acc}22 inset`:"none",opacity:ghostActive?0.45:1}}><IC.Brain/></button>}
           {panel==="chat"&&<button onClick={toggleGhostMode} aria-pressed={ghostActive} title={ghostActive?"Ghost mode on: this chat is local only and will not be saved or indexed":"Ghost mode: start a chat that is never saved or indexed"} style={{background:ghostActive?`${t.pink}18`:"none",border:`1px solid ${ghostActive?t.pink:t.brd}33`,color:ghostActive?t.pink:t.mut,cursor:"pointer",padding:"4px 8px",borderRadius:8,fontSize:13,display:"flex",alignItems:"center",boxShadow:ghostActive?`0 0 0 1px ${t.pink}22 inset`:"none"}}><IC.Ghost/></button>}
           {/* Dark/Light mode toggle */}
           <button onClick={()=>{if(isLightTheme){setTm(prevDarkTheme);}else{setPrevDarkTheme(tm);localStorage.setItem("hc-prev-dark",tm);setTm(LIGHT_PAIRS[tm]||"oneLight");}}} title={isLightTheme?"Switch to dark mode":"Switch to light mode"} style={{background:"none",border:`1px solid ${t.brd}33`,color:t.mut,cursor:"pointer",padding:"4px 8px",borderRadius:8,fontSize:13,display:"flex",alignItems:"center"}}>{isLightTheme?"\u2600\uFE0F":"\uD83C\uDF19"}</button>
@@ -5943,6 +6179,7 @@ function HyprChat(){
             onPreview={openPreview} models={models} wsModel={wsModel}
             notify={notify}
             onPersonaCreated={mc=>{const norm={...mc,parameters:normalizeProfileParams(mc)};setMcs(p=>[...p,norm]);setProfileTab(getProfileType(norm)==="persona"?"personas":"agents");setPanel("personas");setEditMc(mc.id);}}/>
+      :panel==="memory"?<MemoryProfilePanel t={t} API={API} font={font} notify={notify} onOpenConv={id=>loadConversation(id)} models={models} wsModel={wsModel}/>
       :panel==="kb"?<div style={{flex:1,display:"flex",flexDirection:"column",overflow:"hidden"}}>
     <div style={{padding:"16px 20px",borderBottom:`1px solid ${t.brd}28`,display:"flex",justifyContent:"space-between",alignItems:"center"}}>
       <div style={{display:"flex",alignItems:"center",gap:8}}><IC.Database/><span style={{fontSize:14,fontWeight:700,letterSpacing:1,textTransform:"uppercase",color:t.acc}}>Knowledge Bases</span></div>
@@ -6803,35 +7040,50 @@ function HyprChat(){
   </div>
 
       :panel==="models"?<div style={{flex:1,display:"flex",flexDirection:"column",overflow:"hidden"}}>
-    {/* Tab bar */}
-    <div style={{padding:"14px 24px 0",flexShrink:0,display:"flex",alignItems:"flex-end",gap:4,borderBottom:`1px solid ${t.brd}22`}}>
-      <span style={{fontSize:16,fontWeight:700,color:t.acc,letterSpacing:1,textTransform:"uppercase",marginRight:16,paddingBottom:10}}>Models</span>
-      {[["ollama","📦 Installed"],["hf","🤗 HuggingFace"]].map(([key,label])=>
-        <button key={key} onClick={()=>setModelsTab(key)} style={{padding:"8px 20px",borderRadius:"8px 8px 0 0",border:`1px solid ${modelsTab===key?t.acc:t.brd}44`,borderBottom:`2px solid ${modelsTab===key?t.acc:"transparent"}`,background:modelsTab===key?`${t.acc}12`:"transparent",color:modelsTab===key?t.acc:t.mut,fontFamily:font,fontSize:13,cursor:"pointer",fontWeight:modelsTab===key?700:400,marginBottom:-1,transition:"all .15s"}}>
-          {label}
-        </button>
-      )}
-    </div>
-
-    {/* Pull / Search bar — sticky top */}
-    <div style={{padding:"8px 16px 6px",flexShrink:0,borderBottom:`1px solid ${t.brd}15`,background:`${t.bgDeep}EE`}}>
-      {modelsTab==="ollama"?<div style={{display:"flex",gap:6,alignItems:"center"}}>
-        <span style={{fontSize:11,color:t.dim,fontWeight:600,flexShrink:0}}>Pull</span>
-        <input value={pullName} onChange={e=>setPullName(e.target.value)} placeholder="llama3.1:8b" onKeyDown={e=>e.key==="Enter"&&pullModel()} style={{...inputS,width:220,flex:"none",fontSize:12,padding:"6px 10px"}}/>
-        <button onClick={pullModel} disabled={!pullName.trim()} style={{...btnS(t.ok),padding:"6px 12px",fontSize:11,flexShrink:0}}>Pull</button>
-      </div>:null}
+    {/* Toolbar */}
+    <div style={{padding:"14px 20px",flexShrink:0,display:"flex",alignItems:"center",gap:14,borderBottom:`1px solid ${t.brd}24`,background:`${t.bgDeep}E8`,minHeight:62,boxSizing:"border-box",flexWrap:"wrap"}}>
+      <div style={{display:"flex",alignItems:"center",gap:10,minWidth:180}}>
+        <span style={{display:"flex",color:t.acc}}><IC.Database/></span>
+        <div>
+          <div style={{fontSize:15,fontWeight:900,color:t.acc,letterSpacing:1.2,textTransform:"uppercase",lineHeight:1}}>Models</div>
+          <div style={{fontSize:10,color:t.mut,marginTop:3}}>{models.length} installed · {models.filter(m=>m.startsWith("hf.co/")).length} from HuggingFace</div>
+        </div>
+      </div>
+      <div style={{display:"flex",alignItems:"center",gap:4,padding:3,borderRadius:8,border:`1px solid ${t.brd}28`,background:`${t.surface}44`}}>
+        {[["ollama","Installed",models.length],["hf","HuggingFace",models.filter(m=>m.startsWith("hf.co/")).length]].map(([key,label,count])=>{
+          const active=modelsTab===key;
+          return <button key={key} onClick={()=>setModelsTab(key)} style={{padding:"7px 13px",borderRadius:7,border:"none",background:active?`${t.acc}18`:"transparent",color:active?t.acc:t.mut,fontFamily:font,fontSize:12,cursor:"pointer",fontWeight:active?900:700,display:"flex",alignItems:"center",gap:7,transition:"all .15s"}}>
+            <span>{key==="ollama"?"📦":"🤗"}</span><span>{label}</span><span style={{...mmChipS(active?t.acc:t.mut,active?`${t.acc}12`:`${t.surface}66`),fontSize:8,padding:"1px 5px"}}>{count}</span>
+          </button>;
+        })}
+      </div>
+      <div style={{flex:1}}/>
+      {modelsTab==="ollama"&&<div style={{display:"flex",gap:6,alignItems:"center",minWidth:280,maxWidth:430,flex:"1 1 320px"}}>
+        <input value={pullName} onChange={e=>setPullName(e.target.value)} placeholder="Pull model, e.g. llama3.1:8b" onKeyDown={e=>e.key==="Enter"&&pullModel()} style={{...inputS,flex:1,minWidth:180,fontSize:12,padding:"7px 10px",background:t.bgDeep}}/>
+        <button onClick={pullModel} disabled={!pullName.trim()} style={{...btnS(t.ok),padding:"7px 12px",fontSize:11,flexShrink:0,opacity:pullName.trim()?1:.55}}><IC.Download/> Pull</button>
+      </div>}
+      <button onClick={refreshModels} title="Refresh models" style={mmIconBtnS(t.acc)}><IC.Refresh/></button>
     </div>
 
     {/* ── OLLAMA TAB ── */}
-    {modelsTab==="ollama"&&<div style={{flex:1,display:"flex",overflow:"hidden"}}>
+    {modelsTab==="ollama"&&<div style={{flex:1,display:"flex",overflow:"hidden",background:`${t.bg}22`}}>
 
       {/* Left: model list */}
-      <div style={{width:320,minWidth:320,borderRight:`1px solid ${t.brd}18`,display:"flex",flexDirection:"column",overflow:"hidden"}}>
+      <div style={{width:"clamp(360px,30vw,460px)",minWidth:340,borderRight:`1px solid ${t.brd}20`,display:"flex",flexDirection:"column",overflow:"hidden",background:`${t.bgDeep}66`}}>
         {/* Search bar */}
-        <div style={{padding:"12px 12px 8px",flexShrink:0}}>
-          <input value={modelSearch} onChange={e=>setModelSearch(e.target.value)} placeholder="Search installed models..." style={{...inputS,width:"100%",fontSize:12,padding:"8px 12px"}}/>
+        <div style={{padding:"12px 12px 10px",flexShrink:0,borderBottom:`1px solid ${t.brd}16`}}>
+          <div style={{display:"flex",gap:8,alignItems:"center",marginBottom:8}}>
+            <div style={{position:"relative",flex:1}}>
+              <span style={{position:"absolute",left:10,top:"50%",transform:"translateY(-50%)",color:t.mut,display:"flex",opacity:.75}}><IC.Search/></span>
+              <input value={modelSearch} onChange={e=>setModelSearch(e.target.value)} placeholder="Search installed models..." style={{...inputS,width:"100%",fontSize:13,padding:"9px 13px 9px 34px",background:t.bgDeep}}/>
+            </div>
+          </div>
+          <div style={{display:"flex",gap:6,alignItems:"center",justifyContent:"space-between"}}>
+            <span style={mmKickerS}>Inventory</span>
+            <span style={mmMetaS}>{models.filter(m=>!m.startsWith("hf.co/")).length} local · {models.filter(m=>m.startsWith("hf.co/")).length} HF</span>
+          </div>
         </div>
-        <div style={{flex:1,overflowY:"auto",padding:"4px 12px"}}>
+        <div style={{flex:1,overflowY:"auto",padding:"10px 12px 14px"}}>
           {(()=>{
             const searchLower=modelSearch.toLowerCase();
             const families={};
@@ -6856,11 +7108,11 @@ function HyprChat(){
             const icon=(n)=>{const b=n.toLowerCase();if(b.startsWith("hf.co/"))return"🤗";if(b.includes("qwen"))return"🌸";if(b.includes("llama"))return"🦙";if(b.includes("mistral")||b.includes("mixtral"))return"💨";if(b.includes("gemma"))return"💎";if(b.includes("phi"))return"φ";if(b.includes("deepseek"))return"🔍";if(b.includes("coder")||b.includes("code"))return"💻";if(b.includes("wizard"))return"🧙";return"🤖";};
             const famEmoji={HuggingFace:"🤗",Qwen:"🌸",Llama:"🦙",Mistral:"💨",Gemma:"💎",Phi:"φ",DeepSeek:"🔍",Command:"⚡",WizardLM:"🧙",Hermes:"🏛",Other:"🤖"};
             const allItems=Object.values(families).flat();
-            if(!models.length)return <div style={{padding:"24px 8px",color:t.mut,fontSize:12,fontStyle:"italic",textAlign:"center"}}>No models found.<br/>Pull one below.</div>;
-            if(allItems.length===0&&searchLower)return <div style={{padding:"24px 8px",color:t.mut,fontSize:12,fontStyle:"italic",textAlign:"center"}}>No models matching "{modelSearch}"</div>;
-            return Object.entries(families).map(([fam,items])=><div key={fam} style={{marginBottom:12}}>
-              <div style={{fontSize:10,color:t.mut,textTransform:"uppercase",letterSpacing:.6,marginBottom:5,paddingLeft:6,display:"flex",alignItems:"center",gap:5}}>
-                <span>{famEmoji[fam]||"🤖"}</span><span style={{fontWeight:600}}>{fam}</span><span style={{opacity:.5}}>({items.length})</span>
+            if(!models.length)return <div style={{...mmPanelS,padding:"28px 14px",color:t.mut,fontSize:12,textAlign:"center",lineHeight:1.6}}>No installed models yet.<br/>Pull one from Ollama to start.</div>;
+            if(allItems.length===0&&searchLower)return <div style={{...mmPanelS,padding:"28px 14px",color:t.mut,fontSize:12,textAlign:"center"}}>No models matching "{modelSearch}"</div>;
+            return Object.entries(families).map(([fam,items])=><div key={fam} style={{marginBottom:16}}>
+              <div style={{fontSize:11,color:t.mut,textTransform:"uppercase",letterSpacing:.7,margin:"0 2px 7px",display:"flex",alignItems:"center",gap:7}}>
+                <span style={{opacity:.82}}>{famEmoji[fam]||"🤖"}</span><span style={{fontWeight:900}}>{fam}</span><span style={{opacity:.6}}>{items.length}</span>
               </div>
               {items.map(({m,name,tag})=>{
                 const sc=szCol(tag);const sel=modelParamsOpen===m;
@@ -6871,26 +7123,26 @@ function HyprChat(){
                 const diskSz=md.size?fmtSize(md.size):"";
                 const caps=capTags(m);
                 return <div key={m} onClick={()=>{const newSel=sel?null:m;setModelParamsOpen(newSel);setShowModelfile(false);setFixTemplateMsg(null);setFixTemplateFamily("");if(newSel&&!modelInfoCache[newSel]){setModelInfoLoading(true);fetch(`${API}/api/models/${encodeURIComponent(newSel)}/info`).then(r=>r.json()).then(d=>setModelInfoCache(p=>({...p,[newSel]:d}))).catch(()=>{}).finally(()=>setModelInfoLoading(false));}}}
-                  style={{display:"flex",alignItems:"center",gap:10,padding:"10px 12px",borderRadius:10,marginBottom:3,cursor:"pointer",background:sel?`${t.acc}12`:`${t.surface}44`,border:`1px solid ${sel?t.acc:t.brd}${sel?"44":"18"}`,transition:"all .15s"}}>
-                  <span style={{fontSize:18,flexShrink:0}}>{icon(name)}</span>
+                  style={{display:"flex",alignItems:"center",gap:12,padding:"13px 14px",borderRadius:8,marginBottom:7,cursor:"pointer",background:sel?`${t.acc}14`:`${t.surface}40`,border:`1px solid ${sel?t.acc:t.brd}${sel?"55":"18"}`,transition:"all .15s",boxShadow:sel?`inset 3px 0 0 ${t.acc}`:"none"}}>
+                  <span style={{fontSize:18,flexShrink:0,width:24,textAlign:"center"}}>{icon(name)}</span>
                   <div style={{flex:1,minWidth:0}}>
                     <div style={{display:"flex",alignItems:"center",gap:6}}>
-                      <span style={{fontSize:13,fontWeight:600,color:sel?t.acc:t.text,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{name}</span>
-                      {m.startsWith("hf.co/")&&<span style={{fontSize:8,padding:"1px 5px",borderRadius:5,background:"#ff660022",color:"#ff8a3d",fontWeight:700,border:"1px solid #ff660033",flexShrink:0}}>HF</span>}
+                      <span style={{fontSize:14,fontWeight:800,color:sel?t.acc:t.text,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap",lineHeight:1.25}}>{name}</span>
+                      {m.startsWith("hf.co/")&&<span style={mmChipS(t.warm)}>HF</span>}
                       {hasCustom&&<div style={{width:6,height:6,borderRadius:"50%",background:t.acc,flexShrink:0}} title="Custom parameters"/>}
                     </div>
-                    <div style={{display:"flex",alignItems:"center",gap:6,marginTop:3}}>
-                      {paramSz&&<span style={{fontSize:10,color:sc,fontWeight:700}}>{paramSz}</span>}
-                      {!paramSz&&<span style={{fontSize:10,color:sc,fontWeight:700}}>{tag}</span>}
-                      {quant&&(()=>{const qc=quantColor(quant);return <span style={{fontSize:9,padding:"1px 4px",borderRadius:4,background:`${qc}18`,color:qc,fontWeight:600}}>{quant}</span>;})()}
-                      {diskSz&&<span style={{fontSize:9,color:t.mut,opacity:.7}}>{diskSz}</span>}
+                    <div style={{display:"flex",alignItems:"center",gap:6,marginTop:5,flexWrap:"wrap"}}>
+                      {paramSz&&<span style={{fontSize:11,color:sc,fontWeight:800}}>{paramSz}</span>}
+                      {!paramSz&&<span style={{fontSize:11,color:sc,fontWeight:800}}>{tag}</span>}
+                      {quant&&(()=>{const qc=quantColor(quant);return <span style={{...mmChipS(qc),fontSize:10,padding:"2px 7px"}}>{quant}</span>;})()}
+                      {diskSz&&<span style={{fontSize:10,color:t.mut,opacity:.85}}>{diskSz}</span>}
                     </div>
                     {caps.length>0&&<div style={{display:"flex",gap:3,marginTop:4,flexWrap:"wrap"}}>
-                      {caps.map(c=><span key={c.label} style={{fontSize:8,padding:"1px 5px",borderRadius:4,background:`${c.color}15`,color:c.color,fontWeight:600}}>{c.emoji} {c.label}</span>)}
+                      {caps.slice(0,3).map(c=><span key={c.label} style={{...mmChipS(c.color),fontSize:10,padding:"2px 7px",fontWeight:700}}>{c.emoji} {c.label}</span>)}
                     </div>}
                   </div>
-                  <button onClick={e=>{e.stopPropagation();deleteModel(m);}} style={{background:"none",border:"none",color:t.mut,cursor:"pointer",padding:"2px 4px",borderRadius:4,flexShrink:0,display:"flex",alignItems:"center",opacity:.3,transition:"opacity .15s"}} onMouseEnter={e=>e.currentTarget.style.opacity=1} onMouseLeave={e=>e.currentTarget.style.opacity=.3}><IC.Trash/></button>
-                  <span style={{fontSize:11,color:t.mut,flexShrink:0,transition:"transform .2s",transform:sel?"rotate(90deg)":"none"}}>›</span>
+                  <button onClick={e=>{e.stopPropagation();deleteModel(m);}} title="Delete model" style={{...mmIconBtnS(t.err),opacity:.35,background:"transparent",borderColor:"transparent"}} onMouseEnter={e=>e.currentTarget.style.opacity=1} onMouseLeave={e=>e.currentTarget.style.opacity=.35}><IC.Trash/></button>
+                  <span style={{fontSize:13,color:sel?t.acc:t.mut,flexShrink:0,transition:"transform .2s",transform:sel?"rotate(90deg)":"none"}}>›</span>
                 </div>;
               })}
             </div>);
@@ -6899,26 +7151,47 @@ function HyprChat(){
       </div>
 
       {/* Right: parameter detail */}
-      <div style={{flex:1,overflowY:"auto",padding:"24px 28px"}}>
+      <div style={{flex:1,overflowY:"auto",padding:"24px 28px 40px"}}>
         {!modelParamsOpen?
           /* Global defaults shown when nothing is selected */
-          <div style={{maxWidth:580}}>
-            <div style={{fontSize:16,fontWeight:700,color:t.text,marginBottom:6}}>Global Defaults</div>
-            <div style={{fontSize:12,color:t.mut,marginBottom:24}}>Applied to all models unless overridden. Select a model on the left to customize it individually.</div>
+          <div style={{maxWidth:860}}>
+            <div style={{...mmPanelStrongS,padding:20,marginBottom:16}}>
+              <div style={{display:"flex",alignItems:"flex-start",justifyContent:"space-between",gap:14,marginBottom:18,flexWrap:"wrap"}}>
+                <div>
+                  <div style={mmKickerS}>Defaults</div>
+                  <div style={{fontSize:20,fontWeight:900,color:t.text,marginTop:4}}>Global model behavior</div>
+                  <div style={{fontSize:12,color:t.mut,marginTop:5,maxWidth:520,lineHeight:1.5}}>Applied to every model unless that model has its own override. Select a model from the inventory to tune context and sampling individually.</div>
+                </div>
+                <div style={{display:"flex",gap:8,flexWrap:"wrap",justifyContent:"flex-end"}}>
+                  <span style={mmChipS(t.acc)}>{models.length} installed</span>
+                  <span style={mmChipS(t.warm)}>{Object.keys(modelParams).filter(k=>Object.values(modelParams[k]||{}).some(v=>v&&v!=="default")).length} overrides</span>
+                </div>
+              </div>
             {[
               ["Default Temperature","range","0","2","0.05",defaultTemp,v=>setDefaultTemp(parseFloat(v)),v=>v.toFixed(2),"Precise","Balanced","Creative","temperature"],
               ["Default Top-P","range","0.1","1","0.05",defaultTopP,v=>setDefaultTopP(parseFloat(v)),v=>v.toFixed(2),"Focused","Balanced","Diverse","top_p"],
             ].map(([lbl,type,min,max,step,val,setter,fmt,l1,l2,l3,tipKey])=>
-              <div key={lbl} style={{marginBottom:24}}>
+              <div key={lbl} style={{...mmPanelS,padding:"14px 16px",marginBottom:12}}>
                 <div style={{display:"flex",justifyContent:"space-between",alignItems:"baseline",marginBottom:8}}>
-                  <span style={{fontSize:12,color:t.dim,textTransform:"uppercase",letterSpacing:.5,fontWeight:600}}>{lbl} {tipKey&&<Tip k={tipKey} t={t}/>}</span>
+                  <span style={{fontSize:12,color:t.dim,textTransform:"uppercase",letterSpacing:.6,fontWeight:900}}>{lbl} {tipKey&&<Tip k={tipKey} t={t}/>}</span>
                   <span style={{fontSize:16,fontWeight:700,color:t.acc,fontVariantNumeric:"tabular-nums"}}>{fmt(val)}</span>
                 </div>
                 <input type="range" min={min} max={max} step={step} value={val} onChange={e=>setter(e.target.value)} style={{width:"100%",accentColor:t.acc,cursor:"pointer",height:6}}/>
                 <div style={{display:"flex",justifyContent:"space-between",fontSize:10,color:t.mut,marginTop:4}}><span>{l1}</span><span>{l2}</span><span>{l3}</span></div>
               </div>
             )}
-            <div style={{fontSize:11,color:t.mut,marginTop:4}}>Select a model on the left to set its context window.</div>
+            </div>
+            <div style={{...mmPanelS,padding:"14px 16px",display:"grid",gridTemplateColumns:"repeat(auto-fit,minmax(180px,1fr))",gap:12}}>
+              <div>
+                <div style={mmKickerS}>Next step</div>
+                <div style={{fontSize:12,color:t.dim,marginTop:5,lineHeight:1.5}}>Select an installed model to set its context window, tool template, and per-model sampling overrides.</div>
+              </div>
+              <div>
+                <div style={mmKickerS}>Global context</div>
+                <div style={{fontSize:18,fontWeight:900,color:t.acc,marginTop:5}}>{numCtx>=1024?`${(numCtx/1024).toFixed(0)}K`:numCtx}</div>
+                <div style={mmMetaS}>Configured from Settings</div>
+              </div>
+            </div>
           </div>
         :
           /* Per-model parameters */
@@ -6957,27 +7230,29 @@ function HyprChat(){
               }
               setFixingTemplate(false);
             };
-            return <div style={{maxWidth:580,animation:"fadeIn .2s"}}>
+            return <div style={{maxWidth:900,animation:"fadeIn .2s"}}>
               {/* Model header */}
-              <div style={{display:"flex",alignItems:"center",gap:14,marginBottom:20,paddingBottom:16,borderBottom:`1px solid ${t.brd}22`}}>
-                <span style={{fontSize:34}}>{icon(name)}</span>
-                <div style={{flex:1}}>
-                  <div style={{fontSize:18,fontWeight:700,color:t.text}}>{name}</div>
-                  <div style={{display:"flex",gap:5,flexWrap:"wrap",marginTop:4}}>
-                    <span style={{fontSize:11,fontWeight:700,color:sc,background:`${sc}15`,padding:"3px 10px",borderRadius:8,border:`1px solid ${sc}33`}}>{tag}</span>
-                    {quant&&<span style={{fontSize:10,fontWeight:700,color:t.f1,background:`${t.f1}15`,padding:"3px 9px",borderRadius:8,border:`1px solid ${t.f1}33`}}>{quant}</span>}
-                    {format&&<span style={{fontSize:10,color:t.mut,background:`${t.surface}88`,padding:"3px 9px",borderRadius:8,border:`1px solid ${t.brd}33`}}>{format}</span>}
+              <div style={{...mmPanelStrongS,padding:"18px 20px",marginBottom:14,display:"flex",alignItems:"center",gap:14,flexWrap:"wrap"}}>
+                <span style={{fontSize:28,width:40,height:40,borderRadius:8,display:"flex",alignItems:"center",justifyContent:"center",background:`${t.acc}10`,border:`1px solid ${t.acc}22`,flexShrink:0}}>{icon(name)}</span>
+                <div style={{flex:1,minWidth:220}}>
+                  <div style={mmKickerS}>Installed model</div>
+                  <div style={{fontSize:20,fontWeight:900,color:t.text,marginTop:3,wordBreak:"break-word"}}>{name}</div>
+                  <div style={{display:"flex",gap:6,flexWrap:"wrap",marginTop:7}}>
+                    <span style={mmChipS(sc)}>{tag}</span>
+                    {quant&&<span style={mmChipS(quantColor(quant))}>{quant}</span>}
+                    {format&&<span style={mmChipS(t.mut,`${t.surface}66`)}>{format}</span>}
+                    {hasCustom&&<span style={mmChipS(t.acc)}>Custom overrides</span>}
                   </div>
                 </div>
-                <div style={{display:"flex",gap:8}}>
-                  <button onClick={()=>uConv(actId,{model:m})} style={{...btnS(t.acc),padding:"7px 16px",fontSize:12}}>Use</button>
-                  <button onClick={()=>deleteModel(m)} style={{...btnS(t.err),padding:"7px 10px",fontSize:12}}><IC.Trash/></button>
+                <div style={{display:"flex",gap:8,alignItems:"center",flexShrink:0}}>
+                  <button onClick={()=>useModelFromManager(m)} style={{...btnS(t.acc),padding:"8px 16px",fontSize:12,fontWeight:900}}>Use Model</button>
+                  <button onClick={()=>deleteModel(m)} title="Delete model" style={mmIconBtnS(t.err)}><IC.Trash/></button>
                 </div>
               </div>
               {/* Tool calling template fix */}
-              <div style={{marginBottom:18,padding:"14px 16px",background:`${t.warm}08`,border:`1px solid ${t.warm}22`,borderRadius:12}}>
-                <div style={{fontSize:12,fontWeight:700,color:t.warm,marginBottom:8,display:"flex",alignItems:"center",gap:6}}>🔧 Fix Tool Calling Template</div>
-                <div style={{fontSize:11,color:t.mut,marginBottom:12}}>Apply a chat template so this model can use tools. Only needed for custom GGUF models.</div>
+              <details style={{...mmPanelS,marginBottom:14,padding:"0 14px"}}>
+                <summary style={{fontSize:12,fontWeight:900,color:t.warm,cursor:"pointer",padding:"12px 0",display:"flex",alignItems:"center",gap:7}}>🔧 Advanced · Tool Calling Template</summary>
+                <div style={{fontSize:11,color:t.mut,margin:"0 0 12px",lineHeight:1.5}}>Apply a chat template so this model can use tools. This is mainly for custom GGUF models.</div>
                 <div style={{display:"flex",gap:8,alignItems:"center",flexWrap:"wrap",marginBottom:fixTemplateMsg?10:0}}>
                   <select value={effectiveFamily} onChange={e=>setFixTemplateFamily(e.target.value)}
                     style={{background:t.bgDeep,border:`1px solid ${t.brd}44`,color:t.text,padding:"7px 10px",borderRadius:7,fontFamily:font,fontSize:12,flex:1,minWidth:160,outline:"none",cursor:"pointer"}}>
@@ -6989,24 +7264,25 @@ function HyprChat(){
                   </button>
                 </div>
                 {fixTemplateMsg&&<div style={{fontSize:11,color:fixTemplateMsg.ok?t.ok:t.err,padding:"6px 10px",background:fixTemplateMsg.ok?`${t.ok}12`:`${t.err}12`,borderRadius:7,border:`1px solid ${fixTemplateMsg.ok?t.ok:t.err}33`}}>{fixTemplateMsg.text}</div>}
-              </div>
+              </details>
               {/* Info strip */}
-              {(paramSz||diskSz||family||modifiedAt)&&<div style={{display:"flex",flexWrap:"wrap",gap:12,marginBottom:18,padding:"12px 16px",background:`${t.surface}44`,borderRadius:12,border:`1px solid ${t.brd}18`}}>
-                {paramSz&&<div style={{display:"flex",flexDirection:"column",gap:2}}><span style={{fontSize:10,color:t.mut,textTransform:"uppercase",letterSpacing:.5}}>Parameters</span><span style={{fontSize:14,fontWeight:700,color:t.text}}>{paramSz}</span></div>}
-                {diskSz&&<div style={{display:"flex",flexDirection:"column",gap:2}}><span style={{fontSize:10,color:t.mut,textTransform:"uppercase",letterSpacing:.5}}>Disk Size</span><span style={{fontSize:14,fontWeight:700,color:t.text}}>{diskSz}</span></div>}
-                {family&&<div style={{display:"flex",flexDirection:"column",gap:2}}><span style={{fontSize:10,color:t.mut,textTransform:"uppercase",letterSpacing:.5}}>Family</span><span style={{fontSize:14,fontWeight:700,color:t.text,textTransform:"capitalize"}}>{family}</span></div>}
-                {modifiedAt&&<div style={{display:"flex",flexDirection:"column",gap:2,marginLeft:"auto"}}><span style={{fontSize:10,color:t.mut,textTransform:"uppercase",letterSpacing:.5}}>Added</span><span style={{fontSize:12,color:t.dim}}>{modifiedAt}</span></div>}
+              {(paramSz||diskSz||family||modifiedAt)&&<div style={{display:"grid",gridTemplateColumns:"repeat(auto-fit,minmax(130px,1fr))",gap:8,marginBottom:14}}>
+                {paramSz&&<div style={{...mmPanelS,padding:"10px 12px"}}><div style={mmKickerS}>Parameters</div><div style={{fontSize:15,fontWeight:900,color:t.text,marginTop:4}}>{paramSz}</div></div>}
+                {diskSz&&<div style={{...mmPanelS,padding:"10px 12px"}}><div style={mmKickerS}>Disk Size</div><div style={{fontSize:15,fontWeight:900,color:t.text,marginTop:4}}>{diskSz}</div></div>}
+                {family&&<div style={{...mmPanelS,padding:"10px 12px"}}><div style={mmKickerS}>Family</div><div style={{fontSize:15,fontWeight:900,color:t.text,textTransform:"capitalize",marginTop:4}}>{family}</div></div>}
+                {modifiedAt&&<div style={{...mmPanelS,padding:"10px 12px"}}><div style={mmKickerS}>Added</div><div style={{fontSize:13,fontWeight:800,color:t.dim,marginTop:4}}>{modifiedAt}</div></div>}
               </div>}
               {/* Modelfile viewer */}
-              <div style={{marginBottom:18}}>
-                <button onClick={()=>setShowModelfile(p=>!p)} style={{background:"none",border:"none",color:t.mut,cursor:"pointer",fontSize:12,padding:0,display:"flex",alignItems:"center",gap:5,marginBottom:showModelfile?10:0}}>
+              <div style={{...mmPanelS,marginBottom:14,padding:"12px 14px"}}>
+                <button onClick={()=>setShowModelfile(p=>!p)} style={{background:"none",border:"none",color:t.dim,cursor:"pointer",fontSize:12,padding:0,display:"flex",alignItems:"center",gap:6,marginBottom:showModelfile?10:0,fontWeight:800}}>
                   <span style={{transition:"transform .2s",transform:showModelfile?"rotate(90deg)":"none",display:"inline-block"}}>›</span>
-                  {modelInfoLoading&&!info.modelfile?"Loading modelfile...":"📄 View Modelfile"}
+                  {modelInfoLoading&&!info.modelfile?"Loading modelfile...":"View Modelfile"}
                 </button>
                 {showModelfile&&<pre style={{background:t.bgDeep,border:`1px solid ${t.brd}33`,borderRadius:10,padding:"12px 14px",fontSize:11,color:t.dim,overflowX:"auto",whiteSpace:"pre-wrap",wordBreak:"break-all",maxHeight:260,overflowY:"auto",lineHeight:1.5}}>{info.modelfile||"No modelfile data."}</pre>}
               </div>
               {/* Parameter sliders */}
-              <div style={{fontSize:12,color:t.mut,marginBottom:18}}>Override parameters for this model. Leave blank to use global defaults.</div>
+              <div style={{...mmSectionTitleS,marginTop:18}}>Generation overrides</div>
+              <div style={{fontSize:12,color:t.mut,marginBottom:12}}>Leave blank to inherit global defaults.</div>
               {[
                 ["temperature","Temperature","0","2","0.05","Precise","Balanced","Creative"],
                 ["top_p","Top-P","0.1","1","0.05","Focused","Balanced","Diverse"],
@@ -7014,12 +7290,12 @@ function HyprChat(){
               ].map(([key,lbl,min,max,step,l1,l2,l3])=>{
                 const raw=mp[key]||"";const isEmpty=raw===""||raw==="default";
                 const numVal=isEmpty?parseFloat(key==="temperature"?defaultTemp:key==="top_p"?defaultTopP:"1.1"):parseFloat(raw);
-                return <div key={key} style={{marginBottom:24}}>
+                return <div key={key} style={{...mmPanelS,padding:"13px 14px",marginBottom:10}}>
                   <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:8}}>
-                    <span style={{fontSize:12,color:isEmpty?t.mut:t.dim,textTransform:"uppercase",letterSpacing:.5,fontWeight:600}}>{lbl}</span>
+                    <span style={{fontSize:12,color:isEmpty?t.mut:t.dim,textTransform:"uppercase",letterSpacing:.6,fontWeight:900}}>{lbl}</span>
                     <div style={{display:"flex",alignItems:"center",gap:10}}>
                       {!isEmpty&&<button onClick={()=>setModelParams(p=>({...p,[m]:{...(p[m]||{}),[key]:""}}))} style={{background:"none",border:"none",color:t.mut,cursor:"pointer",fontSize:10,padding:0,opacity:.7}}>reset</button>}
-                      <span style={{fontSize:16,fontWeight:700,color:isEmpty?t.mut:t.acc,fontVariantNumeric:"tabular-nums",minWidth:40,textAlign:"right"}}>{isEmpty?"default":numVal.toFixed(2)}</span>
+                      <span style={{fontSize:15,fontWeight:900,color:isEmpty?t.mut:t.acc,fontVariantNumeric:"tabular-nums",minWidth:54,textAlign:"right"}}>{isEmpty?"global":numVal.toFixed(2)}</span>
                     </div>
                   </div>
                   <input type="range" min={min} max={max} step={step} value={numVal}
@@ -7029,12 +7305,12 @@ function HyprChat(){
                 </div>;
               })}
               {/* Top-K */}
-              <div style={{marginBottom:24}}>
+              <div style={{marginBottom:10}}>
                 {(()=>{
                   const key="top_k";const val=mp[key]||"";const isEmpty=val===""||val==="default";
-                  return <div style={{background:`${t.surface}44`,borderRadius:12,padding:"12px 14px",border:`1px solid ${isEmpty?t.brd:t.acc}22`}}>
+                  return <div style={{...mmPanelS,padding:"13px 14px",border:`1px solid ${isEmpty?t.brd:t.acc}22`}}>
                     <div style={{display:"flex",justifyContent:"space-between",marginBottom:8}}>
-                      <span style={{fontSize:11,color:t.mut,textTransform:"uppercase",letterSpacing:.5,fontWeight:600}}>Top-K</span>
+                      <span style={{fontSize:12,color:t.mut,textTransform:"uppercase",letterSpacing:.6,fontWeight:900}}>Top-K</span>
                       {!isEmpty&&<button onClick={()=>setModelParams(p=>({...p,[m]:{...(p[m]||{}),[key]:""}}))} style={{background:"none",border:"none",color:t.mut,cursor:"pointer",fontSize:10,padding:0}}>reset</button>}
                     </div>
                     <input type="number" value={isEmpty?"":val} onChange={e=>setModelParams(p=>({...p,[m]:{...(p[m]||{}),[key]:e.target.value}}))}
@@ -7045,13 +7321,13 @@ function HyprChat(){
                 })()}
               </div>
               {/* Context Window — button grid, defaults to global numCtx */}
-              <div style={{marginBottom:24}}>
+              <div style={{...mmPanelS,padding:"13px 14px",marginBottom:16}}>
                 {(()=>{
                   const ctxVal=mp["num_ctx"]||"";const isDefault=ctxVal===""||ctxVal==="default";
                   const effectiveCtx=isDefault?numCtx:parseInt(ctxVal);
                   return <div>
                     <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:8}}>
-                      <span style={{fontSize:12,color:t.dim,textTransform:"uppercase",letterSpacing:.5,fontWeight:600}}>Context Window <Tip k="num_ctx" t={t}/></span>
+                      <span style={{fontSize:12,color:t.dim,textTransform:"uppercase",letterSpacing:.6,fontWeight:900}}>Context Window <Tip k="num_ctx" t={t}/></span>
                       <div style={{display:"flex",alignItems:"center",gap:8}}>
                         {!isDefault&&<button onClick={()=>setModelParams(p=>({...p,[m]:{...(p[m]||{}),num_ctx:""}}))} style={{background:"none",border:"none",color:t.mut,cursor:"pointer",fontSize:10,padding:0}}>reset to global</button>}
                         <span style={{fontSize:11,color:isDefault?t.mut:t.acc,fontWeight:600}}>{isDefault?"global default":""}</span>
@@ -7074,26 +7350,26 @@ function HyprChat(){
     </div>}
 
     {/* ── HUGGINGFACE TAB ── */}
-    {modelsTab==="hf"&&<div style={{flex:1,display:"flex",overflow:"hidden"}}>
+    {modelsTab==="hf"&&<div style={{flex:1,display:"flex",overflow:"hidden",background:`${t.bg}22`}}>
 
       {/* Left: search/installed toggle + results */}
-      <div style={{width:310,minWidth:310,borderRight:`1px solid ${t.brd}18`,display:"flex",flexDirection:"column",overflow:"hidden"}}>
+      <div style={{width:"clamp(360px,30vw,460px)",minWidth:340,borderRight:`1px solid ${t.brd}20`,display:"flex",flexDirection:"column",overflow:"hidden",background:`${t.bgDeep}66`}}>
         {/* Sub-tab toggle */}
-        <div style={{display:"flex",borderBottom:`1px solid ${t.brd}22`,flexShrink:0}}>
+        <div style={{display:"flex",gap:4,padding:8,borderBottom:`1px solid ${t.brd}18`,flexShrink:0}}>
           {[["search","🔍 Search"],[true,"📦 Installed"]].map(([key,label])=>{
             const active=key==="search"?!hfInstalledTab:hfInstalledTab;
             const count=key===true?models.filter(m=>m.startsWith("hf.co/")).length:0;
-            return <button key={String(key)} onClick={()=>setHfInstalledTab(key===true)} style={{flex:1,padding:"9px 8px",border:"none",borderBottom:`2px solid ${active?t.acc:"transparent"}`,background:active?`${t.acc}10`:"transparent",color:active?t.acc:t.mut,fontFamily:font,fontSize:10,cursor:"pointer",fontWeight:active?700:400,display:"flex",alignItems:"center",justifyContent:"center",gap:5,transition:"all .15s"}}>
-              {label}{count>0&&key===true&&<span style={{fontSize:8,background:`${t.acc}22`,color:t.acc,padding:"1px 5px",borderRadius:8,border:`1px solid ${t.acc}33`}}>{count}</span>}
+            return <button key={String(key)} onClick={()=>setHfInstalledTab(key===true)} style={{flex:1,padding:"9px 11px",border:`1px solid ${active?t.acc:t.brd}30`,borderRadius:7,background:active?`${t.acc}14`:`${t.surface}33`,color:active?t.acc:t.mut,fontFamily:font,fontSize:12,cursor:"pointer",fontWeight:active?900:700,display:"flex",alignItems:"center",justifyContent:"center",gap:7,transition:"all .15s"}}>
+              {label}{count>0&&key===true&&<span style={{fontSize:9,background:`${t.acc}22`,color:t.acc,padding:"1px 6px",borderRadius:8,border:`1px solid ${t.acc}33`}}>{count}</span>}
             </button>;
           })}
         </div>
 
         {/* INSTALLED HF MODELS */}
-        {hfInstalledTab?<div style={{flex:1,overflowY:"auto",padding:"8px 8px"}}>
+        {hfInstalledTab?<div style={{flex:1,overflowY:"auto",padding:"10px 12px 14px"}}>
           {(()=>{
             const hfModels=models.filter(m=>m.startsWith("hf.co/"));
-            if(!hfModels.length)return <div style={{padding:"30px 12px",textAlign:"center",color:t.mut,fontSize:11,fontStyle:"italic",lineHeight:1.6}}>No HuggingFace models installed yet.<br/>Use the Search tab to find and download models.</div>;
+            if(!hfModels.length)return <div style={{...mmPanelS,padding:"30px 14px",textAlign:"center",color:t.mut,fontSize:12,lineHeight:1.6}}>No HuggingFace models installed yet.<br/>Use Search to find and download GGUF models.</div>;
             return hfModels.map(m=>{
               const md=modelDetails[m]||{};
               const quant=(md.details?.quantization_level||"").toUpperCase();
@@ -7108,46 +7384,46 @@ function HyprChat(){
               const allCaps=[...caps];
               if(!allCaps.find(c=>c.label==="Vision")&&repoName.toLowerCase().match(/vl|vision|llava/))allCaps.push({label:"Vision",emoji:"👁",color:"#e67e22"});
               return <div key={m} onClick={()=>{const newSel=isSel?null:m;setModelParamsOpen(newSel);setShowModelfile(false);if(newSel&&!modelInfoCache[newSel]){setModelInfoLoading(true);fetch(`${API}/api/models/${encodeURIComponent(newSel)}/info`).then(r=>r.json()).then(d=>setModelInfoCache(p=>({...p,[newSel]:d}))).catch(()=>{}).finally(()=>setModelInfoLoading(false));}}}
-                style={{padding:"9px 10px",borderRadius:8,marginBottom:4,cursor:"pointer",background:isSel?`${t.acc}12`:`${t.surface}33`,border:`1px solid ${isSel?t.acc:t.brd}${isSel?"44":"15"}`,transition:"all .12s",display:"flex",alignItems:"center",gap:8}}>
-                <span style={{fontSize:14,flexShrink:0}}>🤗</span>
+                style={{padding:"13px 14px",borderRadius:8,marginBottom:7,cursor:"pointer",background:isSel?`${t.acc}14`:`${t.surface}40`,border:`1px solid ${isSel?t.acc:t.brd}${isSel?"55":"18"}`,transition:"all .12s",display:"flex",alignItems:"center",gap:12,boxShadow:isSel?`inset 3px 0 0 ${t.acc}`:"none"}}>
+                <span style={{fontSize:18,flexShrink:0,width:24,textAlign:"center"}}>🤗</span>
                 <div style={{flex:1,minWidth:0}}>
-                  <div style={{fontSize:10,color:t.mut,marginBottom:1,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{repoBase}</div>
-                  <div style={{fontSize:11,fontWeight:600,color:isSel?t.acc:t.text,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap",marginBottom:3}}>{repoName}</div>
+                  <div style={{fontSize:10,color:t.mut,marginBottom:3,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{repoBase}</div>
+                  <div style={{fontSize:14,fontWeight:800,color:isSel?t.acc:t.text,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap",marginBottom:5}}>{repoName}</div>
                   <div style={{display:"flex",gap:4,flexWrap:"wrap",alignItems:"center"}}>
-                    {quant&&(()=>{const qc=quantColor(quant);return <span style={{fontSize:8,padding:"1px 4px",borderRadius:4,background:`${qc}18`,color:qc,fontWeight:600,border:`1px solid ${qc}33`}}>{quant}</span>;})()}
-                    {paramSz&&<span style={{fontSize:8,color:t.mut}}>{paramSz}</span>}
-                    {diskSz&&<span style={{fontSize:8,color:t.mut}}>{diskSz}</span>}
-                    {allCaps.map(c=><span key={c.label} style={{fontSize:8,padding:"1px 4px",borderRadius:4,background:`${c.color}22`,color:c.color,fontWeight:600,border:`1px solid ${c.color}44`}}>{c.emoji} {c.label}</span>)}
+                    {quant&&(()=>{const qc=quantColor(quant);return <span style={{...mmChipS(qc),fontSize:10,padding:"2px 7px"}}>{quant}</span>;})()}
+                    {paramSz&&<span style={{fontSize:10,color:t.mut}}>{paramSz}</span>}
+                    {diskSz&&<span style={{fontSize:10,color:t.mut}}>{diskSz}</span>}
+                    {allCaps.slice(0,3).map(c=><span key={c.label} style={{...mmChipS(c.color),fontSize:10,padding:"2px 7px",fontWeight:700}}>{c.emoji} {c.label}</span>)}
                   </div>
                 </div>
                 <div style={{display:"flex",flexDirection:"column",gap:3,flexShrink:0}}>
-                  <button onClick={e=>{e.stopPropagation();patchToolModel(m,"This HuggingFace model can now use tools.");}} disabled={!!makingToolModel} title="Patch modelfile to enable native tool calling" style={{background:makingToolModel===m?`${t.mut}15`:`${t.ok}22`,border:`1px solid ${makingToolModel===m?t.mut:t.ok}55`,color:makingToolModel===m?t.mut:t.ok,cursor:makingToolModel?"wait":"pointer",padding:"4px 8px",borderRadius:5,fontSize:9,fontWeight:700,whiteSpace:"nowrap",transition:"all .15s"}}>{makingToolModel===m?"⏳ Patching…":"🔧 Enable Tools"}</button>
-                  <button onClick={e=>{e.stopPropagation();deleteModel(m);}}  style={{background:"none",border:`1px solid ${t.err}33`,color:t.err,cursor:"pointer",padding:"3px 8px",borderRadius:5,fontSize:9,fontWeight:600,opacity:.6,transition:"opacity .15s"}} onMouseEnter={e=>e.currentTarget.style.opacity=1} onMouseLeave={e=>e.currentTarget.style.opacity=.6}>🗑 Delete</button>
+                  <button onClick={e=>{e.stopPropagation();patchToolModel(m,"This HuggingFace model can now use tools.");}} disabled={!!makingToolModel} title="Patch modelfile to enable native tool calling" style={{background:makingToolModel===m?`${t.mut}15`:`${t.ok}18`,border:`1px solid ${makingToolModel===m?t.mut:t.ok}44`,color:makingToolModel===m?t.mut:t.ok,cursor:makingToolModel?"wait":"pointer",padding:"5px 8px",borderRadius:6,fontSize:10,fontWeight:800,whiteSpace:"nowrap",transition:"all .15s"}}>{makingToolModel===m?"Patching":"Enable Tools"}</button>
+                  <button onClick={e=>{e.stopPropagation();deleteModel(m);}} title="Delete model" style={{...mmIconBtnS(t.err),width:"100%",height:24,opacity:.45,background:"transparent"}} onMouseEnter={e=>e.currentTarget.style.opacity=1} onMouseLeave={e=>e.currentTarget.style.opacity=.45}><IC.Trash/></button>
                 </div>
-                <span style={{fontSize:9,color:t.mut,flexShrink:0,transition:"transform .2s",transform:isSel?"rotate(90deg)":"none"}}>›</span>
+                <span style={{fontSize:13,color:isSel?t.acc:t.mut,flexShrink:0,transition:"transform .2s",transform:isSel?"rotate(90deg)":"none"}}>›</span>
               </div>;
             });
           })()}
         </div>
         :<>
-        <div style={{padding:"10px 10px",flexShrink:0,borderBottom:`1px solid ${t.brd}15`}}>
-          <div style={{display:"flex",gap:5}}>
+        <div style={{padding:"12px 12px 10px",flexShrink:0,borderBottom:`1px solid ${t.brd}16`}}>
+          <div style={{display:"flex",gap:6}}>
             <input value={hfSearch} onChange={e=>setHfSearch(e.target.value)} onKeyDown={e=>e.key==="Enter"&&hfDoSearch(hfSearch)}
-              placeholder="Search models..." style={{...inputS,flex:1,fontSize:11,padding:"6px 8px"}}/>
-            <button onClick={()=>hfDoSearch(hfSearch)} disabled={hfLoading||!hfSearch.trim()} style={{...btnS(t.acc),padding:"5px 8px",flexShrink:0}}><IC.Search/></button>
+              placeholder="Search HuggingFace models..." style={{...inputS,flex:1,fontSize:13,padding:"9px 11px",background:t.bgDeep}}/>
+            <button onClick={()=>hfDoSearch(hfSearch)} disabled={hfLoading||!hfSearch.trim()} style={{...btnS(t.acc),padding:"7px 10px",flexShrink:0,opacity:(!hfLoading&&hfSearch.trim())?1:.55}}><IC.Search/></button>
           </div>
-          <label style={{display:"flex",alignItems:"center",gap:5,marginTop:6,cursor:"pointer",fontSize:9,color:t.mut}}>
+          <label style={{display:"flex",alignItems:"center",gap:6,marginTop:8,cursor:"pointer",fontSize:11,color:t.mut}}>
             <input type="checkbox" checked={hfGgufOnly} onChange={e=>setHfGgufOnly(e.target.checked)} style={{accentColor:t.acc}}/>
             GGUF only (Ollama-compatible)
           </label>
-          {!hfResults.length&&!hfLoading&&<div style={{marginTop:8,fontSize:9,color:t.mut}}>
+          {!hfResults.length&&!hfLoading&&<div style={{marginTop:10,fontSize:11,color:t.mut,lineHeight:1.7}}>
             Try: {["Llama 3","Qwen2.5","Mistral","Gemma","Phi-3"].map((s,i)=><span key={s}>
               <span style={{color:t.acc,cursor:"pointer"}} onClick={()=>{setHfSearch(s);hfDoSearch(s);}}>{s}</span>
               {i<4?" · ":""}
             </span>)}
           </div>}
         </div>
-        <div style={{flex:1,overflowY:"auto",padding:"6px 8px"}}>
+        <div style={{flex:1,overflowY:"auto",padding:"10px 12px 14px"}}>
           {hfLoading&&<div style={{display:"flex",justifyContent:"center",padding:24,gap:5,alignItems:"center",color:t.mut,fontSize:11}}>
             <div style={{display:"flex",gap:3}}>{[0,1,2].map(i=><div key={i} style={{width:5,height:5,borderRadius:"50%",background:t.acc,animation:`pulse 1.4s ${i*.16}s infinite`}}/>)}</div>Searching...
           </div>}
@@ -7163,13 +7439,13 @@ function HyprChat(){
               if(b.match(/abliterated|uncensored|unfiltered|dolphin/))caps.push({label:"Uncensored",emoji:"🔓",color:"#ef4444"});
               if(b.match(/instruct|chat|[\-:]it(?:$|[\-:])/))caps.push({label:"Instruct",emoji:"📝",color:"#64748b"});
               return caps;})();
-            return <div key={m.id} onClick={()=>hfSelectModel(m)} style={{padding:"9px 10px",borderRadius:8,marginBottom:3,cursor:"pointer",background:isSel?`${t.acc}12`:`${t.surface}33`,border:`1px solid ${isSel?t.acc:t.brd}${isSel?"44":"15"}`,transition:"all .12s"}}>
-              <div style={{fontSize:9,color:t.mut,marginBottom:1}}>{author}/</div>
-              <div style={{fontSize:11,fontWeight:600,color:isSel?t.acc:t.text,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap",marginBottom:4}}>{name||m.id}</div>
+            return <div key={m.id} onClick={()=>hfSelectModel(m)} style={{padding:"13px 14px",borderRadius:8,marginBottom:7,cursor:"pointer",background:isSel?`${t.acc}14`:`${t.surface}40`,border:`1px solid ${isSel?t.acc:t.brd}${isSel?"55":"18"}`,transition:"all .12s",boxShadow:isSel?`inset 3px 0 0 ${t.acc}`:"none"}}>
+              <div style={{fontSize:10,color:t.mut,marginBottom:3,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{author}/</div>
+              <div style={{fontSize:14,fontWeight:800,color:isSel?t.acc:t.text,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap",marginBottom:6}}>{name||m.id}</div>
               <div style={{display:"flex",gap:6,alignItems:"center",flexWrap:"wrap"}}>
-                <span style={{fontSize:9,color:t.mut}}>⬇ {m.downloads>999?`${(m.downloads/1000).toFixed(1)}k`:m.downloads}</span>
-                <span style={{fontSize:9,color:t.mut}}>♥ {m.likes}</span>
-                {hfCaps.map(c=><span key={c.label} style={{fontSize:8,padding:"1px 5px",borderRadius:4,background:`${c.color}22`,color:c.color,fontWeight:600,border:`1px solid ${c.color}44`,marginLeft:2}}>{c.emoji} {c.label}</span>)}
+                <span style={{fontSize:10,color:t.mut}}>⬇ {m.downloads>999?`${(m.downloads/1000).toFixed(1)}k`:m.downloads}</span>
+                <span style={{fontSize:10,color:t.mut}}>♥ {m.likes}</span>
+                {hfCaps.slice(0,4).map(c=><span key={c.label} style={{...mmChipS(c.color),fontSize:10,padding:"2px 7px",fontWeight:700}}>{c.emoji} {c.label}</span>)}
               </div>
             </div>;
           })}
@@ -7181,7 +7457,7 @@ function HyprChat(){
       <div style={{flex:1,display:"flex",flexDirection:"column",overflow:"hidden"}}>
         {hfInstalledTab&&modelParamsOpen&&models.includes(modelParamsOpen)?
           /* installed model settings panel */
-          <div style={{flex:1,overflowY:"auto",padding:"20px 24px"}}>
+          <div style={{flex:1,overflowY:"auto",padding:"24px 28px 40px"}}>
             {(()=>{
               const m=modelParamsOpen;const [mname,mtag="latest"]=m.split(":");const mp=modelParams[m]||{};
               const hasCustom=Object.values(mp).some(v=>v&&v!=="default");
@@ -7196,48 +7472,51 @@ function HyprChat(){
               const repoPath=m.replace("hf.co/","");
               const repoName=repoPath.split("/").pop()?.split(":")[0]||m;
               const sc=(tag)=>{const l=(tag||"").toLowerCase();if(l.match(/70b|65b|72b/))return t.err;if(l.match(/30b|32b|34b/))return t.warm;if(l.match(/13b|14b|27b/))return t.acc;if(l.match(/7b|8b/))return t.ok;if(l.match(/1b|3b|4b/))return t.f1;return t.mut;};
-              return <div style={{maxWidth:520,animation:"fadeIn .2s"}}>
-                <div style={{display:"flex",alignItems:"center",gap:12,marginBottom:16,paddingBottom:14,borderBottom:`1px solid ${t.brd}22`}}>
-                  <span style={{fontSize:28}}>🤗</span>
+              return <div style={{maxWidth:900,animation:"fadeIn .2s"}}>
+                <div style={{...mmPanelStrongS,padding:"18px 20px",marginBottom:14,display:"flex",alignItems:"center",gap:14,flexWrap:"wrap"}}>
+                  <span style={{fontSize:26,width:40,height:40,borderRadius:8,display:"flex",alignItems:"center",justifyContent:"center",background:`${t.warm}10`,border:`1px solid ${t.warm}22`,flexShrink:0}}>🤗</span>
                   <div style={{flex:1,minWidth:0}}>
-                    <div style={{fontSize:9,color:t.mut,marginBottom:2}}>{repoPath.split(":")[0]}</div>
-                    <div style={{fontSize:14,fontWeight:700,color:t.text,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{repoName}</div>
-                    <div style={{display:"flex",gap:4,flexWrap:"wrap",marginTop:3}}>
-                      {quant&&<span style={{fontSize:9,fontWeight:700,color:t.f1,background:`${t.f1}15`,padding:"2px 7px",borderRadius:8,border:`1px solid ${t.f1}33`}}>{quant}</span>}
-                      {format&&<span style={{fontSize:9,color:t.mut,background:`${t.surface}88`,padding:"2px 7px",borderRadius:8,border:`1px solid ${t.brd}33`}}>{format}</span>}
+                    <div style={mmKickerS}>{repoPath.split(":")[0]}</div>
+                    <div style={{fontSize:20,fontWeight:900,color:t.text,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap",marginTop:3}}>{repoName}</div>
+                    <div style={{display:"flex",gap:6,flexWrap:"wrap",marginTop:7}}>
+                      <span style={mmChipS(t.warm)}>HuggingFace</span>
+                      {quant&&<span style={mmChipS(quantColor(quant))}>{quant}</span>}
+                      {format&&<span style={mmChipS(t.mut,`${t.surface}66`)}>{format}</span>}
+                      {hasCustom&&<span style={mmChipS(t.acc)}>Custom overrides</span>}
                     </div>
                   </div>
-                  <div style={{display:"flex",flexDirection:"column",gap:5,alignItems:"flex-end"}}>
+                  <div style={{display:"flex",flexDirection:"column",gap:7,alignItems:"flex-end",flexShrink:0}}>
                     <div style={{display:"flex",gap:6}}>
-                      <button onClick={()=>uConv(actId,{model:m})} style={{...btnS(t.acc),padding:"5px 12px"}}>Use</button>
-                      <button onClick={()=>deleteModel(m)} style={{...btnS(t.err),padding:"5px 8px"}}><IC.Trash/></button>
+                      <button onClick={()=>useModelFromManager(m)} style={{...btnS(t.acc),padding:"8px 16px",fontSize:12,fontWeight:900}}>Use Model</button>
+                      <button onClick={()=>deleteModel(m)} title="Delete model" style={mmIconBtnS(t.err)}><IC.Trash/></button>
                     </div>
-                    <button onClick={e=>{e.stopPropagation();patchToolModel(m,"This model can now use tools.");}} disabled={!!makingToolModel} style={{background:makingToolModel===m?`${t.mut}15`:`${t.ok}22`,border:`1px solid ${makingToolModel===m?t.mut:t.ok}66`,color:makingToolModel===m?t.mut:t.ok,cursor:makingToolModel?"wait":"pointer",padding:"5px 12px",borderRadius:7,fontSize:10,fontWeight:700,whiteSpace:"nowrap",letterSpacing:.3,transition:"all .15s"}}>{makingToolModel===m?"⏳ Patching…":"🔧 Enable Tool Calling"}</button>
+                    <button onClick={e=>{e.stopPropagation();patchToolModel(m,"This model can now use tools.");}} disabled={!!makingToolModel} style={{background:makingToolModel===m?`${t.mut}15`:`${t.ok}18`,border:`1px solid ${makingToolModel===m?t.mut:t.ok}44`,color:makingToolModel===m?t.mut:t.ok,cursor:makingToolModel?"wait":"pointer",padding:"6px 12px",borderRadius:7,fontSize:10,fontWeight:900,whiteSpace:"nowrap",letterSpacing:.2,transition:"all .15s"}}>{makingToolModel===m?"Patching...":"Enable Tool Calling"}</button>
                   </div>
                 </div>
-                {(paramSz||diskSz||family||modifiedAt)&&<div style={{display:"flex",flexWrap:"wrap",gap:8,marginBottom:16,padding:"10px 14px",background:`${t.surface}44`,borderRadius:10,border:`1px solid ${t.brd}18`}}>
-                  {paramSz&&<div style={{display:"flex",flexDirection:"column",gap:1}}><span style={{fontSize:8,color:t.mut,textTransform:"uppercase",letterSpacing:.5}}>Parameters</span><span style={{fontSize:12,fontWeight:700,color:t.text}}>{paramSz}</span></div>}
-                  {diskSz&&<div style={{display:"flex",flexDirection:"column",gap:1}}><span style={{fontSize:8,color:t.mut,textTransform:"uppercase",letterSpacing:.5}}>Disk Size</span><span style={{fontSize:12,fontWeight:700,color:t.text}}>{diskSz}</span></div>}
-                  {family&&<div style={{display:"flex",flexDirection:"column",gap:1}}><span style={{fontSize:8,color:t.mut,textTransform:"uppercase",letterSpacing:.5}}>Family</span><span style={{fontSize:12,fontWeight:700,color:t.text,textTransform:"capitalize"}}>{family}</span></div>}
-                  {modifiedAt&&<div style={{display:"flex",flexDirection:"column",gap:1,marginLeft:"auto"}}><span style={{fontSize:8,color:t.mut,textTransform:"uppercase",letterSpacing:.5}}>Added</span><span style={{fontSize:11,color:t.dim}}>{modifiedAt}</span></div>}
+                {(paramSz||diskSz||family||modifiedAt)&&<div style={{display:"grid",gridTemplateColumns:"repeat(auto-fit,minmax(130px,1fr))",gap:8,marginBottom:14}}>
+                  {paramSz&&<div style={{...mmPanelS,padding:"10px 12px"}}><div style={mmKickerS}>Parameters</div><div style={{fontSize:15,fontWeight:900,color:t.text,marginTop:4}}>{paramSz}</div></div>}
+                  {diskSz&&<div style={{...mmPanelS,padding:"10px 12px"}}><div style={mmKickerS}>Disk Size</div><div style={{fontSize:15,fontWeight:900,color:t.text,marginTop:4}}>{diskSz}</div></div>}
+                  {family&&<div style={{...mmPanelS,padding:"10px 12px"}}><div style={mmKickerS}>Family</div><div style={{fontSize:15,fontWeight:900,color:t.text,textTransform:"capitalize",marginTop:4}}>{family}</div></div>}
+                  {modifiedAt&&<div style={{...mmPanelS,padding:"10px 12px"}}><div style={mmKickerS}>Added</div><div style={{fontSize:13,fontWeight:800,color:t.dim,marginTop:4}}>{modifiedAt}</div></div>}
                 </div>}
-                <div style={{marginBottom:16}}>
-                  <button onClick={()=>setShowModelfile(p=>!p)} style={{background:"none",border:"none",color:t.mut,cursor:"pointer",fontSize:10,padding:0,display:"flex",alignItems:"center",gap:4,marginBottom:showModelfile?8:0}}>
+                <div style={{...mmPanelS,marginBottom:14,padding:"12px 14px"}}>
+                  <button onClick={()=>setShowModelfile(p=>!p)} style={{background:"none",border:"none",color:t.dim,cursor:"pointer",fontSize:12,padding:0,display:"flex",alignItems:"center",gap:6,marginBottom:showModelfile?8:0,fontWeight:800}}>
                     <span style={{transition:"transform .2s",transform:showModelfile?"rotate(90deg)":"none",display:"inline-block"}}>›</span>
-                    {modelInfoLoading&&!info.modelfile?"Loading modelfile...":"📄 View Modelfile"}
+                    {modelInfoLoading&&!info.modelfile?"Loading modelfile...":"View Modelfile"}
                   </button>
                   {showModelfile&&<pre style={{background:t.bgDeep,border:`1px solid ${t.brd}33`,borderRadius:8,padding:"10px 12px",fontSize:10,color:t.dim,overflowX:"auto",whiteSpace:"pre-wrap",wordBreak:"break-all",maxHeight:200,overflowY:"auto",lineHeight:1.5}}>{info.modelfile||"No modelfile data."}</pre>}
                 </div>
-                <div style={{fontSize:10,color:t.mut,marginBottom:16}}>Override parameters for this model. Leave blank to use global defaults.</div>
+                <div style={{...mmSectionTitleS,marginTop:18}}>Generation overrides</div>
+                <div style={{fontSize:12,color:t.mut,marginBottom:12}}>Leave blank to inherit global defaults.</div>
                 {[["temperature","Temperature","0","2","0.05","Precise","Balanced","Creative"],["top_p","Top-P","0.1","1","0.05","Focused","Balanced","Diverse"],["repeat_penalty","Repeat Penalty","1","2","0.05","None","Normal","Strong"]].map(([key,lbl,min,max,step,l1,l2,l3])=>{
                   const raw=mp[key]||"";const isEmpty=raw===""||raw==="default";
                   const numVal=isEmpty?parseFloat(key==="temperature"?defaultTemp:key==="top_p"?defaultTopP:"1.1"):parseFloat(raw);
-                  return <div key={key} style={{marginBottom:20}}>
+                  return <div key={key} style={{...mmPanelS,padding:"13px 14px",marginBottom:10}}>
                     <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:6}}>
-                      <span style={{fontSize:10,color:isEmpty?t.mut:t.text,textTransform:"uppercase",letterSpacing:.5}}>{lbl}</span>
+                      <span style={{fontSize:12,color:isEmpty?t.mut:t.dim,textTransform:"uppercase",letterSpacing:.6,fontWeight:900}}>{lbl}</span>
                       <div style={{display:"flex",alignItems:"center",gap:8}}>
                         {!isEmpty&&<button onClick={()=>setModelParams(p=>({...p,[m]:{...(p[m]||{}),[key]:""}}))} style={{background:"none",border:"none",color:t.mut,cursor:"pointer",fontSize:9,padding:0,opacity:.7}}>reset</button>}
-                        <span style={{fontSize:13,fontWeight:700,color:isEmpty?t.mut:t.acc,fontVariantNumeric:"tabular-nums",minWidth:36,textAlign:"right"}}>{isEmpty?"default":numVal.toFixed(2)}</span>
+                        <span style={{fontSize:15,fontWeight:900,color:isEmpty?t.mut:t.acc,fontVariantNumeric:"tabular-nums",minWidth:54,textAlign:"right"}}>{isEmpty?"global":numVal.toFixed(2)}</span>
                       </div>
                     </div>
                     <input type="range" min={min} max={max} step={step} value={numVal} onChange={e=>setModelParams(p=>({...p,[m]:{...(p[m]||{}),[key]:e.target.value}}))} style={{width:"100%",accentColor:isEmpty?t.mut:t.acc,cursor:"pointer",opacity:isEmpty?0.6:1}}/>
@@ -7247,9 +7526,9 @@ function HyprChat(){
                 <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:14,marginBottom:20}}>
                   {[["top_k","Top-K","1","200","1","Integer sample pool"],["num_ctx","Context (tokens)","2048","131072","1024","Max token window"]].map(([key,lbl,min,max,step,desc])=>{
                     const val=mp[key]||"";const isEmpty=val===""||val==="default";
-                    return <div key={key} style={{background:`${t.surface}44`,borderRadius:10,padding:"10px 12px",border:`1px solid ${isEmpty?t.brd:t.acc}22`}}>
+                    return <div key={key} style={{...mmPanelS,padding:"12px 14px",border:`1px solid ${isEmpty?t.brd:t.acc}22`}}>
                       <div style={{display:"flex",justifyContent:"space-between",marginBottom:6}}>
-                        <span style={{fontSize:9,color:t.mut,textTransform:"uppercase",letterSpacing:.5}}>{lbl}</span>
+                        <span style={{fontSize:10,color:t.mut,textTransform:"uppercase",letterSpacing:.6,fontWeight:900}}>{lbl}</span>
                         {!isEmpty&&<button onClick={()=>setModelParams(p=>({...p,[m]:{...(p[m]||{}),[key]:""}}))} style={{background:"none",border:"none",color:t.mut,cursor:"pointer",fontSize:9,padding:0}}>reset</button>}
                       </div>
                       <input type="number" value={isEmpty?"":val} onChange={e=>setModelParams(p=>({...p,[m]:{...(p[m]||{}),[key]:e.target.value}}))} placeholder="Default" min={min} max={max} step={step} style={{...inputS,padding:"5px 8px",fontSize:12,color:isEmpty?t.mut:t.acc,width:"100%"}}/>
@@ -7262,20 +7541,27 @@ function HyprChat(){
             })()}
           </div>
         :hfInstalledTab?
-          <div style={{flex:1,display:"flex",alignItems:"center",justifyContent:"center",flexDirection:"column",gap:10,opacity:.4}}>
-            <span style={{fontSize:36}}>🤗</span>
-            <div style={{fontSize:12,color:t.mut}}>Select an installed model to view settings</div>
+          <div style={{flex:1,display:"flex",alignItems:"center",justifyContent:"center",padding:24}}>
+            <div style={{...mmPanelS,padding:"28px 34px",textAlign:"center",maxWidth:360}}>
+              <span style={{fontSize:32}}>🤗</span>
+              <div style={{fontSize:14,fontWeight:900,color:t.text,marginTop:10}}>Select an installed model</div>
+              <div style={{fontSize:12,color:t.mut,marginTop:5,lineHeight:1.5}}>Review settings, tool calling, and per-model overrides.</div>
+            </div>
           </div>
-        :!hfSelected?<div style={{flex:1,display:"flex",alignItems:"center",justifyContent:"center",flexDirection:"column",gap:10,opacity:.4}}>
-          <span style={{fontSize:36}}>🤗</span>
-          <div style={{fontSize:12,color:t.mut}}>Search and select a model to view details</div>
+        :!hfSelected?<div style={{flex:1,display:"flex",alignItems:"center",justifyContent:"center",padding:24}}>
+          <div style={{...mmPanelS,padding:"28px 34px",textAlign:"center",maxWidth:380}}>
+            <span style={{fontSize:32}}>🤗</span>
+            <div style={{fontSize:14,fontWeight:900,color:t.text,marginTop:10}}>Search HuggingFace</div>
+            <div style={{fontSize:12,color:t.mut,marginTop:5,lineHeight:1.5}}>Select a GGUF model to inspect files, compatibility, and README details.</div>
+          </div>
         </div>:
         <div style={{flex:1,display:"flex",flexDirection:"column",overflow:"hidden"}}>
           {/* Model header */}
-          <div style={{padding:"14px 20px",flexShrink:0,borderBottom:`1px solid ${t.brd}18`,display:"flex",alignItems:"center",gap:12}}>
+          <div style={{padding:"16px 20px",flexShrink:0,borderBottom:`1px solid ${t.brd}20`,display:"flex",alignItems:"center",gap:12,background:`${t.surface}33`}}>
+            <span style={{fontSize:24,width:36,height:36,borderRadius:8,display:"flex",alignItems:"center",justifyContent:"center",background:`${t.warm}10`,border:`1px solid ${t.warm}22`,flexShrink:0}}>🤗</span>
             <div style={{flex:1,minWidth:0}}>
-              <div style={{fontSize:9,color:t.mut}}>{hfSelected.id.split("/")[0]}/</div>
-              <div style={{fontSize:14,fontWeight:700,color:t.acc,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap"}}>{hfSelected.id.split("/")[1]||hfSelected.id}</div>
+              <div style={mmKickerS}>{hfSelected.id.split("/")[0]}/</div>
+              <div style={{fontSize:17,fontWeight:900,color:t.acc,overflow:"hidden",textOverflow:"ellipsis",whiteSpace:"nowrap",marginTop:3}}>{hfSelected.id.split("/")[1]||hfSelected.id}</div>
             </div>
             <div style={{display:"flex",gap:12,fontSize:10,color:t.mut,flexShrink:0,alignItems:"center"}}>
               {hfModelInfo?.gguf_files?.length>0&&(()=>{
@@ -7291,7 +7577,7 @@ function HyprChat(){
             const c=compat.level==="bad"?t.err:compat.level==="warn"?(t.warm||"#eab308"):t.ok;
             const icon=compat.level==="bad"?"⚠":compat.level==="warn"?"△":"✓";
             const title=compat.level==="ok"?"No obvious Ollama compatibility flags":compat.level==="bad"?"Likely compatibility issue":"Possible compatibility issue";
-            return <div style={{padding:"9px 16px",flexShrink:0,borderBottom:`1px solid ${c}22`,background:`${c}0F`,display:"flex",gap:10,alignItems:"flex-start"}}>
+            return <div style={{padding:"10px 16px",flexShrink:0,borderBottom:`1px solid ${c}22`,background:`${c}0C`,display:"flex",gap:10,alignItems:"flex-start"}}>
               <span style={{color:c,fontSize:13,fontWeight:900,lineHeight:"18px",flexShrink:0}}>{icon}</span>
               <div style={{flex:1,minWidth:0}}>
                 <div style={{fontSize:11,fontWeight:800,color:c,letterSpacing:.2}}>Ollama Compatibility · {title}</div>
@@ -7309,8 +7595,8 @@ function HyprChat(){
             const compat=hfCompatibilityReport(hfSelected,hfModelInfo,hfReadme,hfSelectedFiles);
             const risky=compat.level!=="ok";
             const c=compat.level==="bad"?t.err:compat.level==="warn"?(t.warm||"#eab308"):t.ok;
-            return <div style={{padding:"8px 16px",flexShrink:0,borderBottom:`1px solid ${t.brd}18`,background:`${c}06`,display:"flex",alignItems:"center",gap:8}}>
-              <input value={hfDownloadName} onChange={e=>setHfDownloadName(e.target.value)} placeholder="Model name, e.g. llama3-q5" style={{...inputS,fontSize:11,padding:"6px 10px",width:200,flex:"none"}}/>
+            return <div style={{padding:"10px 16px",flexShrink:0,borderBottom:`1px solid ${t.brd}18`,background:`${c}06`,display:"flex",alignItems:"center",gap:8,flexWrap:"wrap"}}>
+              <input value={hfDownloadName} onChange={e=>setHfDownloadName(e.target.value)} placeholder="Model name, e.g. llama3-q5" style={{...inputS,fontSize:11,padding:"7px 10px",width:220,flex:"none",background:t.bgDeep}}/>
               <span style={{fontSize:9,color:t.mut,flexShrink:0}}>{hfSelectedFiles.length} file{hfSelectedFiles.length>1?"s":""} · {fmtSize((hfModelInfo?.gguf_files||[]).filter(f=>hfSelectedFiles.includes(f.name)).reduce((a,f)=>a+(f.size||0),0))}</span>
               {risky&&<span style={{fontSize:9,color:c,fontWeight:800,flexShrink:0}}>compatibility flagged</span>}
               <div style={{flex:1}}/>
@@ -7322,8 +7608,8 @@ function HyprChat(){
           {/* Body: files left, readme right */}
           <div style={{flex:1,display:"flex",overflow:"hidden"}}>
             {/* Files + download */}
-            <div style={{width:280,minWidth:280,borderRight:`1px solid ${t.brd}15`,overflowY:"auto",padding:"14px 14px"}}>
-              <div style={{fontSize:9,color:t.mut,textTransform:"uppercase",letterSpacing:.5,marginBottom:8}}>GGUF Files</div>
+            <div style={{width:"clamp(280px,24vw,320px)",minWidth:280,borderRight:`1px solid ${t.brd}18`,overflowY:"auto",padding:"16px 14px",background:`${t.bgDeep}33`}}>
+              <div style={{...mmKickerS,marginBottom:10}}>GGUF Files</div>
               {!hfModelInfo?<div style={{color:t.mut,fontSize:11,fontStyle:"italic"}}>Loading...</div>:
               hfModelInfo.gguf_files.length===0?<div style={{color:t.mut,fontSize:11,fontStyle:"italic"}}>No GGUF files.</div>:
               <>
@@ -7336,7 +7622,7 @@ function HyprChat(){
                     const toggle=()=>{if(allSel)setHfSelectedFiles(p=>p.filter(n=>!files.map(f=>f.name).includes(n)));else setHfSelectedFiles(p=>[...new Set([...p,...files.map(f=>f.name)])]);};
                     const fname=isGroup?groupKey:files[0].name;
                     const ql=quantLabel(fname);const qc=quantColor(ql);
-                    return <div key={groupKey} onClick={toggle} style={{display:"flex",alignItems:"flex-start",gap:8,padding:"8px 9px",borderRadius:8,background:allSel?`${t.acc}10`:`${t.surface}33`,border:`1px solid ${allSel?t.acc:t.brd}${allSel?"44":"18"}`,marginBottom:4,cursor:"pointer",transition:"all .12s"}}>
+                    return <div key={groupKey} onClick={toggle} style={{display:"flex",alignItems:"flex-start",gap:8,padding:"9px 10px",borderRadius:8,background:allSel?`${t.acc}14`:`${t.surface}40`,border:`1px solid ${allSel?t.acc:t.brd}${allSel?"55":"18"}`,marginBottom:5,cursor:"pointer",transition:"all .12s"}}>
                       <input type="checkbox" checked={allSel} onChange={toggle} onClick={e=>e.stopPropagation()} style={{accentColor:t.acc,flexShrink:0,marginTop:2}}/>
                       <div style={{flex:1,minWidth:0}}>
                         <div style={{display:"flex",alignItems:"center",gap:5,marginBottom:2,flexWrap:"wrap"}}>
@@ -7351,8 +7637,8 @@ function HyprChat(){
               </>}
             </div>
             {/* README */}
-            <div style={{flex:1,overflowY:"auto",padding:"14px 18px"}}>
-              <div style={{fontSize:9,color:t.mut,textTransform:"uppercase",letterSpacing:.5,marginBottom:12}}>README</div>
+            <div style={{flex:1,overflowY:"auto",padding:"18px 22px"}}>
+              <div style={{...mmKickerS,marginBottom:12}}>README</div>
               {hfReadmeLoading?<div style={{color:t.mut,fontSize:11,fontStyle:"italic"}}>Loading README...</div>:
               hfReadme?<div style={{fontSize:12,lineHeight:1.7,color:t.dim}}><MDWrap>{md(hfReadme)}</MDWrap></div>:
               <div style={{color:t.mut,fontSize:11,fontStyle:"italic"}}>No README available.</div>}

--- a/scripts/setup-searxng-privacy.sh
+++ b/scripts/setup-searxng-privacy.sh
@@ -1,0 +1,471 @@
+#!/usr/bin/env bash
+# Harden an existing SearXNG host for HyprChat.
+#
+# Required env:
+#   HYPRCHAT_IP=192.168.1.120
+#
+# Optional env:
+#   DEV_IP=192.168.1.x          # may access SearXNG :8888, not proxy :8899
+#   PROTON_OPENVPN=auto|true|false
+#
+# Proton assets, when used, must already exist on this host:
+#   /etc/openvpn/proton-ovpn/*.ovpn
+#   /etc/openvpn/proton-ovpn/auth.txt
+
+set -u
+
+HYPRCHAT_IP="${HYPRCHAT_IP:-}"
+DEV_IP="${DEV_IP:-}"
+PROTON_OPENVPN="${PROTON_OPENVPN:-auto}"
+SEARXNG_USER="${SEARXNG_USER:-searxng}"
+SEARXNG_GROUP="${SEARXNG_GROUP:-}"
+PROXY_PORT="${PROXY_PORT:-8899}"
+SEARXNG_PORT="${SEARXNG_PORT:-8888}"
+POLICY_SCRIPT="/usr/local/sbin/searxng-vpn-policy"
+FIREWALL_UNIT="/etc/systemd/system/searxng-privacy-firewall.service"
+POLICY_UNIT="/etc/systemd/system/searxng-vpn-policy.service"
+PROXY_UNIT="/etc/systemd/system/searxng-privacy-proxy.service"
+PROXY_CONF="/etc/tinyproxy/searxng-privacy.conf"
+OVPN_DIR="/etc/openvpn/proton-ovpn"
+OVPN_AUTH="$OVPN_DIR/auth.txt"
+OVPN_CONF="/etc/openvpn/client/searxng-proton.conf"
+OPENVPN_UNIT="openvpn-client@searxng-proton.service"
+BACKUP_DIR="/root/searxng-privacy-setup-$(date +%Y%m%d-%H%M%S)"
+
+log() { printf '%s\n' "$*"; }
+warn() { log "WARNING: $*"; }
+die() { log "ERROR: $*" >&2; exit 1; }
+
+need_root() {
+  [ "$(id -u)" -eq 0 ] || die "Run this script as root."
+}
+
+valid_ip_or_empty() {
+  local ip="$1"
+  [ -z "$ip" ] && return 0
+  printf '%s' "$ip" | grep -Eq '^[0-9]{1,3}(\.[0-9]{1,3}){3}$'
+}
+
+backup() {
+  local path="$1"
+  [ -e "$path" ] || return 0
+  mkdir -p "$BACKUP_DIR"
+  local name="${path#/}"
+  name="${name//\//__}"
+  cp -a "$path" "$BACKUP_DIR/$name"
+}
+
+install_packages() {
+  if command -v apt-get >/dev/null 2>&1; then
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq >/dev/null 2>&1 || warn "apt-get update failed; continuing with installed packages."
+    apt-get install -y -qq iproute2 iptables openvpn tinyproxy ca-certificates curl >/dev/null 2>&1 \
+      || warn "Could not install every package; setup will use what is already installed."
+  fi
+}
+
+disable_conflicting_wireguard_units() {
+  command -v systemctl >/dev/null 2>&1 || return 0
+  local units=()
+  while IFS= read -r unit; do
+    [ -n "$unit" ] && units+=("$unit")
+  done < <(
+    systemctl list-unit-files --type=service --no-legend 2>/dev/null \
+      | awk '{print $1}' \
+      | grep -Ei '^(wg-quick@.*(proton|searxng)|.*(wireguard|wg).*(proton|searxng)|.*proton.*(wireguard|wg|split)).service$' \
+      || true
+  )
+  for unit in "${units[@]}"; do
+    [ "$unit" = "$OPENVPN_UNIT" ] && continue
+    if systemctl disable --now "$unit" >/dev/null 2>&1; then
+      log "Disabled conflicting WireGuard/Proton unit: $unit"
+    fi
+  done
+}
+
+write_policy_script() {
+  backup "$POLICY_SCRIPT"
+  cat > "$POLICY_SCRIPT" <<EOF
+#!/usr/bin/env bash
+set -u
+
+ACTION="\${1:-apply}"
+SEARXNG_USER="$SEARXNG_USER"
+HYPRCHAT_IP="$HYPRCHAT_IP"
+DEV_IP="$DEV_IP"
+SEARXNG_PORT="$SEARXNG_PORT"
+PROXY_PORT="$PROXY_PORT"
+TABLE_ID="177"
+RULE_PRIO="17700"
+UID_CHAIN="HC_SEARXNG_UID"
+IN_CHAIN="HC_SEARXNG_IN"
+
+uid_for_user() {
+  id -u "\$SEARXNG_USER" 2>/dev/null
+}
+
+ipt() {
+  iptables -w "\$@"
+}
+
+delete_jump() {
+  local table_chain="\$1"
+  shift
+  while ipt -D "\$table_chain" "\$@" 2>/dev/null; do :; done
+}
+
+cleanup_uid() {
+  local uid
+  uid="\$(uid_for_user)" || return 0
+  delete_jump OUTPUT -m owner --uid-owner "\$uid" -j "\$UID_CHAIN"
+  ipt -F "\$UID_CHAIN" 2>/dev/null || true
+  ipt -X "\$UID_CHAIN" 2>/dev/null || true
+  while ip rule del priority "\$RULE_PRIO" table "\$TABLE_ID" 2>/dev/null; do :; done
+  ip route flush table "\$TABLE_ID" 2>/dev/null || true
+  ip route flush cache 2>/dev/null || true
+}
+
+cleanup_firewall() {
+  delete_jump INPUT -p tcp -m multiport --dports "\$SEARXNG_PORT,\$PROXY_PORT" -j "\$IN_CHAIN"
+  ipt -F "\$IN_CHAIN" 2>/dev/null || true
+  ipt -X "\$IN_CHAIN" 2>/dev/null || true
+}
+
+add_bypass_route() {
+  local ip="\$1"
+  [ -z "\$ip" ] && return 0
+  local route dev via
+  route="\$(ip -4 route get "\$ip" 2>/dev/null | head -n1 || true)"
+  dev="\$(printf '%s\n' "\$route" | awk '{for(i=1;i<=NF;i++) if(\$i=="dev") {print \$(i+1); exit}}')"
+  via="\$(printf '%s\n' "\$route" | awk '{for(i=1;i<=NF;i++) if(\$i=="via") {print \$(i+1); exit}}')"
+  [ -z "\$dev" ] && return 0
+  if [ -n "\$via" ]; then
+    ip route replace "\$ip/32" via "\$via" dev "\$dev" table "\$TABLE_ID" 2>/dev/null || true
+  else
+    ip route replace "\$ip/32" dev "\$dev" table "\$TABLE_ID" 2>/dev/null || true
+  fi
+}
+
+private_dns_resolvers() {
+  awk '/^nameserver[[:space:]]+/ {print \$2}' /etc/resolv.conf 2>/dev/null \\
+    | grep -E '^(10\\.|192\\.168\\.|172\\.(1[6-9]|2[0-9]|3[0-1])\\.)' \\
+    || true
+}
+
+apply_firewall() {
+  cleanup_firewall
+  ipt -N "\$IN_CHAIN" 2>/dev/null || true
+  ipt -F "\$IN_CHAIN"
+  ipt -A "\$IN_CHAIN" -i lo -j ACCEPT
+  [ -n "\$HYPRCHAT_IP" ] && ipt -A "\$IN_CHAIN" -s "\$HYPRCHAT_IP" -p tcp --dport "\$SEARXNG_PORT" -j ACCEPT
+  [ -n "\$HYPRCHAT_IP" ] && ipt -A "\$IN_CHAIN" -s "\$HYPRCHAT_IP" -p tcp --dport "\$PROXY_PORT" -j ACCEPT
+  [ -n "\$DEV_IP" ] && ipt -A "\$IN_CHAIN" -s "\$DEV_IP" -p tcp --dport "\$SEARXNG_PORT" -j ACCEPT
+  ipt -A "\$IN_CHAIN" -p tcp --dport "\$SEARXNG_PORT" -j REJECT --reject-with tcp-reset
+  ipt -A "\$IN_CHAIN" -p tcp --dport "\$PROXY_PORT" -j REJECT --reject-with tcp-reset
+  ipt -I INPUT 1 -p tcp -m multiport --dports "\$SEARXNG_PORT,\$PROXY_PORT" -j "\$IN_CHAIN"
+}
+
+apply_vpn_policy() {
+  local uid tun_dev
+  uid="\$(uid_for_user)" || exit 0
+  cleanup_uid
+  ip route replace 127.0.0.0/8 dev lo table "\$TABLE_ID" 2>/dev/null || true
+  add_bypass_route "\$HYPRCHAT_IP"
+  add_bypass_route "\$DEV_IP"
+  for dns_ip in \$(private_dns_resolvers); do
+    add_bypass_route "\$dns_ip"
+  done
+  tun_dev="\$(ip -o link show 2>/dev/null | awk -F': ' '/: tun[0-9A-Za-z_.-]*:/{print \$2; exit}')"
+  if [ -n "\$tun_dev" ]; then
+    ip route replace default dev "\$tun_dev" table "\$TABLE_ID"
+  fi
+  ip rule add uidrange "\$uid-\$uid" priority "\$RULE_PRIO" table "\$TABLE_ID" 2>/dev/null || true
+  ip route flush cache 2>/dev/null || true
+
+  ipt -N "\$UID_CHAIN" 2>/dev/null || true
+  ipt -F "\$UID_CHAIN"
+  ipt -A "\$UID_CHAIN" -o lo -j ACCEPT
+  [ -n "\$HYPRCHAT_IP" ] && ipt -A "\$UID_CHAIN" -d "\$HYPRCHAT_IP" -j ACCEPT
+  [ -n "\$DEV_IP" ] && ipt -A "\$UID_CHAIN" -d "\$DEV_IP" -j ACCEPT
+  for dns_ip in \$(private_dns_resolvers); do
+    ipt -A "\$UID_CHAIN" -d "\$dns_ip" -p udp --dport 53 -j ACCEPT
+    ipt -A "\$UID_CHAIN" -d "\$dns_ip" -p tcp --dport 53 -j ACCEPT
+  done
+  ipt -A "\$UID_CHAIN" -o tun+ -j ACCEPT
+  ipt -A "\$UID_CHAIN" -j REJECT
+  ipt -I OUTPUT 1 -m owner --uid-owner "\$uid" -j "\$UID_CHAIN"
+}
+
+case "\$ACTION" in
+  apply)
+    apply_vpn_policy
+    apply_firewall
+    ;;
+  apply-firewall)
+    apply_firewall
+    ;;
+  vpn-down)
+    cleanup_uid
+    apply_firewall
+    ;;
+  cleanup-firewall)
+    cleanup_firewall
+    ;;
+  cleanup)
+    cleanup_uid
+    cleanup_firewall
+    ;;
+  *)
+    echo "usage: \$0 {apply|apply-firewall|vpn-down|cleanup-firewall|cleanup}" >&2
+    exit 2
+    ;;
+esac
+EOF
+  chmod 0755 "$POLICY_SCRIPT"
+}
+
+write_firewall_unit() {
+  backup "$FIREWALL_UNIT"
+  cat > "$FIREWALL_UNIT" <<EOF
+[Unit]
+Description=HyprChat SearXNG privacy firewall
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=$POLICY_SCRIPT apply-firewall
+ExecStop=$POLICY_SCRIPT cleanup-firewall
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+write_proxy_config() {
+  mkdir -p "$(dirname "$PROXY_CONF")"
+  backup "$PROXY_CONF"
+  cat > "$PROXY_CONF" <<EOF
+Port $PROXY_PORT
+Listen 0.0.0.0
+User $SEARXNG_USER
+Group $SEARXNG_GROUP
+Timeout 600
+LogLevel Warning
+Syslog On
+MaxClients 100
+StartServers 1
+MinSpareServers 1
+MaxSpareServers 5
+Allow 127.0.0.1
+Allow $HYPRCHAT_IP
+ConnectPort 443
+ConnectPort 563
+ViaProxyName "searxng-privacy"
+DisableViaHeader Yes
+EOF
+}
+
+write_proxy_unit() {
+  backup "$PROXY_UNIT"
+  cat > "$PROXY_UNIT" <<EOF
+[Unit]
+Description=HyprChat SearXNG outbound privacy proxy
+After=network-online.target $OPENVPN_UNIT searxng-vpn-policy.service
+Requires=searxng-vpn-policy.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/tinyproxy -d -c $PROXY_CONF
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+write_policy_unit() {
+  backup "$POLICY_UNIT"
+  cat > "$POLICY_UNIT" <<EOF
+[Unit]
+Description=HyprChat SearXNG UID VPN policy
+After=$OPENVPN_UNIT
+Requires=$OPENVPN_UNIT
+
+[Service]
+Type=oneshot
+ExecStart=$POLICY_SCRIPT apply
+ExecStop=$POLICY_SCRIPT vpn-down
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+find_proton_ovpn() {
+  find "$OVPN_DIR" -maxdepth 1 -type f -name '*.ovpn' 2>/dev/null | sort | head -n1
+}
+
+proton_requested() {
+  case "$(printf '%s' "$PROTON_OPENVPN" | tr '[:upper:]' '[:lower:]')" in
+    0|false|no|off|disabled) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+proton_assets_ready() {
+  proton_requested || return 1
+  [ -f "$OVPN_AUTH" ] || return 1
+  [ -n "$(find_proton_ovpn)" ] || return 1
+}
+
+write_openvpn_config() {
+  local src
+  src="$(find_proton_ovpn)"
+  [ -n "$src" ] || return 1
+  mkdir -p "$(dirname "$OVPN_CONF")"
+  backup "$OVPN_CONF"
+  awk '
+    /^auth-user-pass([[:space:]]|$)/ {next}
+    /^auth-nocache([[:space:]]|$)/ {next}
+    /^route-nopull([[:space:]]|$)/ {next}
+    /^redirect-gateway([[:space:]]|$)/ {next}
+    /^script-security([[:space:]]|$)/ {next}
+    /^up[[:space:]]/ {next}
+    /^down[[:space:]]/ {next}
+    /^down-pre([[:space:]]|$)/ {next}
+    {print}
+  ' "$src" > "$OVPN_CONF"
+  cat >> "$OVPN_CONF" <<EOF
+
+auth-user-pass $OVPN_AUTH
+auth-nocache
+route-nopull
+script-security 2
+up $POLICY_SCRIPT apply
+down $POLICY_SCRIPT vpn-down
+down-pre
+EOF
+  chmod 0600 "$OVPN_CONF" "$OVPN_AUTH" 2>/dev/null || true
+}
+
+unit_file_exists() {
+  systemctl list-unit-files "$1" --no-legend 2>/dev/null | grep -q .
+}
+
+wait_for_tun() {
+  local i
+  for i in $(seq 1 30); do
+    ip -o link show 2>/dev/null | grep -Eq ': tun[0-9A-Za-z_.-]*:' && return 0
+    sleep 1
+  done
+  return 1
+}
+
+disable_vpn_proxy_stack() {
+  systemctl disable --now searxng-privacy-proxy.service >/dev/null 2>&1 || true
+  systemctl disable --now searxng-vpn-policy.service >/dev/null 2>&1 || true
+  systemctl disable --now "$OPENVPN_UNIT" >/dev/null 2>&1 || true
+}
+
+activate_firewall_only() {
+  systemctl daemon-reload
+  systemctl enable --now searxng-privacy-firewall.service >/dev/null 2>&1 \
+    || warn "Could not enable privacy firewall service."
+}
+
+activate_vpn_proxy() {
+  command -v tinyproxy >/dev/null 2>&1 || {
+    warn "tinyproxy is not installed; proxy cannot be activated."
+    echo "HYPRCHAT_PROXY_ACTIVE=0"
+    return 0
+  }
+  command -v openvpn >/dev/null 2>&1 || {
+    warn "openvpn is not installed; proxy cannot be activated."
+    echo "HYPRCHAT_PROXY_ACTIVE=0"
+    return 0
+  }
+  unit_file_exists "openvpn-client@.service" || {
+    warn "openvpn-client@.service is unavailable; proxy cannot be activated."
+    echo "HYPRCHAT_PROXY_ACTIVE=0"
+    return 0
+  }
+
+  write_openvpn_config || {
+    warn "Could not write Proton OpenVPN client config."
+    echo "HYPRCHAT_PROXY_ACTIVE=0"
+    return 0
+  }
+
+  systemctl daemon-reload
+  systemctl enable --now "$OPENVPN_UNIT" >/dev/null 2>&1 || {
+    warn "Could not start $OPENVPN_UNIT."
+    echo "HYPRCHAT_PROXY_ACTIVE=0"
+    return 0
+  }
+  wait_for_tun || {
+    warn "OpenVPN did not create a tun device; leaving proxy disabled."
+    echo "HYPRCHAT_PROXY_ACTIVE=0"
+    return 0
+  }
+  systemctl enable searxng-vpn-policy.service >/dev/null 2>&1 || true
+  systemctl restart searxng-vpn-policy.service >/dev/null 2>&1 || {
+    warn "Could not apply UID VPN policy; leaving proxy disabled."
+    echo "HYPRCHAT_PROXY_ACTIVE=0"
+    return 0
+  }
+  systemctl enable --now searxng-privacy-proxy.service >/dev/null 2>&1 || {
+    warn "Could not start searxng-privacy-proxy.service."
+    echo "HYPRCHAT_PROXY_ACTIVE=0"
+    return 0
+  }
+  if ss -ltn 2>/dev/null | awk '{print $4}' | grep -Eq "(:|\\.)$PROXY_PORT$"; then
+    echo "HYPRCHAT_PROXY_ACTIVE=1"
+  else
+    warn "Proxy service started but :$PROXY_PORT is not listening."
+    echo "HYPRCHAT_PROXY_ACTIVE=0"
+  fi
+}
+
+main() {
+  need_root
+  [ -n "$HYPRCHAT_IP" ] || die "HYPRCHAT_IP is required."
+  valid_ip_or_empty "$HYPRCHAT_IP" || die "HYPRCHAT_IP must be an IPv4 address."
+  valid_ip_or_empty "$DEV_IP" || die "DEV_IP must be empty or an IPv4 address."
+  id -u "$SEARXNG_USER" >/dev/null 2>&1 || die "User '$SEARXNG_USER' does not exist. Install SearXNG first."
+  SEARXNG_GROUP="${SEARXNG_GROUP:-$(id -gn "$SEARXNG_USER")}"
+
+  mkdir -p "$BACKUP_DIR"
+  log "Backup directory: $BACKUP_DIR"
+  install_packages
+  disable_conflicting_wireguard_units
+  write_policy_script
+  write_firewall_unit
+  write_policy_unit
+  write_proxy_config
+  write_proxy_unit
+  activate_firewall_only
+
+  if ! proton_requested; then
+    warn "PROTON_OPENVPN=$PROTON_OPENVPN; VPN/proxy activation skipped."
+    disable_vpn_proxy_stack
+    echo "HYPRCHAT_PROXY_ACTIVE=0"
+    exit 0
+  fi
+
+  if ! proton_assets_ready; then
+    warn "Missing Proton OpenVPN assets. Expected $OVPN_DIR/*.ovpn and $OVPN_AUTH."
+    warn "Firewall hardening was applied; VPN/proxy activation was skipped."
+    disable_vpn_proxy_stack
+    echo "HYPRCHAT_PROXY_ACTIVE=0"
+    exit 0
+  fi
+
+  activate_vpn_proxy
+}
+
+main "$@"


### PR DESCRIPTION
## Alpha v17.1.2 — June 10, 2026

### HyprChat Memory & Navigation
- Added global HyprChat memory that can persist across chats when memory is enabled for a conversation.
- Added a user profile and memory management panel for profile details, interests, links, manual memories, and reviewed memory suggestions.
- Added a per-chat memory toggle, including support for enabling memory on an empty chat before the first message creates the saved conversation.
- Reorganized the left rail so Search, Chat, Research, Council, Memory, Agents, and Prompt Library are always visible.
- Moved Knowledge Bases, Tools, Model Manager, and Analytics behind an inline expandable More section that opens inside the rail instead of a separate popout.

### Workspace Memory & Ghost Mode
- Added workspace-scoped memory with reviewed suggestions, accepted memories, and manual memory blocks that can be injected into workspace chats.
- Added memory review controls for accepting, rejecting, editing, deleting, and manually creating semantic, episodic, and procedural memories.
- Added Ghost Mode for local-only chats that are not saved, indexed, added to history, or used for workspace memory suggestions.

### Quick Search
- Improved same-day event queries so prompts like "WWDC that just took place today" search cleaner event/year/date variants instead of dragging filler words into SearXNG.
- Added a general-web fallback for strict same-day searches so fresh official pages, live blogs, and tech coverage can surface when the news/day filter misses them.
- Made same-day evidence handling smarter by accepting exact dates, "today", recent-hour snippets, and current-year live-update text before warning that sources are stale.

### Chat Streaming & Context Meter
- Tool-enabled chat rounds now stream assistant text live while it is generated instead of waiting for the full model output to finish.
- If streamed draft text turns into a native or text-parsed tool call, the chat clears that draft before showing the tool execution cards/results.
- Replaced the misleading live "Generating ... chars" status with token-based wording that matches the top-right context meter.
- Clarified the header context meter tooltip as prompt plus generated tokens against the active `num_ctx`.

### Multi-User support (Not for concurrent usage, only for splitting up your chats)
- Now you have the option to have different users for different things. Keep all your chats, workspaces and configurations separate from each other by signing into the appropriate user.
- Each user has the option to have a password or not.
- Manage users in the settings panel. You can set passwords, reset passwords, add users and remove users.


### Bug Fixes
- Fixed a fresh empty-chat race where selecting a model in the top-left picker and immediately sending could create the chat with the selected model but stream the first response through a stale/default model before React state caught up.